### PR TITLE
Add ability to generically access a record's primary key without knowing its field name

### DIFF
--- a/src/Lightweight/DataMapper/Field.hpp
+++ b/src/Lightweight/DataMapper/Field.hpp
@@ -150,6 +150,15 @@ namespace detail
 {
 
 template <typename T>
+struct IsAutoAssignPrimaryKeyField: std::false_type {};
+
+template <typename T, auto P>
+struct IsAutoAssignPrimaryKeyField<Field<T, PrimaryKey::AutoAssign, P>>: std::true_type {};
+
+template <typename T, auto P>
+struct IsAutoAssignPrimaryKeyField<Field<T, P, PrimaryKey::AutoAssign>>: std::true_type {};
+
+template <typename T>
 struct IsAutoIncrementPrimaryKeyField: std::false_type {};
 
 template <typename T, auto P>
@@ -183,6 +192,10 @@ struct FieldNameOfImpl<R T::*, F>
 } // namespace detail
 // clang-format on
 
+/// Tests if T is a Field<> that is a primary key.
+template <typename T>
+constexpr bool IsPrimaryKey =
+    detail::IsAutoAssignPrimaryKeyField<T>::value || detail::IsAutoIncrementPrimaryKeyField<T>::value;
 
 /// @brief Returns the name of the field referenced by the given pointer-to-member.
 ///
@@ -191,7 +204,7 @@ template <auto ReferencedField>
 constexpr inline std::string_view FieldNameOf =
     detail::FieldNameOfImpl<decltype(ReferencedField), ReferencedField>::value;
 
-// Requires that T satisfies to be a field with storage and is considered a primary key.
+/// Requires that T satisfies to be a field with storage and is considered a primary key.
 template <typename T>
 constexpr bool IsAutoIncrementPrimaryKey = detail::IsAutoIncrementPrimaryKeyField<T>::value;
 

--- a/src/Lightweight/DataMapper/Record.hpp
+++ b/src/Lightweight/DataMapper/Record.hpp
@@ -2,6 +2,10 @@
 
 #pragma once
 
+#include "Field.hpp"
+
+#include <reflection-cpp/reflection.hpp>
+
 #include <concepts>
 
 /// @brief Represents a record type that can be used with the DataMapper.
@@ -12,3 +16,39 @@
 /// @ingroup DataMapper
 template <typename Record>
 concept DataMapperRecord = std::is_aggregate_v<Record>;
+
+namespace detail
+{
+
+template <std::size_t I, typename Record>
+constexpr std::optional<size_t> FindPrimaryKeyIndex()
+{
+    static_assert(DataMapperRecord<Record>, "Record must satisfy DataMapperRecord");
+    if constexpr (I < Reflection::CountMembers<Record>)
+    {
+        if constexpr (IsPrimaryKey<Reflection::MemberTypeOf<I, Record>>)
+            return { I };
+        else
+            return FindPrimaryKeyIndex<I + 1, Record>();
+    }
+    return std::nullopt;
+}
+
+} // namespace detail
+
+/// Declare RecordPrimaryKeyIndex<Record> to retrieve the primary key index of the given record.
+template <typename Record>
+constexpr size_t RecordPrimaryKeyIndex = detail::FindPrimaryKeyIndex<0, Record>().value_or(static_cast<size_t>(-1));
+
+/// Retrieves a reference to the given record's primary key.
+template <typename Record>
+decltype(auto) RecordPrimaryKeyOf(Record&& record)
+{
+    // static_assert(DataMapperRecord<Record>, "Record must satisfy DataMapperRecord");
+    // static_assert(RecordPrimaryKeyIndex<Record> != static_cast<size_t>(-1), "Record must have a primary key");
+    return Reflection::GetMemberAt<RecordPrimaryKeyIndex<std::remove_cvref_t<Record>>>(std::forward<Record>(record));
+}
+
+/// Reflects the primary key type of the given record.
+template <typename Record>
+using RecordPrimaryKeyType = typename Reflection::MemberTypeOf<RecordPrimaryKeyIndex<Record>, Record>::ValueType;


### PR DESCRIPTION
I'm hijacking this PR as I think it's not agood idea to implement dm-caching right now.

However, it certainly makes sense to keep the helper API that I created, in order to generically find and reference the primary key's field of a record, without knowing its name.

p.s.: see test file for example uses :)