### PR TITLE
Reduce CREATE TABLE code duplication by making use of the query builder in data mapper's CreateTable<>

### DIFF
--- a/src/Lightweight/DataMapper/Detail.hpp
+++ b/src/Lightweight/DataMapper/Detail.hpp
@@ -5,11 +5,10 @@
 #include <string>
 #include <type_traits>
 
+#include "../Utils.hpp"
+
 namespace detail
 {
-
-template <typename T, typename... Comps>
-concept OneOf = (std::same_as<T, Comps> || ...);
 
 struct StringBuilder
 {

--- a/src/Lightweight/SqlQueryFormatter.cpp
+++ b/src/Lightweight/SqlQueryFormatter.cpp
@@ -472,6 +472,8 @@ class PostgreSqlFormatter final: public BasicSqlQueryFormatter
                 using Type = std::decay_t<decltype(actualType)>;
                 if constexpr (std::same_as<Type, Guid>)
                     return "UUID";
+                else if constexpr (std::same_as<Type, DateTime>)
+                    return "TIMESTAMP";
                 else
                     return BasicSqlQueryFormatter::ColumnType(type);
             },

--- a/src/Lightweight/Utils.hpp
+++ b/src/Lightweight/Utils.hpp
@@ -9,6 +9,12 @@
 namespace detail
 {
 
+template <typename T, typename... Comps>
+concept OneOf = (std::same_as<T, Comps> || ...);
+
+template <typename T>
+constexpr auto AlwaysFalse = std::false_type::value;
+
 constexpr auto Finally(auto&& cleanupRoutine) noexcept
 {
     // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)

--- a/src/tests/DataMapperTests.cpp
+++ b/src/tests/DataMapperTests.cpp
@@ -564,8 +564,8 @@ TEST_CASE_METHOD(SqlTestFixture, "Query: SELECT into simple struct", "[DataMappe
 
 struct MultiPkRecord
 {
-    Field<SqlFixedString<32>, PrimaryKey::Manual> firstName;
-    Field<SqlFixedString<32>, PrimaryKey::Manual> lastName;
+    Field<SqlString<32>, PrimaryKey::Manual> firstName;
+    Field<SqlString<32>, PrimaryKey::Manual> lastName;
 
     constexpr std::weak_ordering operator<=>(MultiPkRecord const& other) const = default;
 };
@@ -574,12 +574,7 @@ TEST_CASE_METHOD(SqlTestFixture, "Table with multiple primary keys", "[DataMappe
 {
     auto dm = DataMapper {};
 
-    SqlStatement(dm.Connection()).MigrateDirect([](SqlMigrationQueryBuilder& migration) {
-        using namespace SqlColumnTypeDefinitions;
-        migration.CreateTable(RecordTableName<MultiPkRecord>)
-            .PrimaryKey("firstName", Varchar { 32 })
-            .PrimaryKey("lastName", Varchar { 32 });
-    });
+    dm.CreateTable<MultiPkRecord>();
 
     auto record = MultiPkRecord { .firstName = "John", .lastName = "Doe" };
     dm.Create(record);

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -757,7 +757,7 @@ TEST_CASE_METHOD(SqlTestFixture, "CreateTable complex demo", "[SqlQueryBuilder][
                     CREATE TABLE "Test" (
                         "a" SERIAL NOT NULL PRIMARY KEY,
                         "b" VARCHAR(32) NOT NULL UNIQUE,
-                        "c" DATETIME,
+                        "c" TIMESTAMP,
                         "d" VARCHAR(255)
                     );
                     CREATE INDEX "Test_c_index" ON "Test"("c");


### PR DESCRIPTION
reducing code duplication

closes #121.