### PR TITLE
DataBinder: Improve Unicode string support, and reduce code duplication

### DIFF
--- a/src/Lightweight/DataBinder/Core.hpp
+++ b/src/Lightweight/DataBinder/Core.hpp
@@ -171,4 +171,3 @@ struct SqlColumnSize
 
 template <typename T>
 constexpr size_t SqlColumnSize = detail::SqlColumnSize<T>::Value;
-

--- a/src/Lightweight/DataBinder/SqlFixedString.hpp
+++ b/src/Lightweight/DataBinder/SqlFixedString.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "Core.hpp"
+#include "UnicodeConverter.hpp"
 
 #include <format>
 #include <stdexcept>
@@ -94,11 +95,9 @@ class SqlFixedString
         _data[newSize] = '\0';
     }
 
-    LIGHTWEIGHT_FORCE_INLINE constexpr void resize(std::size_t n, T c = T {}) noexcept
+    LIGHTWEIGHT_FORCE_INLINE constexpr void resize(std::size_t n) noexcept
     {
         auto const newSize = (std::min)(n, N);
-        if (newSize > _size)
-            std::fill_n(end(), newSize - _size, c);
         _size = newSize;
         _data[newSize] = '\0';
     }
@@ -218,6 +217,16 @@ class SqlFixedString
     }
 };
 
+template <std::size_t N, typename CharT, SqlFixedStringMode Mode>
+struct detail::SqlViewHelper<SqlFixedString<N, CharT, Mode>>
+{
+    static LIGHTWEIGHT_FORCE_INLINE std::basic_string_view<CharT> View(
+        SqlFixedString<N, CharT, Mode> const& str) noexcept
+    {
+        return { str.data(), str.size() };
+    }
+};
+
 template <typename>
 struct IsSqlFixedStringType: std::false_type
 {
@@ -250,13 +259,65 @@ struct detail::SqlColumnSize<std::optional<SqlFixedString<N, T, Mode>>>
 };
 
 template <std::size_t N, typename T, SqlFixedStringMode Mode>
-struct SqlDataBinder<SqlFixedString<N, T, Mode>>
+struct SqlBasicStringOperations<SqlFixedString<N, T, Mode>>
 {
-    static constexpr auto ColumnType =
-        Mode == SqlFixedStringMode::VARIABLE_SIZE ? SqlColumnType::STRING : SqlColumnType::CHAR;
+    using CharType = T;
+    using ValueType = SqlFixedString<N, CharType, Mode>;
+    static constexpr SqlColumnType ColumnType = SqlColumnType::STRING;
 
-    using ValueType = SqlFixedString<N, T, Mode>;
-    using StringTraits = SqlBasicStringOperations<ValueType>;
+    static CharType const* Data(ValueType const* str) noexcept
+    {
+        return str->data();
+    }
+
+    static CharType* Data(ValueType* str) noexcept
+    {
+        return str->data();
+    }
+
+    static SQLULEN Size(ValueType const* str) noexcept
+    {
+        return str->size();
+    }
+
+    static void Clear(ValueType* str) noexcept
+    {
+        str->clear();
+    }
+
+    static void Reserve(ValueType* str, size_t capacity) noexcept
+    {
+        str->reserve((std::min)(N, capacity));
+        str->resize((std::min)(N, capacity));
+    }
+
+    static void Resize(ValueType* str, SQLLEN indicator) noexcept
+    {
+        str->resize(indicator);
+    }
+
+    static void PostProcessOutputColumn(ValueType* result, SQLLEN indicator)
+    {
+        switch (indicator)
+        {
+            case SQL_NULL_DATA:
+                result->clear();
+                break;
+            case SQL_NO_TOTAL:
+                result->resize(N);
+                break;
+            default: {
+                auto const len = (std::min)(N, static_cast<std::size_t>(indicator) / sizeof(CharType));
+                result->setsize(len);
+
+                if constexpr (Mode == SqlFixedStringMode::FIXED_SIZE_RIGHT_TRIMMED)
+                {
+                    TrimRight(result, indicator);
+                }
+                break;
+            }
+        }
+    }
 
     LIGHTWEIGHT_FORCE_INLINE static void TrimRight(ValueType* boundOutputString, SQLLEN indicator) noexcept
     {
@@ -265,94 +326,6 @@ struct SqlDataBinder<SqlFixedString<N, T, Mode>>
             --n;
         boundOutputString->setsize(n);
     }
-
-    LIGHTWEIGHT_FORCE_INLINE static SQLRETURN InputParameter(SQLHSTMT stmt,
-                                                             SQLUSMALLINT column,
-                                                             ValueType const& value,
-                                                             SqlDataBinderCallback& /*cb*/) noexcept
-    {
-        return SQLBindParameter(stmt,
-                                column,
-                                SQL_PARAM_INPUT,
-                                SQL_C_CHAR,
-                                SQL_VARCHAR,
-                                value.size(),
-                                0,
-                                (SQLPOINTER) value.data(),
-                                sizeof(value),
-                                nullptr);
-    }
-
-    LIGHTWEIGHT_FORCE_INLINE static SQLRETURN OutputColumn(
-        SQLHSTMT stmt, SQLUSMALLINT column, ValueType* result, SQLLEN* indicator, SqlDataBinderCallback& cb) noexcept
-    {
-        if constexpr (Mode != SqlFixedStringMode::FIXED_SIZE)
-        {
-            ValueType* boundOutputString = result;
-            cb.PlanPostProcessOutputColumn([indicator, boundOutputString]() {
-                if (*indicator == SQL_NULL_DATA)
-                    return;
-                // NB: If the indicator is greater than the buffer size, we have a truncation.
-                auto const len =
-                    std::cmp_greater_equal(*indicator, N + 1) || *indicator == SQL_NO_TOTAL ? N : *indicator;
-                if constexpr (Mode == SqlFixedStringMode::FIXED_SIZE_RIGHT_TRIMMED)
-                    TrimRight(boundOutputString, len);
-                else
-                    boundOutputString->setsize(len);
-            });
-        }
-        return SQLBindCol(
-            stmt, column, SQL_C_CHAR, (SQLPOINTER) result->data(), (SQLLEN) result->capacity(), indicator);
-    }
-
-    LIGHTWEIGHT_FORCE_INLINE static SQLRETURN GetColumn(SQLHSTMT stmt,
-                                                        SQLUSMALLINT column,
-                                                        ValueType* result,
-                                                        SQLLEN* indicator,
-                                                        SqlDataBinderCallback const& /*cb*/) noexcept
-    {
-        *indicator = 0;
-        const SQLRETURN rv = SQLGetData(stmt, column, SQL_C_CHAR, result->data(), result->capacity(), indicator);
-        switch (rv)
-        {
-            case SQL_SUCCESS:
-            case SQL_NO_DATA:
-                // last successive call
-                result->setsize(*indicator);
-                if constexpr (Mode == SqlFixedStringMode::FIXED_SIZE_RIGHT_TRIMMED)
-                    TrimRight(result, *indicator);
-                return SQL_SUCCESS;
-            case SQL_SUCCESS_WITH_INFO: {
-                // more data pending
-                // Truncating. This case should never happen.
-                result->setsize(result->capacity() - 1);
-                if constexpr (Mode == SqlFixedStringMode::FIXED_SIZE_RIGHT_TRIMMED)
-                    TrimRight(result, *indicator);
-                return SQL_SUCCESS;
-            }
-            default:
-                return rv;
-        }
-    }
-
-    static LIGHTWEIGHT_FORCE_INLINE std::string_view Inspect(ValueType const& value) noexcept
-    {
-        return { value.data(), value.size() };
-    }
-};
-
-template <std::size_t N, typename T, SqlFixedStringMode Mode>
-struct SqlBasicStringOperations<SqlFixedString<N, T, Mode>>
-{
-    using ValueType = SqlFixedString<N, T, Mode>;
-    // clang-format off
-    static char const* Data(ValueType const* str) noexcept { return str->data(); }
-    static char* Data(ValueType* str) noexcept { return str->data(); }
-    static SQLULEN Size(ValueType const* str) noexcept { return str->size(); }
-    static void Clear(ValueType* str) noexcept { str->clear(); }
-    static void Reserve(ValueType* str, size_t capacity) noexcept { str->reserve(capacity); }
-    static void Resize(ValueType* str, SQLLEN indicator) noexcept { str->resize(indicator); }
-    // clang-format on
 };
 
 template <std::size_t N, typename T, SqlFixedStringMode P>

--- a/src/Lightweight/DataBinder/SqlFixedString.hpp
+++ b/src/Lightweight/DataBinder/SqlFixedString.hpp
@@ -52,6 +52,24 @@ class SqlFixedString
     LIGHTWEIGHT_FORCE_INLINE constexpr SqlFixedString& operator=(SqlFixedString&&) noexcept = default;
     LIGHTWEIGHT_FORCE_INLINE constexpr ~SqlFixedString() noexcept = default;
 
+    LIGHTWEIGHT_FORCE_INLINE constexpr SqlFixedString(std::basic_string_view<T> s) noexcept:
+        _size { (std::min)(N, s.size()) }
+    {
+        std::copy_n(s.data(), _size, _data);
+    }
+
+    LIGHTWEIGHT_FORCE_INLINE constexpr SqlFixedString(T const* s, std::size_t len) noexcept:
+        _size { (std::min)(N, len) }
+    {
+        std::copy_n(s, _size, _data);
+    }
+
+    LIGHTWEIGHT_FORCE_INLINE constexpr SqlFixedString(T const* s, T const* e) noexcept:
+        _size { (std::min)(N, static_cast<std::size_t>(e - s)) }
+    {
+        std::copy(s, e, _data);
+    }
+
     LIGHTWEIGHT_FORCE_INLINE void reserve(std::size_t capacity)
     {
         if (capacity > N)
@@ -159,7 +177,7 @@ class SqlFixedString
 
     [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr explicit operator std::basic_string_view<T>() const noexcept
     {
-        return { _data, N - 1 };
+        return { _data, _size };
     }
 
     template <std::size_t OtherSize, SqlFixedStringMode OtherMode>

--- a/src/Lightweight/DataBinder/SqlGuid.cpp
+++ b/src/Lightweight/DataBinder/SqlGuid.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "SqlGuid.hpp"
+#include "StdString.hpp"
+#include "BasicStringBinder.hpp"
 
 #if __has_include(<Windows.h>)
     #include <Windows.h>

--- a/src/Lightweight/DataBinder/UnicodeConverter.hpp
+++ b/src/Lightweight/DataBinder/UnicodeConverter.hpp
@@ -241,6 +241,23 @@ T ToUtf32(std::u8string_view u8InputString)
     return result;
 }
 
+
+template <typename T = std::u32string>
+T ToUtf32(std::u16string_view u16InputString)
+{
+    auto result = T {};
+
+    for (char16_t const c16: u16InputString)
+    {
+        if (c16 < 0xD800 || c16 >= 0xDC00)
+            result.push_back(c16);
+        else
+            result.push_back(0x10000 + ((c16 & 0x3FF) | ((c16 & 0x3FF) << 10)));
+    }
+
+    return result;
+}
+
 // Converts a UTF-8 string to wchar_t-based wide string.
 LIGHTWEIGHT_API std::wstring ToStdWideString(std::u8string_view u8InputString);
 

--- a/src/Lightweight/DataBinder/UnicodeConverter.hpp
+++ b/src/Lightweight/DataBinder/UnicodeConverter.hpp
@@ -213,6 +213,13 @@ inline LIGHTWEIGHT_FORCE_INLINE std::u8string ToUtf8(std::basic_string_view<T> u
     return ToUtf8(std::u16string_view(reinterpret_cast<const char16_t*>(u16InputString.data()), u16InputString.size()));
 }
 
+template <typename T>
+    requires(std::same_as<T, wchar_t> && sizeof(wchar_t) == 4)
+inline LIGHTWEIGHT_FORCE_INLINE std::u8string ToUtf8(std::basic_string_view<T> u32InputString)
+{
+    return ToUtf8(std::u32string_view(reinterpret_cast<const char32_t*>(u32InputString.data()), u32InputString.size()));
+}
+
 // Converts from UTF-32 to UTF-16.
 template <typename T>
     requires std::same_as<T, char32_t> || (std::same_as<T, wchar_t> && sizeof(wchar_t) == 4)


### PR DESCRIPTION
### Checklist

* [x] Add templated `SqlDataBinder` test for `std::u16string`
* [x] Add templated `SqlDataBinder` test for `std::u32string`
* [x] Add templated `SqlDataBinder` test for `std::wstring`
* [x] Add templated `SqlDataBinder` test for `SqlFixedString<N, char16_t>`
* [x] Add templated `SqlDataBinder` test for `SqlFixedString<N, char32_t>`
* [x] Add templated `SqlDataBinder` test for `SqlFixedString<N, wchar_t>`


### Also:

* added `std::u32string ToUtf32(std::u16string_view const&)` Unicode helper function
* `SqlFixedString<>` improved
