### PR TITLE
Add input binder support & test cases for string_view/wstring_view/u16string_view/u32string_view

### DIFF
--- a/src/Lightweight/DataBinder/BasicStringBinder.hpp
+++ b/src/Lightweight/DataBinder/BasicStringBinder.hpp
@@ -82,7 +82,7 @@ struct LIGHTWEIGHT_API SqlDataBinder<AnsiStringType>
     using CharType = typename AnsiStringType::value_type;
     using StringTraits = SqlBasicStringOperations<AnsiStringType>;
 
-    static constexpr SqlColumnType ColumnType = StringTraits::ColumnType;
+    static constexpr auto ColumnType = StringTraits::ColumnType;
 
     static SQLRETURN InputParameter(SQLHSTMT stmt,
                                     SQLUSMALLINT column,
@@ -250,7 +250,7 @@ struct LIGHTWEIGHT_API SqlDataBinder<Utf16StringType>
     using CharType = typename Utf16StringType::value_type;
     using StringTraits = SqlBasicStringOperations<Utf16StringType>;
 
-    static constexpr SqlColumnType ColumnType = StringTraits::ColumnType;
+    static constexpr auto ColumnType = StringTraits::ColumnType;
 
     static constexpr auto CType = SQL_C_WCHAR;
     static constexpr auto SqlType = SQL_WVARCHAR;
@@ -361,7 +361,7 @@ struct LIGHTWEIGHT_API SqlDataBinder<Utf32StringType>
     using CharType = typename Utf32StringType::value_type;
     using StringTraits = SqlBasicStringOperations<Utf32StringType>;
 
-    static constexpr SqlColumnType ColumnType = StringTraits::ColumnType;
+    static constexpr auto ColumnType = StringTraits::ColumnType;
 
     static constexpr auto CType = SQL_C_WCHAR;
     static constexpr auto SqlType = SQL_WVARCHAR;

--- a/src/Lightweight/DataBinder/Primitives.hpp
+++ b/src/Lightweight/DataBinder/Primitives.hpp
@@ -2,27 +2,31 @@
 
 #pragma once
 
+#include "../SqlColumnTypeDefinitions.hpp"
 #include "Core.hpp"
 
-#include <concepts>
-
-// clang-format off
-template <typename T, SQLSMALLINT TheCType, SQLINTEGER TheSqlType, SqlColumnType TheColumnType>
+template <typename T, SQLSMALLINT TheCType, SQLINTEGER TheSqlType, auto TheColumnType>
 struct SqlSimpleDataBinder
 {
-    static constexpr SqlColumnType ColumnType = TheColumnType;
+    static constexpr SqlColumnTypeDefinition ColumnType = TheColumnType;
 
-    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN InputParameter(SQLHSTMT stmt, SQLUSMALLINT column, T const& value, SqlDataBinderCallback& /*cb*/) noexcept
+    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN InputParameter(SQLHSTMT stmt,
+                                                             SQLUSMALLINT column,
+                                                             T const& value,
+                                                             SqlDataBinderCallback& /*cb*/) noexcept
     {
-        return SQLBindParameter(stmt, column, SQL_PARAM_INPUT, TheCType, TheSqlType, 0, 0, (SQLPOINTER) &value, 0, nullptr);
+        return SQLBindParameter(
+            stmt, column, SQL_PARAM_INPUT, TheCType, TheSqlType, 0, 0, (SQLPOINTER) &value, 0, nullptr);
     }
 
-    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN OutputColumn(SQLHSTMT stmt, SQLUSMALLINT column, T* result, SQLLEN* indicator, SqlDataBinderCallback& /*unused*/) noexcept
+    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN OutputColumn(
+        SQLHSTMT stmt, SQLUSMALLINT column, T* result, SQLLEN* indicator, SqlDataBinderCallback& /*unused*/) noexcept
     {
         return SQLBindCol(stmt, column, TheCType, result, 0, indicator);
     }
 
-    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN GetColumn(SQLHSTMT stmt, SQLUSMALLINT column, T* result, SQLLEN* indicator, SqlDataBinderCallback const& /*cb*/) noexcept
+    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN GetColumn(
+        SQLHSTMT stmt, SQLUSMALLINT column, T* result, SQLLEN* indicator, SqlDataBinderCallback const& /*cb*/) noexcept
     {
         return SQLGetData(stmt, column, TheCType, result, 0, indicator);
     }
@@ -33,21 +37,22 @@ struct SqlSimpleDataBinder
     }
 };
 
-template <> struct SqlDataBinder<bool>: SqlSimpleDataBinder<bool, SQL_BIT, SQL_BIT, SqlColumnType::BOOLEAN> {};
-template <> struct SqlDataBinder<char>: SqlSimpleDataBinder<char, SQL_C_CHAR, SQL_CHAR, SqlColumnType::CHAR> {};
-template <> struct SqlDataBinder<int16_t>: SqlSimpleDataBinder<int16_t, SQL_C_SSHORT, SQL_SMALLINT, SqlColumnType::SMALLINT> {};
-template <> struct SqlDataBinder<uint16_t>: SqlSimpleDataBinder<uint16_t, SQL_C_USHORT, SQL_SMALLINT, SqlColumnType::SMALLINT> {};
-template <> struct SqlDataBinder<int32_t>: SqlSimpleDataBinder<int32_t, SQL_C_SLONG, SQL_INTEGER, SqlColumnType::INTEGER> {};
-template <> struct SqlDataBinder<uint32_t>: SqlSimpleDataBinder<uint32_t, SQL_C_ULONG, SQL_INTEGER, SqlColumnType::INTEGER> {};
-template <> struct SqlDataBinder<int64_t>: SqlSimpleDataBinder<int64_t, SQL_C_SBIGINT, SQL_BIGINT, SqlColumnType::BIGINT> {};
-template <> struct SqlDataBinder<uint64_t>: SqlSimpleDataBinder<uint64_t, SQL_C_UBIGINT, SQL_BIGINT, SqlColumnType::BIGINT> {};
-template <> struct SqlDataBinder<float>: SqlSimpleDataBinder<float, SQL_C_FLOAT, SQL_REAL, SqlColumnType::REAL> {};
-template <> struct SqlDataBinder<double>: SqlSimpleDataBinder<double, SQL_C_DOUBLE, SQL_DOUBLE, SqlColumnType::REAL> {};
+// clang-format off
+template <> struct SqlDataBinder<bool>: SqlSimpleDataBinder<bool, SQL_BIT, SQL_BIT, SqlColumnTypeDefinitions::Bool {}> {};
+template <> struct SqlDataBinder<char>: SqlSimpleDataBinder<char, SQL_C_CHAR, SQL_CHAR, SqlColumnTypeDefinitions::Char {}> {};
+template <> struct SqlDataBinder<int16_t>: SqlSimpleDataBinder<int16_t, SQL_C_SSHORT, SQL_SMALLINT, SqlColumnTypeDefinitions::Smallint {}> {};
+template <> struct SqlDataBinder<uint16_t>: SqlSimpleDataBinder<uint16_t, SQL_C_USHORT, SQL_SMALLINT, SqlColumnTypeDefinitions::Smallint {}> {};
+template <> struct SqlDataBinder<int32_t>: SqlSimpleDataBinder<int32_t, SQL_C_SLONG, SQL_INTEGER, SqlColumnTypeDefinitions::Integer {}> {};
+template <> struct SqlDataBinder<uint32_t>: SqlSimpleDataBinder<uint32_t, SQL_C_ULONG, SQL_INTEGER, SqlColumnTypeDefinitions::Integer {}> {};
+template <> struct SqlDataBinder<int64_t>: SqlSimpleDataBinder<int64_t, SQL_C_SBIGINT, SQL_BIGINT, SqlColumnTypeDefinitions::Bigint {}> {};
+template <> struct SqlDataBinder<uint64_t>: SqlSimpleDataBinder<uint64_t, SQL_C_UBIGINT, SQL_BIGINT, SqlColumnTypeDefinitions::Bigint {}> {};
+template <> struct SqlDataBinder<float>: SqlSimpleDataBinder<float, SQL_C_FLOAT, SQL_REAL, SqlColumnTypeDefinitions::Real {}> {};
+template <> struct SqlDataBinder<double>: SqlSimpleDataBinder<double, SQL_C_DOUBLE, SQL_DOUBLE, SqlColumnTypeDefinitions::Real {}> {};
 #if !defined(_WIN32) && !defined(__APPLE__)
-template <> struct SqlDataBinder<long long>: SqlSimpleDataBinder<long long, SQL_C_SBIGINT, SQL_BIGINT, SqlColumnType::BIGINT> {};
-template <> struct SqlDataBinder<unsigned long long>: SqlSimpleDataBinder<unsigned long long, SQL_C_UBIGINT, SQL_BIGINT, SqlColumnType::BIGINT> {};
+template <> struct SqlDataBinder<long long>: SqlSimpleDataBinder<long long, SQL_C_SBIGINT, SQL_BIGINT, SqlColumnTypeDefinitions::Bigint {}> {};
+template <> struct SqlDataBinder<unsigned long long>: SqlSimpleDataBinder<unsigned long long, SQL_C_UBIGINT, SQL_BIGINT, SqlColumnTypeDefinitions::Bigint {}> {};
 #endif
 #if defined(__APPLE__) // size_t is a different type on macOS
-template <> struct SqlDataBinder<std::size_t>: SqlSimpleDataBinder<std::size_t, SQL_C_SBIGINT, SQL_BIGINT> {};
+template <> struct SqlDataBinder<std::size_t>: SqlSimpleDataBinder<std::size_t, SQL_C_SBIGINT, SqlColumnTypeDefinitions::Bigint {}> {};
 #endif
 // clang-format on

--- a/src/Lightweight/DataBinder/SqlDate.hpp
+++ b/src/Lightweight/DataBinder/SqlDate.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "../SqlColumnTypeDefinitions.hpp"
 #include "Core.hpp"
 
 #include <chrono>
@@ -84,7 +85,7 @@ struct std::formatter<SqlDate>: std::formatter<std::string>
 template <>
 struct LIGHTWEIGHT_API SqlDataBinder<SqlDate>
 {
-    static constexpr auto ColumnType = SqlColumnType::DATE;
+    static constexpr auto ColumnType = SqlColumnTypeDefinitions::Date {};
 
     static LIGHTWEIGHT_FORCE_INLINE SQLRETURN InputParameter(SQLHSTMT stmt,
                                                              SQLUSMALLINT column,

--- a/src/Lightweight/DataBinder/SqlDateTime.hpp
+++ b/src/Lightweight/DataBinder/SqlDateTime.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "Core.hpp"
+#include "../SqlColumnTypeDefinitions.hpp"
 
 #include <chrono>
 #include <format>
@@ -131,7 +132,7 @@ struct LIGHTWEIGHT_API SqlDataBinder<SqlDateTime::native_type>
 template <>
 struct LIGHTWEIGHT_API SqlDataBinder<SqlDateTime>
 {
-    static constexpr auto ColumnType = SqlColumnType::DATETIME;
+    static constexpr auto ColumnType = SqlColumnTypeDefinitions::DateTime {};
 
     static LIGHTWEIGHT_FORCE_INLINE SQLRETURN InputParameter(SQLHSTMT stmt,
                                                              SQLUSMALLINT column,

--- a/src/Lightweight/DataBinder/SqlFixedString.hpp
+++ b/src/Lightweight/DataBinder/SqlFixedString.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "../SqlColumnTypeDefinitions.hpp"
 #include "Core.hpp"
 #include "UnicodeConverter.hpp"
 
@@ -263,7 +264,22 @@ struct SqlBasicStringOperations<SqlFixedString<N, T, Mode>>
 {
     using CharType = T;
     using ValueType = SqlFixedString<N, CharType, Mode>;
-    static constexpr SqlColumnType ColumnType = SqlColumnType::STRING;
+    static constexpr auto ColumnType = []() constexpr -> SqlColumnTypeDefinition {
+        if constexpr (std::same_as<CharType, char>)
+        {
+            if constexpr (Mode == SqlFixedStringMode::VARIABLE_SIZE)
+                return SqlColumnTypeDefinitions::Varchar { N };
+            else
+                return SqlColumnTypeDefinitions::Char { N };
+        }
+        else
+        {
+            if constexpr (Mode == SqlFixedStringMode::VARIABLE_SIZE)
+                return SqlColumnTypeDefinitions::NVarchar { N };
+            else
+                return SqlColumnTypeDefinitions::NChar { N };
+        }
+    }();
 
     static CharType const* Data(ValueType const* str) noexcept
     {

--- a/src/Lightweight/DataBinder/SqlGuid.hpp
+++ b/src/Lightweight/DataBinder/SqlGuid.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "../SqlColumnTypeDefinitions.hpp"
 #include "BasicStringBinder.hpp"
 #include "Core.hpp"
 #include "StdString.hpp"
@@ -96,7 +97,7 @@ inline LIGHTWEIGHT_FORCE_INLINE std::string to_string(SqlGuid const& guid)
 template <>
 struct LIGHTWEIGHT_API SqlDataBinder<SqlGuid>
 {
-    static constexpr auto ColumnType = SqlColumnType::GUID;
+    static constexpr auto ColumnType = SqlColumnTypeDefinitions::Guid {};
 
     static SQLRETURN InputParameter(SQLHSTMT stmt,
                                     SQLUSMALLINT column,

--- a/src/Lightweight/DataBinder/SqlNullValue.hpp
+++ b/src/Lightweight/DataBinder/SqlNullValue.hpp
@@ -16,8 +16,6 @@ constexpr auto SqlNullValue = SqlNullType {};
 template <>
 struct SqlDataBinder<SqlNullType>
 {
-    static constexpr auto ColumnType = SqlColumnType::UNKNOWN;
-
     static LIGHTWEIGHT_FORCE_INLINE SQLRETURN InputParameter(SQLHSTMT stmt,
                                                              SQLUSMALLINT column,
                                                              SqlNullType const& value,

--- a/src/Lightweight/DataBinder/SqlNumeric.hpp
+++ b/src/Lightweight/DataBinder/SqlNumeric.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "../SqlColumnTypeDefinitions.hpp"
 #include "../SqlError.hpp"
 #include "../SqlLogger.hpp"
 #include "Primitives.hpp"
@@ -29,7 +30,7 @@
 template <std::size_t ThePrecision, std::size_t TheScale>
 struct SqlNumeric
 {
-    static constexpr auto ColumnType = SqlColumnType::NUMERIC;
+    static constexpr auto ColumnType = SqlColumnTypeDefinitions::Decimal { .precision = ThePrecision, .scale = TheScale };
 
     // Number of total digits
     static constexpr auto Precision = ThePrecision;
@@ -145,7 +146,7 @@ struct SqlDataBinder<SqlNumeric<Precision, Scale>>
 {
     using ValueType = SqlNumeric<Precision, Scale>;
 
-    static constexpr SqlColumnType ColumnType = SqlColumnType::NUMERIC;
+    static constexpr auto ColumnType = SqlColumnTypeDefinitions::Decimal { .precision = Precision, .scale = Scale };
 
     static void RequireSuccess(SQLHSTMT stmt, SQLRETURN error, std::source_location sourceLocation = std::source_location::current())
     {

--- a/src/Lightweight/DataBinder/SqlText.hpp
+++ b/src/Lightweight/DataBinder/SqlText.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "../SqlColumnTypeDefinitions.hpp"
 #include "Core.hpp"
 #include "StdString.hpp"
 
@@ -33,7 +34,7 @@ struct SqlBasicStringOperations<SqlText>
 {
     using Traits = SqlBasicStringOperations<typename SqlText::value_type>;
 
-    static constexpr auto ColumnType = SqlColumnType::TEXT;
+    static constexpr auto ColumnType = SqlColumnTypeDefinitions::Text {};
 
     // clang-format off
     static LIGHTWEIGHT_FORCE_INLINE char const* Data(SqlText const* str) noexcept { return Traits::Data(&str->value); }

--- a/src/Lightweight/DataBinder/SqlTime.hpp
+++ b/src/Lightweight/DataBinder/SqlTime.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "../SqlColumnTypeDefinitions.hpp"
 #include "Core.hpp"
 
 #include <chrono>
@@ -110,7 +111,7 @@ struct SqlTime
 template <>
 struct SqlDataBinder<SqlTime>
 {
-    static constexpr auto ColumnType = SqlColumnType::TIME;
+    static constexpr auto ColumnType = SqlColumnTypeDefinitions::Time {};
 
     static LIGHTWEIGHT_FORCE_INLINE SQLRETURN InputParameter(SQLHSTMT stmt,
                                                              SQLUSMALLINT column,

--- a/src/Lightweight/DataBinder/SqlTrimmedString.hpp
+++ b/src/Lightweight/DataBinder/SqlTrimmedString.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "../SqlColumnTypeDefinitions.hpp"
 #include "Core.hpp"
 #include "StdString.hpp"
 
@@ -31,7 +32,7 @@ struct std::formatter<SqlTrimmedString>: std::formatter<std::string>
 template <>
 struct SqlDataBinder<SqlTrimmedString>
 {
-    static constexpr auto ColumnType = SqlColumnType::STRING;
+    static constexpr auto ColumnType = SqlColumnTypeDefinitions::Varchar { 255 };
 
     using InnerStringType = decltype(std::declval<SqlTrimmedString>().value);
     using StringTraits = SqlBasicStringOperations<InnerStringType>;

--- a/src/Lightweight/DataBinder/SqlVariant.hpp
+++ b/src/Lightweight/DataBinder/SqlVariant.hpp
@@ -245,8 +245,6 @@ struct LIGHTWEIGHT_API std::formatter<SqlVariant>: formatter<string>
 template <>
 struct LIGHTWEIGHT_API SqlDataBinder<SqlVariant>
 {
-    static constexpr auto ColumnType = SqlColumnType::UNKNOWN;
-
     static SQLRETURN InputParameter(SQLHSTMT stmt,
                                     SQLUSMALLINT column,
                                     SqlVariant const& variantValue,

--- a/src/Lightweight/DataBinder/StdOptional.hpp
+++ b/src/Lightweight/DataBinder/StdOptional.hpp
@@ -13,7 +13,7 @@ struct SqlDataBinder<std::optional<T>>
 {
     using OptionalValue = std::optional<T>;
 
-    static constexpr SqlColumnType ColumnType = SqlDataBinder<T>::ColumnType;
+    static constexpr auto ColumnType = SqlDataBinder<T>::ColumnType;
 
     static LIGHTWEIGHT_FORCE_INLINE SQLRETURN InputParameter(SQLHSTMT stmt,
                                                              SQLUSMALLINT column,

--- a/src/Lightweight/DataBinder/StdString.hpp
+++ b/src/Lightweight/DataBinder/StdString.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "../SqlColumnTypeDefinitions.hpp"
 #include "Core.hpp"
 #include "UnicodeConverter.hpp"
 
@@ -17,7 +18,7 @@ struct SqlBasicStringOperations<std::basic_string<CharT>>
     using CharType = CharT;
     using StringType = std::basic_string<CharT>;
 
-    static constexpr SqlColumnType ColumnType = SqlColumnType::STRING;
+    static constexpr auto ColumnType = SqlColumnTypeDefinitions::Varchar { 255 };
 
     static LIGHTWEIGHT_FORCE_INLINE CharType const* Data(StringType const* str) noexcept
     {

--- a/src/Lightweight/DataBinder/StdStringView.hpp
+++ b/src/Lightweight/DataBinder/StdStringView.hpp
@@ -6,34 +6,74 @@
 #include "UnicodeConverter.hpp"
 
 #include <concepts>
-#include <format>
+#include <memory>
 #include <string_view>
 
-template <typename CharT>
-    requires(std::same_as<CharT, char> || std::same_as<CharT, char16_t>
-             || (std::same_as<CharT, wchar_t> && sizeof(wchar_t) == 2))
-struct SqlDataBinder<std::basic_string_view<CharT>>
+template <>
+struct SqlDataBinder<std::basic_string_view<char>>
 {
-    static constexpr SQLSMALLINT cType = sizeof(CharT) == 1 ? SQL_C_CHAR : SQL_C_WCHAR;
-    static constexpr SQLSMALLINT sqlType = sizeof(CharT) == 1 ? SQL_VARCHAR : SQL_WVARCHAR;
+    static constexpr SQLSMALLINT CType = SQL_C_CHAR;
+    static constexpr SQLSMALLINT SqlType = SQL_VARCHAR;
 
     static LIGHTWEIGHT_FORCE_INLINE SQLRETURN InputParameter(SQLHSTMT stmt,
                                                              SQLUSMALLINT column,
-                                                             std::basic_string_view<CharT> value,
+                                                             std::basic_string_view<char> value,
                                                              SqlDataBinderCallback& /*cb*/) noexcept
     {
         return SQLBindParameter(
-            stmt, column, SQL_PARAM_INPUT, cType, sqlType, value.size(), 0, (SQLPOINTER) value.data(), 0, nullptr);
+            stmt, column, SQL_PARAM_INPUT, CType, SqlType, value.size(), 0, (SQLPOINTER) value.data(), 0, nullptr);
     }
 
-    static LIGHTWEIGHT_FORCE_INLINE std::string_view Inspect(std::basic_string_view<CharT> value) noexcept
-        requires(std::same_as<CharT, char>)
+    static LIGHTWEIGHT_FORCE_INLINE std::string_view Inspect(std::basic_string_view<char> value) noexcept
     {
         return { value.data(), value.size() };
     }
+};
 
-    static LIGHTWEIGHT_FORCE_INLINE std::string Inspect(std::basic_string_view<CharT> value) noexcept
-        requires(!std::same_as<CharT, char>)
+template <typename Char16Type>
+    requires std::same_as<Char16Type, char16_t> || (std::same_as<Char16Type, wchar_t> && sizeof(wchar_t) == 2)
+struct SqlDataBinder<std::basic_string_view<Char16Type>>
+{
+    static constexpr SQLSMALLINT CType = SQL_C_WCHAR;
+    static constexpr SQLSMALLINT SqlType = SQL_WVARCHAR;
+
+    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN InputParameter(SQLHSTMT stmt,
+                                                             SQLUSMALLINT column,
+                                                             std::basic_string_view<Char16Type> value,
+                                                             SqlDataBinderCallback& /*cb*/) noexcept
+    {
+        return SQLBindParameter(
+            stmt, column, SQL_PARAM_INPUT, CType, SqlType, value.size(), 0, (SQLPOINTER) value.data(), 0, nullptr);
+    }
+
+    static LIGHTWEIGHT_FORCE_INLINE std::string Inspect(std::basic_string_view<Char16Type> value) noexcept
+    {
+        auto u8String = ToUtf8(value);
+        return std::string((char const*) u8String.data(), u8String.size());
+    }
+};
+
+template <typename Char32Type>
+    requires std::same_as<Char32Type, char32_t> || (std::same_as<Char32Type, wchar_t> && sizeof(wchar_t) == 4)
+struct SqlDataBinder<std::basic_string_view<Char32Type>>
+{
+    static constexpr SQLSMALLINT CType = SQL_C_WCHAR;
+    static constexpr SQLSMALLINT SqlType = SQL_WVARCHAR;
+
+    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN InputParameter(SQLHSTMT stmt,
+                                                             SQLUSMALLINT column,
+                                                             std::basic_string_view<Char32Type> value,
+                                                             SqlDataBinderCallback& cb) noexcept
+    {
+        auto u16String = std::make_shared<std::u16string>(ToUtf16(value));
+        cb.PlanPostExecuteCallback([u16String = u16String]() {}); // Keep the string alive
+        auto const* data = u16String->data();
+        auto const sizeInBytes = u16String->size() * sizeof(Char32Type);
+        return SQLBindParameter(
+            stmt, column, SQL_PARAM_INPUT, CType, SqlType, sizeInBytes, 0, (SQLPOINTER) data, 0, nullptr);
+    }
+
+    static LIGHTWEIGHT_FORCE_INLINE std::string Inspect(std::basic_string_view<Char32Type> value) noexcept
     {
         auto u8String = ToUtf8(value);
         return std::string((char const*) u8String.data(), u8String.size());

--- a/src/Lightweight/SqlColumnTypeDefinitions.hpp
+++ b/src/Lightweight/SqlColumnTypeDefinitions.hpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <variant>
+
+namespace SqlColumnTypeDefinitions
+{
+
+// clang-format off
+struct Bool {};
+struct Char { std::size_t size = 1; };
+struct NChar { std::size_t size = 1; };
+struct Varchar { std::size_t size = 255; };
+struct NVarchar { std::size_t size = 255; };
+struct Text { std::size_t size {}; };
+struct Smallint {};
+struct Integer {};
+struct Bigint {};
+struct Real {};
+struct Decimal { std::size_t precision {}; std::size_t scale {}; };
+struct DateTime {};
+struct Timestamp {};
+struct Date {};
+struct Time {};
+struct Guid {};
+// clang-format on
+
+} // namespace SqlColumnTypeDefinitions
+
+using SqlColumnTypeDefinition = std::variant<SqlColumnTypeDefinitions::Bigint,
+                                             SqlColumnTypeDefinitions::Bool,
+                                             SqlColumnTypeDefinitions::Char,
+                                             SqlColumnTypeDefinitions::Date,
+                                             SqlColumnTypeDefinitions::DateTime,
+                                             SqlColumnTypeDefinitions::Decimal,
+                                             SqlColumnTypeDefinitions::Guid,
+                                             SqlColumnTypeDefinitions::Integer,
+                                             SqlColumnTypeDefinitions::NChar,
+                                             SqlColumnTypeDefinitions::NVarchar,
+                                             SqlColumnTypeDefinitions::Real,
+                                             SqlColumnTypeDefinitions::Smallint,
+                                             SqlColumnTypeDefinitions::Text,
+                                             SqlColumnTypeDefinitions::Time,
+                                             SqlColumnTypeDefinitions::Timestamp,
+                                             SqlColumnTypeDefinitions::Varchar>;

--- a/src/Lightweight/SqlQuery/MigrationPlan.hpp
+++ b/src/Lightweight/SqlQuery/MigrationPlan.hpp
@@ -3,7 +3,8 @@
 #pragma once
 
 #include "../Api.hpp"
-#include "../SqlDataBinder.hpp"
+#include "../DataBinder/SqlFixedString.hpp"
+#include "../SqlColumnTypeDefinitions.hpp"
 #include "../Utils.hpp"
 
 #include <reflection-cpp/reflection.hpp>
@@ -14,49 +15,6 @@
 #include <vector>
 
 class SqlQueryFormatter;
-
-// clang-format off
-namespace SqlColumnTypeDefinitions
-{
-
-struct Bool {};
-struct Char { size_t size = 1; };
-struct NChar { size_t size = 1; };
-struct Varchar { size_t size {}; };
-struct NVarchar { size_t size {}; };
-struct Text { size_t size {}; };
-struct Smallint {};
-struct Integer {};
-struct Bigint {};
-struct Real {};
-struct Decimal { size_t precision {}; size_t scale {}; };
-struct DateTime {};
-struct Timestamp {};
-struct Date {};
-struct Time {};
-struct Guid {};
-
-} // namespace SqlColumnTypeDefinitions
-
-using SqlColumnTypeDefinition = std::variant<
-    SqlColumnTypeDefinitions::Bigint,
-    SqlColumnTypeDefinitions::Bool,
-    SqlColumnTypeDefinitions::Char,
-    SqlColumnTypeDefinitions::Date,
-    SqlColumnTypeDefinitions::DateTime,
-    SqlColumnTypeDefinitions::Decimal,
-    SqlColumnTypeDefinitions::Guid,
-    SqlColumnTypeDefinitions::Integer,
-    SqlColumnTypeDefinitions::NChar,
-    SqlColumnTypeDefinitions::NVarchar,
-    SqlColumnTypeDefinitions::Real,
-    SqlColumnTypeDefinitions::Smallint,
-    SqlColumnTypeDefinitions::Text,
-    SqlColumnTypeDefinitions::Time,
-    SqlColumnTypeDefinitions::Timestamp,
-    SqlColumnTypeDefinitions::Varchar
->;
-// clang-format on
 
 namespace detail
 {

--- a/src/Lightweight/SqlQuery/MigrationPlan.hpp
+++ b/src/Lightweight/SqlQuery/MigrationPlan.hpp
@@ -21,7 +21,9 @@ namespace SqlColumnTypeDefinitions
 
 struct Bool {};
 struct Char { size_t size = 1; };
+struct NChar { size_t size = 1; };
 struct Varchar { size_t size {}; };
+struct NVarchar { size_t size {}; };
 struct Text { size_t size {}; };
 struct Smallint {};
 struct Integer {};
@@ -45,6 +47,8 @@ using SqlColumnTypeDefinition = std::variant<
     SqlColumnTypeDefinitions::Decimal,
     SqlColumnTypeDefinitions::Guid,
     SqlColumnTypeDefinitions::Integer,
+    SqlColumnTypeDefinitions::NChar,
+    SqlColumnTypeDefinitions::NVarchar,
     SqlColumnTypeDefinitions::Real,
     SqlColumnTypeDefinitions::Smallint,
     SqlColumnTypeDefinitions::Text,
@@ -134,21 +138,44 @@ struct SqlColumnTypeDefinitionOf<T>
 };
 
 template <size_t N, typename CharT>
+    requires(detail::OneOf<CharT, char>)
 struct SqlColumnTypeDefinitionOf<SqlFixedString<N, CharT, SqlFixedStringMode::VARIABLE_SIZE>>
 {
     static constexpr auto value = SqlColumnTypeDefinitions::Varchar { N };
 };
 
 template <size_t N, typename CharT>
+    requires(detail::OneOf<CharT, char16_t, char32_t, wchar_t>)
+struct SqlColumnTypeDefinitionOf<SqlFixedString<N, CharT, SqlFixedStringMode::VARIABLE_SIZE>>
+{
+    static constexpr auto value = SqlColumnTypeDefinitions::NVarchar { N };
+};
+
+template <size_t N, typename CharT>
+    requires(detail::OneOf<CharT, char>)
 struct SqlColumnTypeDefinitionOf<SqlFixedString<N, CharT, SqlFixedStringMode::FIXED_SIZE>>
 {
     static constexpr auto value = SqlColumnTypeDefinitions::Char { N };
 };
 
 template <size_t N, typename CharT>
+    requires(detail::OneOf<CharT, char16_t, char32_t, wchar_t>)
+struct SqlColumnTypeDefinitionOf<SqlFixedString<N, CharT, SqlFixedStringMode::FIXED_SIZE>>
+{
+    static constexpr auto value = SqlColumnTypeDefinitions::NChar { N };
+};
+
+template <size_t N, typename CharT>
 struct SqlColumnTypeDefinitionOf<SqlFixedString<N, CharT, SqlFixedStringMode::FIXED_SIZE_RIGHT_TRIMMED>>
 {
     static constexpr auto value = SqlColumnTypeDefinitions::Char { N };
+};
+
+template <size_t N, typename CharT>
+    requires(detail::OneOf<CharT, char16_t, char32_t, wchar_t>)
+struct SqlColumnTypeDefinitionOf<SqlFixedString<N, CharT, SqlFixedStringMode::FIXED_SIZE_RIGHT_TRIMMED>>
+{
+    static constexpr auto value = SqlColumnTypeDefinitions::NChar { N };
 };
 
 template <typename T>

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -53,7 +53,7 @@ std::ostream& operator<<(std::ostream& os, CustomType const& value)
 template <>
 struct SqlDataBinder<CustomType>
 {
-    static constexpr SqlColumnType ColumnType = SqlDataBinder<decltype(CustomType::value)>::ColumnType;
+    static constexpr auto ColumnType = SqlDataBinder<decltype(CustomType::value)>::ColumnType;
 
     static SQLRETURN InputParameter(SQLHSTMT hStmt,
                                     SQLUSMALLINT column,
@@ -692,7 +692,7 @@ TEMPLATE_LIST_TEST_CASE("SqlDataBinder specializations", "[SqlDataBinder]", Type
             if constexpr (requires { TestTypeTraits<TestType>::sqlColumnTypeNameOverride; })
                 return conn.QueryFormatter().ColumnType(TestTypeTraits<TestType>::sqlColumnTypeNameOverride);
             else
-                return std::string(conn.Traits().ColumnTypeName(SqlDataBinder<TestType>::ColumnType));
+                return conn.QueryFormatter().ColumnType(SqlDataBinder<TestType>::ColumnType);
         }();
 
         stmt.ExecuteDirect(std::format("CREATE TABLE Test (Value {} NULL)", sqlColumnType));

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -287,21 +287,23 @@ TEST_CASE_METHOD(SqlTestFixture, "InputParameter and GetColumn for very large va
 
     auto stmt = SqlStatement {};
     UNSUPPORTED_DATABASE(stmt, SqlServerType::ORACLE);
-    stmt.ExecuteDirect("CREATE TABLE Test (Value TEXT)");
     auto const expectedText = MakeLargeText(8 * 1000);
-    stmt.Prepare("INSERT INTO Test (Value) VALUES (?)");
+    stmt.MigrateDirect([size = expectedText.size()](auto& migration) {
+        migration.CreateTable("Test").Column("Value", SqlColumnTypeDefinitions::Text { size });
+    });
+    stmt.Prepare(stmt.Query("Test").Insert().Set("Value", SqlWildcard));
     stmt.Execute(expectedText);
 
     SECTION("check handling for explicitly fetched output columns")
     {
-        stmt.ExecuteDirect("SELECT Value FROM Test");
+        stmt.ExecuteDirect(stmt.Query("Test").Select().Field("Value").All());
         (void) stmt.FetchRow();
         CHECK(stmt.GetColumn<std::string>(1) == expectedText);
     }
 
     SECTION("check handling for explicitly fetched output columns (in-place store)")
     {
-        stmt.ExecuteDirect("SELECT Value FROM Test");
+        stmt.ExecuteDirect(stmt.Query("Test").Select().Field("Value").All());
         (void) stmt.FetchRow();
         std::string actualText;
         CHECK(stmt.GetColumn(1, &actualText));
@@ -310,7 +312,7 @@ TEST_CASE_METHOD(SqlTestFixture, "InputParameter and GetColumn for very large va
 
     SECTION("check handling for bound output columns")
     {
-        stmt.Prepare("SELECT Value FROM Test");
+        stmt.Prepare(stmt.Query("Test").Select().Field("Value").All());
         stmt.Execute();
         auto reader = stmt.GetResultCursor();
 
@@ -446,7 +448,7 @@ template <>
 struct TestTypeTraits<SqlTrimmedFixedString<20, char>>
 {
     using ValueType = SqlTrimmedFixedString<20, char>;
-    static constexpr auto sqlColumnTypeNameOverride = "CHAR(20)";
+    static constexpr auto sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::Char { 20 };
     static constexpr auto inputValue = ValueType { "Hello " };
     static constexpr auto expectedOutputValue = ValueType { "Hello" };
 };
@@ -455,7 +457,7 @@ template <>
 struct TestTypeTraits<SqlString<20>>
 {
     using ValueType = SqlString<20>;
-    static constexpr auto sqlColumnTypeNameOverride = "VARCHAR(20)";
+    static constexpr auto sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::Varchar { 20 };
     static constexpr auto inputValue = ValueType { "Hello" };
     static constexpr auto expectedOutputValue = ValueType { "Hello" };
 };
@@ -464,7 +466,7 @@ template <>
 struct TestTypeTraits<SqlString<20, char16_t>>
 {
     using ValueType = SqlString<20, char16_t>;
-    static constexpr auto sqlColumnTypeNameOverride = "VARCHAR(20)";
+    static constexpr auto sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::NVarchar { 20 };
     static constexpr auto inputValue = ValueType { u"Hello" };
     static constexpr auto expectedOutputValue = ValueType { u"Hello" };
 };
@@ -473,7 +475,7 @@ template <>
 struct TestTypeTraits<SqlString<20, char32_t>>
 {
     using ValueType = SqlString<20, char32_t>;
-    static constexpr auto sqlColumnTypeNameOverride = "VARCHAR(20)";
+    static constexpr auto sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::NVarchar { 20 };
     static constexpr auto inputValue = ValueType { U"Hello" };
     static constexpr auto expectedOutputValue = ValueType { U"Hello" };
 };
@@ -482,7 +484,7 @@ template <>
 struct TestTypeTraits<SqlString<20, wchar_t>>
 {
     using ValueType = SqlString<20, wchar_t>;
-    static constexpr auto sqlColumnTypeNameOverride = "VARCHAR(20)";
+    static constexpr auto sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::NVarchar { 20 };
     static constexpr auto inputValue = ValueType { L"Hello" };
     static constexpr auto expectedOutputValue = ValueType { L"Hello" };
 };
@@ -490,7 +492,7 @@ struct TestTypeTraits<SqlString<20, wchar_t>>
 template <>
 struct TestTypeTraits<SqlText>
 {
-    static constexpr auto sqlColumnTypeNameOverride = "VARCHAR(255)"; // Oracle does not support TEXT column, so we use VARCHAR(255) here
+    static constexpr auto sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::Text { 255 };
     static auto const inline inputValue = SqlText { "Hello, World!" };
     static auto const inline expectedOutputValue = SqlText { "Hello, World!" };
     static auto const inline outputInitializer = SqlText { std::string(255, '\0') };
@@ -530,7 +532,7 @@ struct TestTypeTraits<SqlNumeric<15, 2>>
     static constexpr auto blacklist = std::array {
         std::pair { SqlServerType::SQLITE, "SQLite does not support NUMERIC type"sv },
     };
-    static constexpr auto sqlColumnTypeNameOverride = "NUMERIC(15, 2)";
+    static constexpr auto sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::Decimal { .precision=15, .scale=2 };
     static const inline auto inputValue = SqlNumeric<15, 2> { 123.45 };
     static const inline auto expectedOutputValue = SqlNumeric<15, 2> { 123.45 };
 };
@@ -538,77 +540,96 @@ struct TestTypeTraits<SqlNumeric<15, 2>>
 template <>
 struct TestTypeTraits<SqlTrimmedString>
 {
-    static constexpr auto sqlColumnTypeNameOverride = "CHAR(50)";
+    static constexpr auto sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::Char { 20 };
     static auto const inline inputValue = SqlTrimmedString { "Alice    " };
     static auto const inline expectedOutputValue = SqlTrimmedString { "Alice" };
 };
 
+template <typename T>
+T MakeStringOuputInitializer(SqlServerType serverType)
+{
+    if (serverType == SqlServerType::MICROSOFT_SQL)
+        // For MS SQL Server, we need to allocate a large enough buffer for the output column.
+        // Because MS SQL's ODBC driver does not support SQLGetData after SQLFetch for truncated data, it seems.
+        return T(50, '\0');
+    else
+        return T {};
+}
+
 template <>
 struct TestTypeTraits<std::string>
 {
-    static constexpr auto sqlColumnTypeNameOverride = "VARCHAR(50)";
+    static constexpr auto sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::Varchar { 50 };
     static auto const inline inputValue = std::string { "Alice" };
     static auto const inline expectedOutputValue = std::string { "Alice" };
+    static auto const inline outputInitializer = &MakeStringOuputInitializer<std::string>;
+};
 
-    static auto const inline outputInitializer = [](SqlServerType serverType) {
-        if (serverType == SqlServerType::MICROSOFT_SQL)
-            // For MS SQL Server, we need to allocate a large enough buffer for the output column.
-            // Because MS SQL's ODBC driver does not support SQLGetData after SQLFetch for truncated data, it seems.
-            return std::string(50, '\0');
-        else
-            return std::string {};
-    };
+template <>
+struct TestTypeTraits<std::string_view>
+{
+    static constexpr auto sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::Varchar { 50 };
+    static auto const inline inputValue = std::string_view { "Alice" };
+    static auto const inline expectedOutputValue = std::string_view { "Alice" };
+    static auto const inline outputInitializer = &MakeStringOuputInitializer<std::string>;
+    using GetColumnTypeOverride = std::string;
 };
 
 template <>
 struct TestTypeTraits<std::u16string>
 {
-    static auto constexpr sqlColumnTypeNameOverride = "VARCHAR(50)";
+    static auto constexpr sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::NVarchar { 50 };
     static auto const inline inputValue = u"Alice"s;
     static auto const inline expectedOutputValue = u"Alice"s;
+    static auto const inline outputInitializer = &MakeStringOuputInitializer<std::u16string>;
+};
 
-    static auto const inline outputInitializer = [](SqlServerType serverType) {
-        if (serverType == SqlServerType::MICROSOFT_SQL)
-            // For MS SQL Server, we need to allocate a large enough buffer for the output column.
-            // Because MS SQL's ODBC driver does not support SQLGetData after SQLFetch for truncated data, it seems.
-            return std::u16string(50, '\0');
-        else
-            return std::u16string {};
-    };
+template <>
+struct TestTypeTraits<std::u16string_view>
+{
+    static constexpr auto sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::NVarchar { 50 };
+    static auto const inline inputValue = std::u16string_view { u"Alice" };
+    static auto const inline expectedOutputValue = std::u16string_view { u"Alice" };
+    static auto const inline outputInitializer = &MakeStringOuputInitializer<std::u16string>;
+    using GetColumnTypeOverride = std::u16string;
 };
 
 template <>
 struct TestTypeTraits<std::u32string>
 {
-    static auto constexpr sqlColumnTypeNameOverride = "VARCHAR(50)";
+    static auto constexpr sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::NVarchar { 50 };
     static auto const inline inputValue = U"Alice"s;
     static auto const inline expectedOutputValue = U"Alice"s;
+    static auto const inline outputInitializer = &MakeStringOuputInitializer<std::u32string>;
+};
 
-    static auto const inline outputInitializer = [](SqlServerType serverType) {
-        if (serverType == SqlServerType::MICROSOFT_SQL)
-            // For MS SQL Server, we need to allocate a large enough buffer for the output column.
-            // Because MS SQL's ODBC driver does not support SQLGetData after SQLFetch for truncated data, it seems.
-            return std::u32string(50, '\0');
-        else
-            return std::u32string {};
-    };
+template <>
+struct TestTypeTraits<std::u32string_view>
+{
+    static constexpr auto sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::NVarchar { 50 };
+    static auto const inline inputValue = std::u32string_view { U"Alice" };
+    static auto const inline expectedOutputValue = std::u32string_view { U"Alice" };
+    static auto const inline outputInitializer = &MakeStringOuputInitializer<std::u32string>;
+    using GetColumnTypeOverride = std::u32string;
 };
 
 template <>
 struct TestTypeTraits<std::wstring>
 {
-    static auto constexpr sqlColumnTypeNameOverride = "VARCHAR(50)";
+    static auto constexpr sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::NVarchar { 50 };
     static auto const inline inputValue = L"Alice"s;
     static auto const inline expectedOutputValue = L"Alice"s;
+    static auto const inline outputInitializer = &MakeStringOuputInitializer<std::wstring>;
+};
 
-    static auto const inline outputInitializer = [](SqlServerType serverType) {
-        if (serverType == SqlServerType::MICROSOFT_SQL)
-            // For MS SQL Server, we need to allocate a large enough buffer for the output column.
-            // Because MS SQL's ODBC driver does not support SQLGetData after SQLFetch for truncated data, it seems.
-            return std::wstring(50, '\0');
-        else
-            return std::wstring {};
-    };
+template <>
+struct TestTypeTraits<std::wstring_view>
+{
+    static constexpr auto sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::NVarchar { 50 };
+    static auto const inline inputValue = std::wstring_view { L"Alice" };
+    static auto const inline expectedOutputValue = std::wstring_view { L"Alice" };
+    static auto const inline outputInitializer = &MakeStringOuputInitializer<std::wstring>;
+    using GetColumnTypeOverride = std::wstring;
 };
 
 using TypesToTest = std::tuple<
@@ -631,9 +652,13 @@ using TypesToTest = std::tuple<
     int32_t,
     int64_t,
     std::string,
+    std::string_view,
     std::u16string,
+    std::u16string_view,
     std::u32string,
-    std::wstring
+    std::u32string_view,
+    std::wstring,
+    std::wstring_view
 >;
 // clang-format on
 
@@ -663,11 +688,11 @@ TEMPLATE_LIST_TEST_CASE("SqlDataBinder specializations", "[SqlDataBinder]", Type
 
         auto stmt = SqlStatement { conn };
 
-        auto const sqlColumnType = [&]() -> std::string_view {
+        auto const sqlColumnType = [&]() -> std::string {
             if constexpr (requires { TestTypeTraits<TestType>::sqlColumnTypeNameOverride; })
-                return TestTypeTraits<TestType>::sqlColumnTypeNameOverride;
+                return conn.QueryFormatter().ColumnType(TestTypeTraits<TestType>::sqlColumnTypeNameOverride);
             else
-                return conn.Traits().ColumnTypeName(SqlDataBinder<TestType>::ColumnType);
+                return std::string(conn.Traits().ColumnTypeName(SqlDataBinder<TestType>::ColumnType));
         }();
 
         stmt.ExecuteDirect(std::format("CREATE TABLE Test (Value {} NULL)", sqlColumnType));
@@ -685,59 +710,68 @@ TEMPLATE_LIST_TEST_CASE("SqlDataBinder specializations", "[SqlDataBinder]", Type
                     CHECK_THAT(
                         stmt.GetColumn<TestType>(1),
                         (Catch::Matchers::WithinAbs(double(TestTypeTraits<TestType>::expectedOutputValue), 0.001)));
+                else if constexpr (requires { typename TestTypeTraits<TestType>::GetColumnTypeOverride; })
+                    CHECK(stmt.GetColumn<typename TestTypeTraits<TestType>::GetColumnTypeOverride>(1)
+                          == TestTypeTraits<TestType>::expectedOutputValue);
                 else
                     CHECK(stmt.GetColumn<TestType>(1) == TestTypeTraits<TestType>::expectedOutputValue);
             }
 
-            THEN("Retrieve value via BindOutputColumns()")
+            if constexpr (!requires { typename TestTypeTraits<TestType>::GetColumnTypeOverride; })
             {
-                stmt.ExecuteDirect("SELECT Value FROM Test");
-                auto actualValue = [&]() -> TestType {
-                    if constexpr (requires(SqlServerType st) { TestTypeTraits<TestType>::outputInitializer(st); })
-                        return TestTypeTraits<TestType>::outputInitializer(conn.ServerType());
-                    else if constexpr (requires { TestTypeTraits<TestType>::outputInitializer; })
-                        return TestTypeTraits<TestType>::outputInitializer;
+                THEN("Retrieve value via BindOutputColumns()")
+                {
+                    stmt.ExecuteDirect("SELECT Value FROM Test");
+                    auto actualValue = [&]() -> TestType {
+                        if constexpr (requires(SqlServerType st) { TestTypeTraits<TestType>::outputInitializer(st); })
+                            return TestTypeTraits<TestType>::outputInitializer(conn.ServerType());
+                        else if constexpr (requires { TestTypeTraits<TestType>::outputInitializer; })
+                            return TestTypeTraits<TestType>::outputInitializer;
+                        else
+                            return TestType {};
+                    }();
+                    stmt.BindOutputColumns(&actualValue);
+                    (void) stmt.FetchRow();
+                    if constexpr (std::is_convertible_v<TestType, double> && !std::integral<TestType>)
+                        CHECK_THAT(
+                            double(actualValue),
+                            (Catch::Matchers::WithinAbs(double(TestTypeTraits<TestType>::expectedOutputValue), 0.001)));
                     else
-                        return TestType {};
-                }();
-                stmt.BindOutputColumns(&actualValue);
-                (void) stmt.FetchRow();
-                if constexpr (std::is_convertible_v<TestType, double> && !std::integral<TestType>)
-                    CHECK_THAT(
-                        double(actualValue),
-                        (Catch::Matchers::WithinAbs(double(TestTypeTraits<TestType>::expectedOutputValue), 0.001)));
-                else
-                    CHECK(actualValue == TestTypeTraits<TestType>::expectedOutputValue);
+                        CHECK(actualValue == TestTypeTraits<TestType>::expectedOutputValue);
+                }
             }
         }
 
-        WHEN("Inserting a NULL value")
+        if constexpr (!requires { typename TestTypeTraits<TestType>::GetColumnTypeOverride; })
         {
-            stmt.Prepare("INSERT INTO Test (Value) VALUES (?)");
-            stmt.Execute(SqlNullValue);
-
-            THEN("Retrieve value via GetNullableColumn()")
+            WHEN("Inserting a NULL value")
             {
-                stmt.ExecuteDirect("SELECT Value FROM Test");
-                (void) stmt.FetchRow();
-                CHECK(!stmt.GetNullableColumn<TestType>(1).has_value());
-            }
+                stmt.Prepare("INSERT INTO Test (Value) VALUES (?)");
+                stmt.Execute(SqlNullValue);
 
-            THEN("Retrieve value via GetColumn()")
-            {
-                stmt.ExecuteDirect("SELECT Value FROM Test");
-                (void) stmt.FetchRow();
-                CHECK_THROWS_AS(stmt.GetColumn<TestType>(1), std::runtime_error);
-            }
+                THEN("Retrieve value via GetNullableColumn()")
+                {
+                    stmt.ExecuteDirect("SELECT Value FROM Test");
+                    (void) stmt.FetchRow();
+                    CHECK(!stmt.GetNullableColumn<TestType>(1).has_value());
+                }
 
-            THEN("Retrieve value via BindOutputColumns()")
-            {
-                stmt.Prepare("SELECT Value FROM Test");
-                stmt.Execute();
-                auto actualValue = std::optional<TestType> {};
-                stmt.BindOutputColumns(&actualValue);
-                (void) stmt.FetchRow();
-                CHECK(!actualValue.has_value());
+                THEN("Retrieve value via GetColumn()")
+                {
+                    stmt.ExecuteDirect("SELECT Value FROM Test");
+                    (void) stmt.FetchRow();
+                    CHECK_THROWS_AS(stmt.GetColumn<TestType>(1), std::runtime_error);
+                }
+
+                THEN("Retrieve value via BindOutputColumns()")
+                {
+                    stmt.Prepare("SELECT Value FROM Test");
+                    stmt.Execute();
+                    auto actualValue = std::optional<TestType> {};
+                    stmt.BindOutputColumns(&actualValue);
+                    (void) stmt.FetchRow();
+                    CHECK(!actualValue.has_value());
+                }
             }
         }
     }

--- a/src/tests/Utils.hpp
+++ b/src/tests/Utils.hpp
@@ -12,6 +12,7 @@
 #include "../Lightweight/SqlDataBinder.hpp"
 #include "../Lightweight/SqlLogger.hpp"
 #include "../Lightweight/SqlStatement.hpp"
+#include "../Lightweight/Utils.hpp"
 
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -61,8 +62,13 @@ namespace std
 // so that we can get them pretty-printed in REQUIRE() and CHECK() macros.
 
 template <typename WideStringT>
-    requires(same_as<WideStringT, WideString> || same_as<WideStringT, WideStringView>
-             || same_as<WideStringT, std::u16string> || same_as<WideStringT, std::u32string>)
+    requires(detail::OneOf<WideStringT,
+                           std::wstring,
+                           std::wstring_view,
+                           std::u16string,
+                           std::u16string_view,
+                           std::u32string,
+                           std::u32string_view>)
 ostream& operator<<(ostream& os, WideStringT const& str)
 {
     auto constexpr BitsPerChar = sizeof(typename WideStringT::value_type) * 8;


### PR DESCRIPTION
tests tests tests

ok, i've changed more than initially anticipated (to just get the string view variants working), but I realized that we did not actually create tables with NCHAR and NVARCHAR data types, which is now fixed.

Oracle SQL got its own dialect formatter (not fully correct one), but this should be fixed by the time we add it to the CI.