### PR TITLE
Fix WhereNull() and WhereNotNull() clauses and add tests for it

### DIFF
--- a/src/Lightweight/SqlQuery/Core.hpp
+++ b/src/Lightweight/SqlQuery/Core.hpp
@@ -130,7 +130,6 @@ class SqlJoinConditionBuilder
     bool _firstCall = true;
 };
 
-
 /// Helper CRTP-based class for building WHERE clauses.
 ///
 /// This class is inherited by the SqlSelectQueryBuilder, SqlUpdateQueryBuilder, and SqlDeleteQueryBuilder
@@ -412,7 +411,8 @@ inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlWhereClauseBuilder<Derived>::Where(C
     return static_cast<Derived&>(*this);
 }
 
-namespace detail {
+namespace detail
+{
 
 inline LIGHTWEIGHT_FORCE_INLINE RawSqlCondition PopulateSqlSetExpression(auto const& values)
 {
@@ -460,14 +460,14 @@ template <typename Derived>
 template <typename ColumnName>
 inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlWhereClauseBuilder<Derived>::WhereNotNull(ColumnName const& columnName)
 {
-    return Where(columnName, "IS NOT", "NULL");
+    return Where(columnName, "IS NOT", detail::RawSqlCondition { "NULL" });
 }
 
 template <typename Derived>
 template <typename ColumnName>
 inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlWhereClauseBuilder<Derived>::WhereNull(ColumnName const& columnName)
 {
-    return Where(columnName, "IS", "NULL");
+    return Where(columnName, "IS", detail::RawSqlCondition { "NULL" });
 }
 
 template <typename Derived>

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -279,6 +279,36 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.ComplexOR", "[SqlQueryBuilder]
                                  RIGHT OUTER JOIN "Table3" ON "Table3"."id" = "Table1"."column1" OR "Table3"."id" = "Table1"."column2" OR "Table3"."id" = "Table1"."column3" OR "Table3"."id" = "Table1"."column4")"));
 }
 
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.WhereNotNull", "[SqlQueryBuilder]")
+{
+    checkSqlQueryBuilder(
+        [](SqlQueryBuilder& q) {
+            // clang-format off
+            return q.FromTable("Table")
+                .Select()
+                .WhereNotNull("Column1")
+                .Count();
+            // clang-format on
+        },
+        QueryExpectations::All(R"SQL(SELECT COUNT(*) FROM "Table"
+                                     WHERE "Column1" IS NOT NULL)SQL"));
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.WhereNull", "[SqlQueryBuilder]")
+{
+    checkSqlQueryBuilder(
+        [](SqlQueryBuilder& q) {
+            // clang-format off
+            return q.FromTable("Table")
+                .Select()
+                .WhereNull("Column1")
+                .Count();
+            // clang-format on
+        },
+        QueryExpectations::All(R"SQL(SELECT COUNT(*) FROM "Table"
+                                     WHERE "Column1" IS NULL)SQL"));
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.Junctors", "[SqlQueryBuilder]")
 {
     checkSqlQueryBuilder(


### PR DESCRIPTION
The initially suggested `SQL_NULL_DATA` by @FelixTheC, was working only by accident. This properly fixes it, and adds some test cases for it.