### PR TITLE
Fix file names and doc updates only on master push

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
-
 
 concurrency:
   group: docs-${{ github.ref }}

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -38,6 +38,8 @@ if(DOXYGEN_FOUND)
   set(DOXYGEN_HTML_EXTRA_STYLESHEET "${CMAKE_BINARY_DIR}/_deps/doxygen-awesome-css-src/doxygen-awesome.css")
   set(DOXYGEN_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}")
   set(DOXYGEN_EXCLUDE_SYMBOLS "detail,detail::*,std,std::*,benchmark,test")
+  set(DOXYGEN_CASE_SENSE_NAMES YES)
+  set(DOXYGEN_CREATE_SUBDIRS YES)
 
   # TODO: get include paths correct, e.g. <Lightweight/SqlConnection.hpp> rather than <SqlConnection.hpp>
   set(DOXYGEN_FULL_PATH_NAMES YES)

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-www.lightweight.org


### PR DESCRIPTION
* Generate docs only when master is updated 
* Use case sensitive names for the header files in the docs, otherwise doxygen can generate files with underscore as a name prefix and they are ignore in github pages 