### PR TITLE
Overall cleanup as suggested by clang-tidy :)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,19 +72,18 @@ jobs:
         chmod +x llvm.sh
         sudo ./llvm.sh 19
         sudo apt -qy install clang-tidy-19
+        which clang-tidy-19
     - name: "install dependencies"
-      run: sudo apt install -y cmake ninja-build catch2 unixodbc-dev sqlite3 libsqlite3-dev libsqliteodbc uuid-dev
-    - name: Install GCC
-      run: sudo apt install -y g++-14
+      run: sudo apt install -y cmake ninja-build catch2 unixodbc-dev sqlite3 libsqlite3-dev libsqliteodbc uuid-dev gcc-14
     - name: "cmake"
       run: |
-        cmake -S . -B build -G Ninja \
-        -D CMAKE_CXX_COMPILER="g++-14"
-    - name: "build"
-      run: cmake --build build
-    - name: "run clang-tidy"
-      # TODO: Reenable Model directory once design is working with Clang/Clang-Tidy
-      run: find ./src/ -name "*.cpp" -o -name "*.h" | grep -v Model | xargs -n 1 -P $(nproc) clang-tidy-19 -format-style=file -p build
+        cmake --preset linux-clang-debug \
+              -D ENABLE_TIDY=ON \
+              -D CMAKE_CXX_COMPILER=clang++-19 \
+              -D CMAKE_C_COMPILER=clang-19 \
+              -D CLANG_TIDY_EXE="/usr/bin/clang-tidy-19"
+    - name: "build with clang-tidy"
+      run: cmake --build --preset linux-clang-debug
 
   # }}}
   # {{{ Windows

--- a/src/Lightweight/SqlConnection.cpp
+++ b/src/Lightweight/SqlConnection.cpp
@@ -302,9 +302,9 @@ bool SqlConnection::IsAlive() const noexcept
     return SQL_SUCCEEDED(sqlResult) && state == SQL_CD_FALSE;
 }
 
-void SqlConnection::RequireSuccess(SQLRETURN error, std::source_location sourceLocation) const
+void SqlConnection::RequireSuccess(SQLRETURN sqlResult, std::source_location sourceLocation) const
 {
-    if (SQL_SUCCEEDED(error))
+    if (SQL_SUCCEEDED(sqlResult))
         return;
 
     auto errorInfo = LastError();

--- a/src/Lightweight/SqlConnection.cpp
+++ b/src/Lightweight/SqlConnection.cpp
@@ -68,6 +68,8 @@ SqlConnection& SqlConnection::operator=(SqlConnection&& other) noexcept
     m_hEnv = other.m_hEnv;
     m_hDbc = other.m_hDbc;
     m_connectionId = other.m_connectionId;
+    m_serverType = other.m_serverType;
+    m_queryFormatter = other.m_queryFormatter;
     m_data = other.m_data;
 
     other.m_hEnv = {};

--- a/src/Lightweight/SqlError.cpp
+++ b/src/Lightweight/SqlError.cpp
@@ -7,7 +7,7 @@ SqlException::SqlException(SqlErrorInfo info, std::source_location sourceLocatio
     std::runtime_error(std::format("{}", info)),
     _info { std::move(info) }
 {
-    SqlLogger::GetLogger().OnError(info, sourceLocation);
+    SqlLogger::GetLogger().OnError(_info, sourceLocation);
 }
 
 void SqlErrorInfo::RequireStatementSuccess(SQLRETURN result, SQLHSTMT hStmt, std::string_view message)

--- a/src/Lightweight/SqlQuery/Migrate.hpp
+++ b/src/Lightweight/SqlQuery/Migrate.hpp
@@ -200,7 +200,7 @@ class [[nodiscard]] SqlMigrationQueryBuilder final
     LIGHTWEIGHT_API SqlMigrationQueryBuilder& BeginTransaction();
     LIGHTWEIGHT_API SqlMigrationQueryBuilder& CommitTransaction();
 
-    LIGHTWEIGHT_API SqlMigrationPlan const& GetPlan() const &;
+    [[nodiscard]] LIGHTWEIGHT_API SqlMigrationPlan const& GetPlan() const &;
     LIGHTWEIGHT_API SqlMigrationPlan GetPlan() &&;
 
   private:

--- a/src/Lightweight/SqlSchema.cpp
+++ b/src/Lightweight/SqlSchema.cpp
@@ -63,7 +63,7 @@ namespace
             case SQL_WLONGVARCHAR: return NVarchar { size };
             case SQL_WVARCHAR: return NVarchar { size };
             // case SQL_UNKNOWN_TYPE:
-            default: 
+            default:
                 SqlLogger::GetLogger().OnError(SqlError::UNSUPPORTED_TYPE);
                 throw std::runtime_error(std::format("Unsupported data type: {}", value));
         }
@@ -276,8 +276,7 @@ void ReadAllTables(std::string_view database, std::string_view schema, EventHand
 std::string ToLowerCase(std::string_view str)
 {
     std::string result(str);
-    std::transform(
-        result.begin(), result.end(), result.begin(), [](char c) { return static_cast<char>(std::tolower(c)); });
+    std::ranges::transform(result, result.begin(), [](char c) { return static_cast<char>(std::tolower(c)); });
     return result;
 }
 

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -43,7 +43,7 @@ class SqlResultCursor;
 /// 3. Execute the statement (optionally with input parameters)
 /// 4. Fetch rows (if any)
 /// 5. Repeat steps 3 and 4 as needed
-class SqlStatement final: public SqlDataBinderCallback
+class [[nodiscard]] SqlStatement final: public SqlDataBinderCallback
 {
   public:
     /// Construct a new SqlStatement object, using a new connection, and connect to the default database.
@@ -102,7 +102,7 @@ class SqlStatement final: public SqlDataBinderCallback
 
     SqlStatement Prepare(SqlQueryObject auto const& queryObject) &&;
 
-    std::string const& PreparedQuery() const noexcept;
+    [[nodiscard]] std::string const& PreparedQuery() const noexcept;
 
     template <SqlInputParameterBinder Arg>
     void BindInputParameter(SQLSMALLINT columnIndex, Arg const& arg);

--- a/src/benchmark/benchmark.cpp
+++ b/src/benchmark/benchmark.cpp
@@ -108,6 +108,11 @@ class SqlTestFixture
         DropAllTablesInDatabase();
     }
 
+    SqlTestFixture(SqlTestFixture&&) = delete;
+    SqlTestFixture(SqlTestFixture const&) = delete;
+    SqlTestFixture& operator=(SqlTestFixture&&) = delete;
+    SqlTestFixture& operator=(SqlTestFixture const&) = delete;
+
     virtual ~SqlTestFixture() = default;
 
   private:

--- a/src/tests/CoreTests.cpp
+++ b/src/tests/CoreTests.cpp
@@ -55,7 +55,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlStatement: ctor std::nullopt")
     // Get `stmt` valid by assigning it a valid SqlStatement
     stmt = SqlStatement {};
     REQUIRE(stmt.IsAlive());
-    CHECK(stmt.ExecuteDirectScalar<int>("SELECT 42").value() == 42);
+    CHECK(stmt.ExecuteDirectScalar<int>("SELECT 42").value_or(-1) == 42);
 }
 
 TEST_CASE_METHOD(SqlTestFixture, "select: get columns")
@@ -69,6 +69,8 @@ TEST_CASE_METHOD(SqlTestFixture, "select: get columns")
 
 TEST_CASE_METHOD(SqlTestFixture, "move semantics", "[SqlConnection]")
 {
+    // NOLINTBEGIN(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
+
     auto a = SqlConnection {};
     CHECK(a.IsAlive());
 
@@ -80,10 +82,14 @@ TEST_CASE_METHOD(SqlTestFixture, "move semantics", "[SqlConnection]")
     CHECK(!a.IsAlive());
     CHECK(!b.IsAlive());
     CHECK(c.IsAlive());
+
+    // NOLINTEND(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
 }
 
 TEST_CASE_METHOD(SqlTestFixture, "move semantics", "[SqlStatement]")
 {
+    // NOLINTBEGIN(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
+
     auto conn = SqlConnection {};
 
     auto const TestRun = [](SqlStatement& stmt) {
@@ -107,6 +113,8 @@ TEST_CASE_METHOD(SqlTestFixture, "move semantics", "[SqlStatement]")
     CHECK(!b.IsAlive());
     CHECK(c.IsAlive());
     TestRun(c);
+
+    // NOLINTEND(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
 }
 
 TEST_CASE_METHOD(SqlTestFixture, "select: get column (invalid index)")

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -56,7 +56,7 @@ namespace std
 
 std::ostream& operator<<(std::ostream& os, std::u8string const& value)
 {
-    return os << std::format("\"{}\"", (char const*) value.c_str());
+    return os << std::format("\"{}\"", value);
 }
 
 std::ostream& operator<<(std::ostream& os, std::u8string_view value)
@@ -242,6 +242,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlVariant: SqlDate", "[SqlDataBinder],[SqlVar
 
     using namespace std::chrono_literals;
     auto const expected = SqlVariant { SqlDate { 2017y, std::chrono::August, 16d } };
+    auto const& expectedDateTime = std::get<SqlDate>(expected.value);
 
     stmt.Prepare(stmt.Query("Test").Insert().Set("Value", SqlWildcard));
     stmt.Execute(expected);
@@ -251,7 +252,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlVariant: SqlDate", "[SqlDataBinder],[SqlVar
         auto reader = stmt.GetResultCursor();
         (void) stmt.FetchRow();
         auto const actual = reader.GetColumn<SqlVariant>(1);
-        CHECK(actual.TryGetDate().value() == std::get<SqlDate>(expected.value));
+        CHECK(actual.TryGetDate().value_or(SqlDate {}) == expectedDateTime);
     }
 
     // Test for inserting/getting NULL values

--- a/src/tests/DataMapperTests.cpp
+++ b/src/tests/DataMapperTests.cpp
@@ -18,6 +18,8 @@
 using namespace std::string_view_literals;
 using namespace std::string_literals;
 
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
+
 std::ostream& operator<<(std::ostream& os, RecordId const& id)
 {
     return os << id.value;
@@ -973,3 +975,5 @@ TEST_CASE_METHOD(SqlTestFixture, "Test DifferenceView", "[DataMapper]")
     // 3 because of the auto-assigned GUID on top of name and age
     CHECK(differenceCount == 3);
 }
+
+// NOLINTEND(bugprone-unchecked-optional-access)

--- a/src/tests/MigrationTests.cpp
+++ b/src/tests/MigrationTests.cpp
@@ -29,6 +29,10 @@ class SqlMigrationTestFixture: public SqlTestFixture
     {
         SqlMigration::MigrationManager::GetInstance().RemoveAllMigrations();
     }
+    SqlMigrationTestFixture(SqlMigrationTestFixture&&) = delete;
+    SqlMigrationTestFixture(SqlMigrationTestFixture const&) = delete;
+    SqlMigrationTestFixture& operator=(SqlMigrationTestFixture&&) = delete;
+    SqlMigrationTestFixture& operator=(SqlMigrationTestFixture const&) = delete;
 
     ~SqlMigrationTestFixture() override
     {

--- a/src/tools/ddl2cpp.cpp
+++ b/src/tools/ddl2cpp.cpp
@@ -362,7 +362,7 @@ int main(int argc, char const* argv[])
         std::println("{}", printer.str(config.modelNamespace));
     else
     {
-        auto file = std::ofstream(config.outputFileName.data());
+        auto file = std::ofstream(config.outputFileName.data()); // NOLINT(bugprone-suspicious-stringview-data-usage)
         file << printer.str(config.modelNamespace);
     }
 


### PR DESCRIPTION
btw, we still fail, because `std::expected<>` is not available on Github actions's clang-tidy (why?)