### PR TITLE
some convenience helper for very complex queries

### DIFF
--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -60,12 +60,6 @@ auto ToSharedPtrList(Container<Object, Allocator<Object>> container)
 
 } // namespace detail
 
-/// @brief Holds the SQL tabl ename for the given record type.
-///
-/// @ingroup DataMapper
-template <DataMapperRecord Record>
-constexpr std::string_view RecordTableName = detail::RecordTableName<Record>::Value;
-
 /// @brief Main API for mapping records to and from the database using high level C++ syntax.
 ///
 /// @see Field, BelongsTo, HasMany, HasManyThrough, HasOneThrough

--- a/src/Lightweight/SqlQuery.cpp
+++ b/src/Lightweight/SqlQuery.cpp
@@ -8,6 +8,12 @@ SqlQueryBuilder& SqlQueryBuilder::FromTable(std::string table)
     return *this;
 }
 
+SqlQueryBuilder& SqlQueryBuilder::FromTable(std::string_view table)
+{
+    m_table = std::string(table);
+    return *this;
+}
+
 SqlQueryBuilder& SqlQueryBuilder::FromTableAs(std::string table, std::string alias)
 {
     m_table = std::move(table);

--- a/src/Lightweight/SqlQuery.hpp
+++ b/src/Lightweight/SqlQuery.hpp
@@ -31,6 +31,16 @@ class [[nodiscard]] SqlQueryBuilder final
     /// Constructs a new query builder for the given table.
     LIGHTWEIGHT_API SqlQueryBuilder& FromTable(std::string table);
 
+    /// Constructs a new query builder for the given table.
+    LIGHTWEIGHT_API SqlQueryBuilder& FromTable(std::string_view table);
+
+    /// Constructs a new query builder for the given table.
+    template <size_t N>
+    SqlQueryBuilder& FromTable(char const (&table)[N])
+    {
+        return FromTable(std::string_view { table, N - 1 });
+    }
+
     /// Constructs a new query builder for the given table with an alias.
     LIGHTWEIGHT_API SqlQueryBuilder& FromTableAs(std::string table, std::string alias);
 

--- a/src/Lightweight/Utils.hpp
+++ b/src/Lightweight/Utils.hpp
@@ -63,6 +63,12 @@ struct RecordTableName
 
 } // namespace detail
 
+/// @brief Holds the SQL tabl ename for the given record type.
+///
+/// @ingroup DataMapper
+template <typename Record>
+constexpr std::string_view RecordTableName = detail::RecordTableName<Record>::Value;
+
 template <template <typename...> class S, class T>
 concept IsSpecializationOf = detail::is_specialization_of<S, T>::value;
 


### PR DESCRIPTION
We have a case where we add many many columns to the query builder and thus, chain each fields into `BindOutputColumn...`.

With this API, it shall be way more easy, concise, and less error prone, to construct and maintain such queries.

NB: check the test case for a usage example