### PR TITLE
Ensure DataMapper works with models within a namespace

### DIFF
--- a/src/Lightweight/Utils.hpp
+++ b/src/Lightweight/Utils.hpp
@@ -56,8 +56,13 @@ struct RecordTableName
         if constexpr (requires { Record::TableName; })
             return Record::TableName;
         else
-            // TODO: Build plural
-            return Reflection::TypeName<Record>;
+            return []() {
+                // TODO: Build plural
+                auto const typeName = Reflection::TypeName<Record>;
+                if (auto const i = typeName.rfind(':'); i != std::string_view::npos)
+                    return typeName.substr(i + 1);
+                return typeName;
+            }();
     }();
 };
 

--- a/src/tests/DataMapperTests.cpp
+++ b/src/tests/DataMapperTests.cpp
@@ -64,6 +64,36 @@ TEST_CASE_METHOD(SqlTestFixture, "SQL entity naming", "[DataMapper]")
     CHECK(RecordTableName<NamingTest2> == "NamingTest2_aliased"sv);
 }
 
+namespace Models
+{
+
+struct NamingTest1
+{
+    Field<int> normal;
+    Field<int, SqlRealName { "c1" }> name;
+};
+
+struct NamingTest2
+{
+    Field<int, PrimaryKey::AutoAssign, SqlRealName { "First_PK" }> pk1;
+    Field<int, SqlRealName { "Second_PK" }, PrimaryKey::AutoAssign> pk2;
+
+    static constexpr std::string_view TableName = "NamingTest2_aliased"sv;
+};
+
+} // namespace Models
+
+TEST_CASE_METHOD(SqlTestFixture, "SQL entity naming (namespace)", "[DataMapper]")
+{
+    CHECK(FieldNameOf<0, Models::NamingTest1> == "normal"sv);
+    CHECK(FieldNameOf<1, Models::NamingTest1> == "c1"sv);
+    CHECK(RecordTableName<Models::NamingTest1> == "NamingTest1"sv);
+
+    CHECK(FieldNameOf<0, Models::NamingTest2> == "First_PK"sv);
+    CHECK(FieldNameOf<1, Models::NamingTest2> == "Second_PK"sv);
+    CHECK(RecordTableName<Models::NamingTest2> == "NamingTest2_aliased"sv);
+}
+
 struct Person
 {
     Field<SqlGuid, PrimaryKey::AutoAssign> id;


### PR DESCRIPTION
might be, that we need/want to have models within their own namespace. Hence, we should support it.

@Yaraslaut / @FelixTheC  we should decide on the name inference that we'd like to expect here. Currently the tests are breaking on the struct's name. I think it could be safe to cut off the namespace part and only use the struct's name alone. We might want to extend reflection-cpp for easy access of that information. :thinking: 

EDIT: ok i fixed the test.