### PR TITLE
some data binder improvements (missing primitives types added)

### DIFF
--- a/src/Lightweight/DataBinder/Primitives.hpp
+++ b/src/Lightweight/DataBinder/Primitives.hpp
@@ -65,6 +65,8 @@ struct Int64DataBinderHelper
 // clang-format off
 template <> struct SqlDataBinder<bool>: SqlSimpleDataBinder<bool, SQL_BIT, SQL_BIT, SqlColumnTypeDefinitions::Bool {}> {};
 template <> struct SqlDataBinder<char>: SqlSimpleDataBinder<char, SQL_C_CHAR, SQL_CHAR, SqlColumnTypeDefinitions::Char {}> {};
+template <> struct SqlDataBinder<int8_t>: SqlSimpleDataBinder<int8_t, SQL_C_STINYINT, SQL_TINYINT, SqlColumnTypeDefinitions::Tinyint {}> {};
+template <> struct SqlDataBinder<uint8_t>: SqlSimpleDataBinder<uint8_t, SQL_C_UTINYINT, SQL_TINYINT, SqlColumnTypeDefinitions::Tinyint {}> {};
 template <> struct SqlDataBinder<int16_t>: SqlSimpleDataBinder<int16_t, SQL_C_SSHORT, SQL_SMALLINT, SqlColumnTypeDefinitions::Smallint {}> {};
 template <> struct SqlDataBinder<uint16_t>: SqlSimpleDataBinder<uint16_t, SQL_C_USHORT, SQL_SMALLINT, SqlColumnTypeDefinitions::Smallint {}> {};
 template <> struct SqlDataBinder<int32_t>: SqlSimpleDataBinder<int32_t, SQL_C_SLONG, SQL_INTEGER, SqlColumnTypeDefinitions::Integer {}> {};

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -515,6 +515,13 @@ template <typename T>
 struct TestTypeTraits;
 
 template <>
+struct TestTypeTraits<int8_t>
+{
+    static constexpr auto inputValue = (std::numeric_limits<int8_t>::max)();
+    static constexpr auto expectedOutputValue = (std::numeric_limits<int8_t>::max)();
+};
+
+template <>
 struct TestTypeTraits<int16_t>
 {
     static constexpr auto inputValue = (std::numeric_limits<int16_t>::max)();
@@ -533,6 +540,27 @@ struct TestTypeTraits<int64_t>
 {
     static constexpr auto inputValue = (std::numeric_limits<int64_t>::max)();
     static constexpr auto expectedOutputValue = (std::numeric_limits<int64_t>::max)();
+};
+
+template <>
+struct TestTypeTraits<uint8_t>
+{
+    static constexpr auto inputValue = (std::numeric_limits<uint8_t>::max)();
+    static constexpr auto expectedOutputValue = (std::numeric_limits<uint8_t>::max)();
+};
+
+template <>
+struct TestTypeTraits<uint16_t>
+{
+    static constexpr auto inputValue = (std::numeric_limits<uint16_t>::max)();
+    static constexpr auto expectedOutputValue = (std::numeric_limits<uint16_t>::max)();
+};
+
+template <>
+struct TestTypeTraits<uint32_t>
+{
+    static constexpr auto inputValue = (std::numeric_limits<uint32_t>::max)();
+    static constexpr auto expectedOutputValue = (std::numeric_limits<uint32_t>::max)();
 };
 
 template <>
@@ -789,9 +817,13 @@ using TypesToTest = std::tuple<
     SqlTrimmedFixedString<20, char>,
     double,
     float,
+    int8_t,
     int16_t,
     int32_t,
     int64_t,
+    uint8_t,
+    // uint16_t, // (not supported by MS-SQL)
+    // uint32_t, // (not supported by MS-SQL)
     // TODO: uint64_t,
     std::string,
     std::string_view,


### PR DESCRIPTION
- [x] added data binder support for `int8_t` and `uint8_t` (TINYINT in SQL)

some problems arose:

- MS SQL does not support unsigned column types, [by design](https://stackoverflow.com/a/18120219), as it was to hard for them to get implicit conversion right inside of MS SQL.