### PR TITLE
[DataMapper] Field: Find better names for the PrimaryKey enum class members

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Documentation is available at [https://lastrada-software.github.io/Lightweight/]
 // Field<> is also used to track what fields are modified and need to be updated.
 struct Person
 {
-    Field<uint64_t, PrimaryKey::AutoIncrement> id;
+    Field<SqlGuid, PrimaryKey::AutoAssgn> id;
     Field<SqlAnsiString<25>> name;
     Field<bool> is_active { true };
     Field<std::optional<int>> age;

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -77,7 +77,7 @@ For more info see `SqlQuery` and `SqlQueryFormatter` documentation
 // Field<> is also used to track what fields are modified and need to be updated.
 struct Person
 {
-    Field<uint64_t, PrimaryKey::AutoIncrement> id;
+    Field<SqlGuid, PrimaryKey::AutoAssign> id;
     Field<SqlAnsiString<25>> name;
     Field<bool> is_active { true };
     Field<std::optional<int>> age;

--- a/src/Lightweight/SqlMigration.cpp
+++ b/src/Lightweight/SqlMigration.cpp
@@ -33,7 +33,7 @@ void MigrationManager::RemoveAllMigrations()
 
 struct SchemaMigration
 {
-    Field<uint64_t, PrimaryKey::Manual> version;
+    Field<uint64_t, PrimaryKey::AutoAssign> version;
 
     static constexpr std::string_view TableName = "schema_migrations";
 };

--- a/src/tests/DataMapperTests.cpp
+++ b/src/tests/DataMapperTests.cpp
@@ -41,7 +41,7 @@ std::ostream& operator<<(std::ostream& os, Field<T, IsPrimaryKeyValue> const& fi
 
 struct Person
 {
-    Field<SqlGuid, PrimaryKey::Manual> id;
+    Field<SqlGuid, PrimaryKey::AutoAssign> id;
     Field<SqlAnsiString<25>> name;
     Field<bool> is_active { true };
     Field<std::optional<int>> age;
@@ -50,7 +50,7 @@ struct Person
 // This is a test to only partially query a table row (a few columns)
 struct PersonName
 {
-    Field<SqlGuid, PrimaryKey::Manual> id;
+    Field<SqlGuid, PrimaryKey::AutoAssign> id;
     Field<SqlAnsiString<25>> name;
 
     static constexpr std::string_view TableName = RecordTableName<Person>;
@@ -139,7 +139,7 @@ TEST_CASE_METHOD(SqlTestFixture, "iterate over database", "[SqlRowIterator]")
 
 struct RecordWithDefaults
 {
-    Field<uint64_t, PrimaryKey::AutoIncrement> id;
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id;
     Field<SqlAnsiString<30>> name1 { "John Doe" };
     Field<std::optional<SqlAnsiString<30>>> name2 { "John Doe" };
     Field<bool> boolean1 { true };
@@ -150,7 +150,7 @@ struct RecordWithDefaults
 
 struct RecordWithNoDefaults
 {
-    Field<uint64_t, PrimaryKey::AutoIncrement> id;
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id;
     Field<SqlAnsiString<30>> name1;
     Field<std::optional<SqlAnsiString<30>>> name2;
     Field<bool> boolean1;
@@ -185,7 +185,7 @@ struct Email;
 
 struct User
 {
-    Field<uint64_t, PrimaryKey::AutoIncrement> id {};
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id {};
     Field<SqlAnsiString<30>> name {};
 
     HasMany<Email> emails {};
@@ -193,7 +193,7 @@ struct User
 
 struct Email
 {
-    Field<uint64_t, PrimaryKey::AutoIncrement> id {};
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id {};
     Field<SqlAnsiString<30>> address {};
     BelongsTo<&User::id> user {};
 
@@ -296,7 +296,7 @@ struct AccountHistory;
 
 struct Suppliers
 {
-    Field<uint64_t, PrimaryKey::AutoIncrement> id {};
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id {};
     Field<SqlAnsiString<30>> name {};
 
     // TODO: HasOne<Account> account;
@@ -310,7 +310,7 @@ std::ostream& operator<<(std::ostream& os, Suppliers const& record)
 
 struct Account
 {
-    Field<uint64_t, PrimaryKey::AutoIncrement> id {};
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id {};
     Field<SqlAnsiString<30>> iban {};
     BelongsTo<&Suppliers::id> supplier {};
 
@@ -324,7 +324,7 @@ std::ostream& operator<<(std::ostream& os, Account const& record)
 
 struct AccountHistory
 {
-    Field<uint64_t, PrimaryKey::AutoIncrement> id {};
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id {};
     Field<int> credit_rating {};
     BelongsTo<&Account::id> account {};
 
@@ -375,7 +375,7 @@ struct Patient;
 
 struct Physician
 {
-    Field<SqlGuid, PrimaryKey::Manual> id;
+    Field<SqlGuid, PrimaryKey::AutoAssign> id;
     Field<SqlAnsiString<30>> name;
     HasMany<Appointment> appointments;
     HasManyThrough<Patient, Appointment> patients;
@@ -383,7 +383,7 @@ struct Physician
 
 struct Patient
 {
-    Field<SqlGuid, PrimaryKey::Manual> id;
+    Field<SqlGuid, PrimaryKey::AutoAssign> id;
     Field<SqlAnsiString<30>> name;
     Field<SqlAnsiString<30>> comment;
     HasMany<Appointment> appointments;
@@ -392,7 +392,7 @@ struct Patient
 
 struct Appointment
 {
-    Field<SqlGuid, PrimaryKey::Manual> id;
+    Field<SqlGuid, PrimaryKey::AutoAssign> id;
     Field<SqlDateTime> date;
     Field<SqlAnsiString<80>> comment;
     BelongsTo<&Physician::id> physician;
@@ -479,7 +479,7 @@ TEST_CASE_METHOD(SqlTestFixture, "HasManyThrough", "[DataMapper][relations]")
 
 struct TestRecord
 {
-    Field<uint64_t, PrimaryKey::Manual> id {};
+    Field<uint64_t, PrimaryKey::AutoAssign> id {};
     Field<SqlAnsiString<30>> comment;
 
     std::weak_ordering operator<=>(TestRecord const& other) const = default;
@@ -563,8 +563,8 @@ TEST_CASE_METHOD(SqlTestFixture, "Query: SELECT into simple struct", "[DataMappe
 
 struct MultiPkRecord
 {
-    Field<SqlAnsiString<32>, PrimaryKey::Manual> firstName;
-    Field<SqlAnsiString<32>, PrimaryKey::Manual> lastName;
+    Field<SqlAnsiString<32>, PrimaryKey::AutoAssign> firstName;
+    Field<SqlAnsiString<32>, PrimaryKey::AutoAssign> lastName;
 
     constexpr std::weak_ordering operator<=>(MultiPkRecord const& other) const = default;
 };

--- a/src/tools/ddl2cpp.cpp
+++ b/src/tools/ddl2cpp.cpp
@@ -165,7 +165,7 @@ class CxxModelPrinter
             std::string type = MakeType(column);
             if (column.isPrimaryKey)
             {
-                m_definitions << std::format("    Field<{}, PrimaryKey::AutoIncrement> {};\n", type, column.name);
+                m_definitions << std::format("    Field<{}, PrimaryKey::ServerSideAutoIncrement> {};\n", type, column.name);
                 continue;
             }
             if (column.isForeignKey)

--- a/src/tools/tests/1.expected
+++ b/src/tools/tests/1.expected
@@ -13,7 +13,7 @@ struct Person;
 
 struct Person final
 {
-    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<int, PrimaryKey::ServerSideAutoIncrement> id;
     Field<std::string> name;
     Field<bool> is_active;
     Field<std::optional<int>> age;

--- a/src/tools/tests/2.expected
+++ b/src/tools/tests/2.expected
@@ -15,21 +15,21 @@ struct Suppliers;
 
 struct Suppliers final
 {
-    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<int, PrimaryKey::ServerSideAutoIncrement> id;
     Field<std::string> name;
     HasOneThrough<AccountHistory, Account> accountHistory;
 }
 
 struct Account final
 {
-    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<int, PrimaryKey::ServerSideAutoIncrement> id;
     Field<std::string> iban;
     BelongsTo<&Suppliers::id> supplier;
 };
 
 struct AccountHistory final
 {
-    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<int, PrimaryKey::ServerSideAutoIncrement> id;
     Field<int> credit_rating;
     BelongsTo<&Account::id> account;
 };

--- a/src/tools/tests/3.expected
+++ b/src/tools/tests/3.expected
@@ -15,20 +15,20 @@ struct User;
 
 struct User final
 {
-    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<int, PrimaryKey::ServerSideAutoIncrement> id;
     Field<std::string> fullname;
     Field<std::string> email;
 };
 
 struct TaskList final
 {
-    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<int, PrimaryKey::ServerSideAutoIncrement> id;
     BelongsTo<&User::id> user;
 };
 
 struct TaskListEntry final
 {
-    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<int, PrimaryKey::ServerSideAutoIncrement> id;
     Field<std::optional<SqlDateTime>> completed;
     Field<std::string> task;
     BelongsTo<&TaskList::id> taskList;


### PR DESCRIPTION
this is in reference to a feedback from @FelixTheC, to find better names for the enum class emmbers, specifically the `Manual` name, that wasn't actually that manual, but more like semi automatic.

I hope this one are now better fitting names.