### PR TITLE
DataMapper: Rename FieldNameOf to FieldNameAt and add an actual FieldNameOf

### DIFF
--- a/src/Lightweight/DataMapper/SqlRealName.hpp
+++ b/src/Lightweight/DataMapper/SqlRealName.hpp
@@ -31,10 +31,16 @@ struct SqlRealName
 
     char value[N] {};
 
+    [[nodiscard]] constexpr bool empty() const noexcept
+    {
+        return length == 0;
+    }
+
     [[nodiscard]] constexpr char const* begin() const noexcept
     {
         return value;
     }
+
     [[nodiscard]] constexpr char const* end() const noexcept
     {
         return value + length;

--- a/src/tests/DataMapperTests.cpp
+++ b/src/tests/DataMapperTests.cpp
@@ -55,12 +55,18 @@ struct NamingTest2
 
 TEST_CASE_METHOD(SqlTestFixture, "SQL entity naming", "[DataMapper]")
 {
-    CHECK(FieldNameOf<0, NamingTest1> == "normal"sv);
-    CHECK(FieldNameOf<1, NamingTest1> == "c1"sv);
+    CHECK(FieldNameAt<0, NamingTest1> == "normal"sv);
+    CHECK(FieldNameAt<1, NamingTest1> == "c1"sv);
     CHECK(RecordTableName<NamingTest1> == "NamingTest1"sv);
 
-    CHECK(FieldNameOf<0, NamingTest2> == "First_PK"sv);
-    CHECK(FieldNameOf<1, NamingTest2> == "Second_PK"sv);
+    CHECK(FieldNameAt<0, NamingTest2> == "First_PK"sv);
+    CHECK(FieldNameAt<1, NamingTest2> == "Second_PK"sv);
+
+    CHECK(FieldNameOf<&NamingTest1::normal> == "normal"sv);
+    CHECK(FieldNameOf<&NamingTest1::name> == "c1"sv);
+    CHECK(FieldNameOf<&NamingTest2::pk1> == "First_PK"sv);
+    CHECK(FieldNameOf<&NamingTest2::pk2> == "Second_PK"sv);
+
     CHECK(RecordTableName<NamingTest2> == "NamingTest2_aliased"sv);
 }
 
@@ -85,12 +91,12 @@ struct NamingTest2
 
 TEST_CASE_METHOD(SqlTestFixture, "SQL entity naming (namespace)", "[DataMapper]")
 {
-    CHECK(FieldNameOf<0, Models::NamingTest1> == "normal"sv);
-    CHECK(FieldNameOf<1, Models::NamingTest1> == "c1"sv);
+    CHECK(FieldNameAt<0, Models::NamingTest1> == "normal"sv);
+    CHECK(FieldNameAt<1, Models::NamingTest1> == "c1"sv);
     CHECK(RecordTableName<Models::NamingTest1> == "NamingTest1"sv);
 
-    CHECK(FieldNameOf<0, Models::NamingTest2> == "First_PK"sv);
-    CHECK(FieldNameOf<1, Models::NamingTest2> == "Second_PK"sv);
+    CHECK(FieldNameAt<0, Models::NamingTest2> == "First_PK"sv);
+    CHECK(FieldNameAt<1, Models::NamingTest2> == "Second_PK"sv);
     CHECK(RecordTableName<Models::NamingTest2> == "NamingTest2_aliased"sv);
 }
 


### PR DESCRIPTION
`FieldNameOf` renamed, because it made more sense to name it like `FieldNameAt`.

The new one has a nice use-case like `FieldNameOf<&Record::columnFoo>` to retrieve the column's name (including SqlRealName-support).