### PR TITLE
feedback oriented improvements

### DIFF
--- a/src/Lightweight/DataBinder/BasicStringBinder.hpp
+++ b/src/Lightweight/DataBinder/BasicStringBinder.hpp
@@ -79,7 +79,7 @@ template <typename AnsiStringType>
 struct LIGHTWEIGHT_API SqlDataBinder<AnsiStringType>
 {
     using ValueType = AnsiStringType;
-    using CharType = typename AnsiStringType::value_type;
+    using CharType = char;
     using StringTraits = SqlBasicStringOperations<AnsiStringType>;
 
     static constexpr auto ColumnType = StringTraits::ColumnType;
@@ -247,7 +247,7 @@ template <typename Utf16StringType>
 struct LIGHTWEIGHT_API SqlDataBinder<Utf16StringType>
 {
     using ValueType = Utf16StringType;
-    using CharType = typename Utf16StringType::value_type;
+    using CharType = std::remove_cvref_t<decltype(std::declval<Utf16StringType>()[0])>;
     using StringTraits = SqlBasicStringOperations<Utf16StringType>;
 
     static constexpr auto ColumnType = StringTraits::ColumnType;

--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -18,8 +18,6 @@
 #include <concepts>
 #include <type_traits>
 
-#include <iostream>
-
 // Requires that T satisfies to be a field with storage.
 template <typename T>
 concept FieldWithStorage = requires(T const& field, T& mutableField) {

--- a/src/Lightweight/SqlQuery/Core.hpp
+++ b/src/Lightweight/SqlQuery/Core.hpp
@@ -485,7 +485,15 @@ inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlWhereClauseBuilder<Derived>::Where(C
     searchCondition.condition += binaryOp;
     searchCondition.condition += ' ';
 
-    if constexpr (std::is_same_v<T, SqlWildcardType>)
+    if constexpr (std::is_same_v<T, SqlQualifiedTableColumnName>)
+    {
+        searchCondition.condition += '"';
+        searchCondition.condition += value.tableName;
+        searchCondition.condition += "\".\"";
+        searchCondition.condition += value.columnName;
+        searchCondition.condition += '"';
+    }
+    else if constexpr (std::is_same_v<T, SqlWildcardType>)
     {
         searchCondition.condition += '?';
     }

--- a/src/Lightweight/SqlQuery/Core.hpp
+++ b/src/Lightweight/SqlQuery/Core.hpp
@@ -183,6 +183,9 @@ class [[nodiscard]] SqlWhereClauseBuilder
     template <typename ColumnName>
     [[nodiscard]] Derived& WhereNotNull(ColumnName const& columnName);
 
+    template <typename ColumnName, typename T>
+    [[nodiscard]] Derived& WhereNotEqual(ColumnName const& columnName, T const& value);
+
     template <typename ColumnName>
     [[nodiscard]] Derived& WhereTrue(ColumnName const& columnName);
 
@@ -433,6 +436,17 @@ template <typename ColumnName>
 inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlWhereClauseBuilder<Derived>::WhereNull(ColumnName const& columnName)
 {
     return Where(columnName, "IS", "NULL");
+}
+
+template <typename Derived>
+template <typename ColumnName, typename T>
+inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlWhereClauseBuilder<Derived>::WhereNotEqual(ColumnName const& columnName,
+                                                                                       T const& value)
+{
+    if constexpr (detail::OneOf<T, SqlNullType, std::nullopt_t>)
+        return Where(columnName, "IS NOT", value);
+    else
+        return Where(columnName, "!=", value);
 }
 
 template <typename Derived>

--- a/src/Lightweight/Utils.hpp
+++ b/src/Lightweight/Utils.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <reflection-cpp/reflection.hpp>
+
+#include <optional>
 #include <string_view>
 #include <type_traits>
 #include <utility>
-
-#include <reflection-cpp/reflection.hpp>
 
 namespace detail
 {

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -456,8 +456,8 @@ TEST_CASE_METHOD(SqlTestFixture, "Where: left IS NULL", "[SqlQueryBuilder]")
             return q.FromTable("That")
                 .Select()
                 .Field("foo")
-                .Not().Where("Left1", SqlNullValue)
-                .Or().Not().Where("Left2", std::nullopt)
+                .WhereNotEqual("Left1", SqlNullValue)
+                .Or().WhereNotEqual("Left2", std::nullopt)
                 .All();
             // clang-format on
         },

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -418,6 +418,24 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereColumn", "[SqlQueryBuilde
                                   WHERE "left" = "right")"));
 }
 
+TEST_CASE_METHOD(SqlTestFixture,
+                 "Where: SqlQualifiedTableColumnName OP SqlQualifiedTableColumnName",
+                 "[SqlQueryBuilder]")
+{
+    checkSqlQueryBuilder(
+        [](SqlQueryBuilder& q) {
+            return q.FromTable("That")
+                .Select()
+                .Field("foo")
+                .Where(SqlQualifiedTableColumnName { .tableName = "That", .columnName = "left" },
+                       "=",
+                       SqlQualifiedTableColumnName { .tableName = "That", .columnName = "right" })
+                .All();
+        },
+        QueryExpectations::All(R"(SELECT "foo" FROM "That"
+                                  WHERE "That"."left" = "That"."right")"));
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "Varying: multiple varying final query types", "[SqlQueryBuilder]")
 {
     auto const& sqliteFormatter = SqlQueryFormatter::Sqlite();

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -436,6 +436,35 @@ TEST_CASE_METHOD(SqlTestFixture,
                                   WHERE "That"."left" = "That"."right")"));
 }
 
+TEST_CASE_METHOD(SqlTestFixture, "Where: left IS NULL", "[SqlQueryBuilder]")
+{
+    checkSqlQueryBuilder(
+        [](SqlQueryBuilder& q) {
+            return q.FromTable("That")
+                .Select()
+                .Field("foo")
+                .Where("Left1", SqlNullValue)
+                .Where("Left2", std::nullopt)
+                .All();
+        },
+        QueryExpectations::All(R"(SELECT "foo" FROM "That"
+                                  WHERE "Left1" IS NULL AND "Left2" IS NULL)"));
+
+    checkSqlQueryBuilder(
+        [](SqlQueryBuilder& q) {
+            // clang-format off
+            return q.FromTable("That")
+                .Select()
+                .Field("foo")
+                .Not().Where("Left1", SqlNullValue)
+                .Or().Not().Where("Left2", std::nullopt)
+                .All();
+            // clang-format on
+        },
+        QueryExpectations::All(R"(SELECT "foo" FROM "That"
+                                  WHERE "Left1" IS NOT NULL OR "Left2" IS NOT NULL)"));
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "Varying: multiple varying final query types", "[SqlQueryBuilder]")
 {
     auto const& sqliteFormatter = SqlQueryFormatter::Sqlite();

--- a/src/tools/ddl2cpp.cpp
+++ b/src/tools/ddl2cpp.cpp
@@ -106,20 +106,6 @@ constexpr bool isVowel(char c) noexcept
     }
 }
 
-std::string MakePluralVariableName(SqlSchema::FullyQualifiedTableName const& table)
-{
-    auto const& sqlName = table.table;
-    if (sqlName.back() == 'y' && sqlName.size() > 1 && !isVowel(sqlName.at(sqlName.size() - 2)))
-    {
-        auto name = std::format("{}ies", sqlName.substr(0, sqlName.size() - 1));
-        name.at(0) = static_cast<char>(std::tolower(name.at(0)));
-        return name;
-    }
-    auto name = std::format("{}s", sqlName);
-    name.at(0) = static_cast<char>(std::tolower(name.at(0)));
-    return name;
-}
-
 class CxxModelPrinter
 {
   private:


### PR DESCRIPTION
# most important additions:

* ddl2cpp: Drop dead `MakePluralVariableName(table)`
* Adapt `BasicStringBinder<T>::CharType` to work with non-stdlib like strings
* QueryBuilder: Extend `Where(A[, OP], B)` to also allow `B` to be a `SqlQualifiedTableColumnName`
* QueryBuilder: Add intuitive way to test for `NULL`: `Where(A, SqlNullValue)` and `Where(A, std::nullopt)`