### PR TITLE
Add support for tables with multiple manual primary keys in Migration builder and data mapper

### DIFF
--- a/src/Lightweight/Utils.hpp
+++ b/src/Lightweight/Utils.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <string_view>
 #include <type_traits>
 #include <utility>
+
+#include <reflection-cpp/reflection.hpp>
 
 namespace detail
 {
@@ -21,10 +24,14 @@ constexpr auto Finally(auto&& cleanupRoutine) noexcept
 }
 
 template <template <typename...> class T, typename U>
-struct is_specialization_of: std::false_type {};
+struct is_specialization_of: std::false_type
+{
+};
 
 template <template <typename...> class T, typename... Us>
-struct is_specialization_of<T, T<Us...>>: std::true_type {};
+struct is_specialization_of<T, T<Us...>>: std::true_type
+{
+};
 
 template <typename T>
 struct MemberClassTypeHelper;
@@ -54,4 +61,3 @@ concept IsSpecializationOf = detail::is_specialization_of<S, T>::value;
 
 template <typename T>
 using MemberClassType = typename detail::MemberClassTypeHelper<T>::type;
-

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -660,7 +660,8 @@ TEST_CASE_METHOD(SqlTestFixture, "CreateTable with PrimaryKey", "[SqlQueryBuilde
             return migration.GetPlan();
         },
         QueryExpectations::All(R"sql(CREATE TABLE "Test" (
-                                        "pk" INTEGER NOT NULL PRIMARY KEY
+                                        "pk" INTEGER NOT NULL,
+                                        PRIMARY KEY ("pk")
                                      );
                                )sql"));
 }


### PR DESCRIPTION
closes #42.