### PR TITLE
Improve handling of LARGEEEEEE data retrieval

### DIFF
--- a/src/Lightweight/CMakeLists.txt
+++ b/src/Lightweight/CMakeLists.txt
@@ -86,6 +86,7 @@ set(SOURCE_FILES
     SqlSchema.cpp
     SqlStatement.cpp
     SqlTransaction.cpp
+    Utils.cpp
 )
 
 set(LIGHTWEIGHT_BUILD_SHARED_DEFAULT OFF)

--- a/src/Lightweight/DataBinder/Core.hpp
+++ b/src/Lightweight/DataBinder/Core.hpp
@@ -147,19 +147,4 @@ concept SqlBasicStringBinderConcept = requires(StringType* str) {
     { SqlBasicStringOperations<StringType>::Resize(str, SQLLEN {}) } -> std::same_as<void>;
     { SqlBasicStringOperations<StringType>::Clear(str) } -> std::same_as<void>;
 };
-
 // clang-format on
-
-namespace detail
-{
-
-template <typename>
-struct SqlColumnSize
-{
-    static constexpr size_t Value = 0;
-};
-
-} // namespace detail
-
-template <typename T>
-constexpr size_t SqlColumnSize = detail::SqlColumnSize<T>::Value;

--- a/src/Lightweight/DataBinder/SqlDynamicString.hpp
+++ b/src/Lightweight/DataBinder/SqlDynamicString.hpp
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "../SqlColumnTypeDefinitions.hpp"
+#include "../Utils.hpp"
+#include "Core.hpp"
+#include "UnicodeConverter.hpp"
+
+#include <format>
+#include <limits>
+#include <string>
+
+constexpr size_t SqlMaxColumnSize = std::numeric_limits<uint32_t>::max();
+
+template <std::size_t N, typename T = char>
+class SqlDynamicString
+{
+  public:
+    static constexpr std::size_t DynamicCapacity = N;
+    using value_type = T;
+    using string_type = std::basic_string<T>;
+
+    /// Constructs a fixed-size string from a string literal.
+    template <std::size_t SourceSize>
+    constexpr LIGHTWEIGHT_FORCE_INLINE SqlDynamicString(T const (&text)[SourceSize]):
+        _value { text, SourceSize - 1 }
+    {
+        static_assert(SourceSize <= N + 1, "RHS string size must not exceed target string's capacity.");
+    }
+
+    /// Constructs a fixed-size string from a string pointer and end pointer.
+    LIGHTWEIGHT_FORCE_INLINE constexpr SqlDynamicString(T const* s, T const* e) noexcept:
+        _value { s, e }
+    {
+    }
+
+    LIGHTWEIGHT_FORCE_INLINE constexpr SqlDynamicString() noexcept = default;
+    LIGHTWEIGHT_FORCE_INLINE constexpr SqlDynamicString(SqlDynamicString const&) noexcept = default;
+    LIGHTWEIGHT_FORCE_INLINE constexpr SqlDynamicString& operator=(SqlDynamicString const&) noexcept = default;
+    LIGHTWEIGHT_FORCE_INLINE constexpr SqlDynamicString(SqlDynamicString&&) noexcept = default;
+    LIGHTWEIGHT_FORCE_INLINE constexpr SqlDynamicString& operator=(SqlDynamicString&&) noexcept = default;
+    LIGHTWEIGHT_FORCE_INLINE constexpr ~SqlDynamicString() noexcept = default;
+
+    /// Constructs a fixed-size string from a string view.
+    LIGHTWEIGHT_FORCE_INLINE constexpr SqlDynamicString(std::basic_string_view<T> s) noexcept:
+        _value { s }
+    {
+    }
+
+    /// Constructs a fixed-size string from a string.
+    LIGHTWEIGHT_FORCE_INLINE constexpr SqlDynamicString(std::basic_string<T> const& s) noexcept:
+        _value { s }
+    {
+    }
+
+    /// Retrieves the string's inner value (std::basic_string<T>).
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE string_type const& value() const noexcept
+    {
+        return _value;
+    }
+
+    /// Retrieves the string's inner value (std::basic_string<T>).
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE string_type& value() noexcept
+    {
+        return _value;
+    }
+
+    /// Retrieves the string's inner value (as T const*).
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE T const* data() const noexcept
+    {
+        return _value.data();
+    }
+
+    /// Retrieves the string's inner value (as T*).
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE T* data() noexcept
+    {
+        return _value.data();
+    }
+
+    /// Retrieves the string's capacity.
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE std::size_t capacity() const noexcept
+    {
+        return N;
+    }
+
+    /// Retrieves the string's size.
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE std::size_t size() const noexcept
+    {
+        return _value.size();
+    }
+
+    /// Tests if the string is empty.
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr bool empty() const noexcept
+    {
+        return _value.empty();
+    }
+
+    /// Clears the string.
+    LIGHTWEIGHT_FORCE_INLINE constexpr void clear() noexcept
+    {
+        _value.clear();
+    }
+
+    /// Resizes the string.
+    LIGHTWEIGHT_FORCE_INLINE constexpr void resize(std::size_t n) noexcept
+    {
+        _value.resize(n);
+    }
+
+    /// Retrieves a string view of the string.
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr std::basic_string_view<T> ToStringView() const noexcept
+    {
+        return { _value.data(), _value.size() };
+    }
+
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr T& operator[](std::size_t index) noexcept
+    {
+        return _value[index];
+    }
+
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr T const& operator[](std::size_t index) const noexcept
+    {
+        return _value[index];
+    }
+
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr explicit operator std::basic_string_view<T>() const noexcept
+    {
+        return ToStringView();
+    }
+
+    template <std::size_t OtherSize>
+    LIGHTWEIGHT_FORCE_INLINE std::weak_ordering operator<=>(SqlDynamicString<OtherSize, T> const& other) const noexcept
+    {
+        return _value <=> other._value;
+    }
+
+    template <std::size_t OtherSize>
+    LIGHTWEIGHT_FORCE_INLINE constexpr bool operator==(SqlDynamicString<OtherSize, T> const& other) const noexcept
+    {
+        return (*this <=> other) == std::weak_ordering::equivalent;
+    }
+
+    template <std::size_t OtherSize>
+    LIGHTWEIGHT_FORCE_INLINE constexpr bool operator!=(SqlDynamicString<OtherSize, T> const& other) const noexcept
+    {
+        return !(*this == other);
+    }
+
+    LIGHTWEIGHT_FORCE_INLINE constexpr bool operator==(std::basic_string_view<T> other) const noexcept
+    {
+        return (ToStringView() <=> other) == std::weak_ordering::equivalent;
+    }
+
+    LIGHTWEIGHT_FORCE_INLINE constexpr bool operator!=(std::basic_string_view<T> other) const noexcept
+    {
+        return !(*this == other);
+    }
+
+  private:
+    string_type _value;
+};
+
+template <std::size_t N, typename CharT>
+struct detail::SqlViewHelper<SqlDynamicString<N, CharT>>
+{
+    static LIGHTWEIGHT_FORCE_INLINE std::basic_string_view<CharT> View(SqlDynamicString<N, CharT> const& str) noexcept
+    {
+        return { str.data(), str.size() };
+    }
+};
+
+namespace detail
+{
+
+template <typename>
+struct IsSqlDynamicStringImpl: std::false_type
+{
+};
+
+template <std::size_t N, typename T>
+struct IsSqlDynamicStringImpl<SqlDynamicString<N, T>>: std::true_type
+{
+};
+
+} // namespace detail
+
+template <typename T>
+constexpr bool IsSqlDynamicString = detail::IsSqlDynamicStringImpl<T>::value;
+
+/// Fixed-size string of element type `char` with a capacity of `N` characters.
+template <std::size_t N>
+using SqlDynamicAnsiString = SqlDynamicString<N, char>;
+
+/// Fixed-size string of element type `char16_t` with a capacity of `N` characters.
+template <std::size_t N>
+using SqlDynamicUtf16String = SqlDynamicString<N, char16_t>;
+
+/// Fixed-size string of element type `char32_t` with a capacity of `N` characters.
+template <std::size_t N>
+using SqlDynamicUtf32String = SqlDynamicString<N, char32_t>;
+
+/// Fixed-size string of element type `wchar_t` with a capacity of `N` characters.
+template <std::size_t N>
+using SqlDynamicWideString = SqlDynamicString<N, wchar_t>;
+
+template <std::size_t N, typename T>
+struct std::formatter<SqlDynamicString<N, T>>: std::formatter<std::string>
+{
+    using value_type = SqlDynamicString<N, T>;
+
+    auto format(value_type const& text, format_context& ctx) const
+    {
+        if constexpr (detail::OneOf<T, wchar_t, char32_t, char16_t>)
+            return std::formatter<std::string>::format((char const*) ToUtf8(text.ToStringView()).c_str(), ctx);
+        else
+            return std::formatter<std::string>::format((char const*) text.data(), ctx);
+    }
+};
+
+template <std::size_t N, typename T>
+struct SqlBasicStringOperations<SqlDynamicString<N, T>>
+{
+    using CharType = T;
+    using ValueType = SqlDynamicString<N, CharType>;
+
+    static constexpr SqlColumnTypeDefinition ColumnType = []() constexpr {
+        if constexpr (std::same_as<CharType, char>)
+            return SqlColumnTypeDefinitions::Varchar { N };
+        else
+            return SqlColumnTypeDefinitions::NVarchar { N };
+    }();
+
+    static CharType const* Data(ValueType const* str) noexcept
+    {
+        return str->data();
+    }
+
+    static CharType* Data(ValueType* str) noexcept
+    {
+        return str->data();
+    }
+
+    static SQLULEN Size(ValueType const* str) noexcept
+    {
+        return str->size();
+    }
+
+    static void Clear(ValueType* str) noexcept
+    {
+        str->value().clear();
+    }
+
+    static void Reserve(ValueType* str, size_t capacity) noexcept
+    {
+        str->value().resize((std::min)(N, capacity));
+    }
+
+    static void Resize(ValueType* str, SQLLEN indicator) noexcept
+    {
+        str->value().resize(indicator);
+    }
+};

--- a/src/Lightweight/DataBinder/SqlFixedString.hpp
+++ b/src/Lightweight/DataBinder/SqlFixedString.hpp
@@ -253,18 +253,23 @@ struct detail::SqlViewHelper<SqlFixedString<N, CharT, Mode>>
     }
 };
 
+namespace detail
+{
+
 template <typename>
-struct IsSqlFixedStringType: std::false_type
+struct IsSqlFixedStringTypeImpl: std::false_type
 {
 };
 
 template <std::size_t N, typename T, SqlFixedStringMode Mode>
-struct IsSqlFixedStringType<SqlFixedString<N, T, Mode>>: std::true_type
+struct IsSqlFixedStringTypeImpl<SqlFixedString<N, T, Mode>>: std::true_type
 {
 };
 
+} // namespace detail
+
 template <typename T>
-constexpr bool IsSqlFixedString = IsSqlFixedStringType<T>::value;
+constexpr bool IsSqlFixedString = detail::IsSqlFixedStringTypeImpl<T>::value;
 
 /// Fixed-size string of element type `char` with a capacity of `N` characters.
 template <std::size_t N>
@@ -288,18 +293,6 @@ using SqlTrimmedFixedString = SqlFixedString<N, T, SqlFixedStringMode::FIXED_SIZ
 
 template <std::size_t N, typename T = char>
 using SqlString = SqlFixedString<N, T, SqlFixedStringMode::VARIABLE_SIZE>;
-
-template <std::size_t N, typename T, SqlFixedStringMode Mode>
-struct detail::SqlColumnSize<SqlFixedString<N, T, Mode>>
-{
-    static constexpr size_t Value = N;
-};
-
-template <std::size_t N, typename T, SqlFixedStringMode Mode>
-struct detail::SqlColumnSize<std::optional<SqlFixedString<N, T, Mode>>>
-{
-    static constexpr size_t Value = N;
-};
 
 template <std::size_t N, typename T, SqlFixedStringMode Mode>
 struct SqlBasicStringOperations<SqlFixedString<N, T, Mode>>

--- a/src/Lightweight/QueryFormatter/OracleFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/OracleFormatter.hpp
@@ -95,7 +95,7 @@ class OracleSqlQueryFormatter final: public SQLiteQueryFormatter
                 [](Real const&) -> std::string { return "REAL"; },
                 [](Smallint const&) -> std::string { return "SMALLINT"; },
                 [](Text const& type) -> std::string {
-                    if (type.size <= 4000)
+                    if (type.size <= SqlOptimalMaxColumnSize)
                         return std::format("VARCHAR2({})", type.size);
                     else
                         return "CLOB";

--- a/src/Lightweight/QueryFormatter/SqlServerFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/SqlServerFormatter.hpp
@@ -92,7 +92,12 @@ class SqlServerQueryFormatter final: public SQLiteQueryFormatter
                 [](Guid const&) -> std::string { return "UNIQUEIDENTIFIER"; },
                 [](Integer const&) -> std::string { return "INTEGER"; },
                 [](NChar const& type) -> std::string { return std::format("NCHAR({})", type.size); },
-                [](NVarchar const& type) -> std::string { return std::format("NVARCHAR({})", type.size); },
+                [](NVarchar const& type) -> std::string {
+                    if (type.size == 0 || type.size > 4000)
+                        return "NVARCHAR(MAX)";
+                    else
+                        return std::format("NVARCHAR({})", type.size);
+                },
                 [](Real const&) -> std::string { return "REAL"; },
                 [](Smallint const&) -> std::string { return "SMALLINT"; },
                 [](Text const&) -> std::string { return "VARCHAR(MAX)"; },
@@ -100,7 +105,12 @@ class SqlServerQueryFormatter final: public SQLiteQueryFormatter
                 [](Timestamp const&) -> std::string { return "TIMESTAMP"; },
                 [](Tinyint const&) -> std::string { return "TINYINT"; },
                 [](VarBinary const& type) -> std::string { return std::format("VARBINARY({})", type.size); },
-                [](Varchar const& type) -> std::string { return std::format("VARCHAR({})", type.size); },
+                [](Varchar const& type) -> std::string {
+                    if (type.size == 0 || type.size > 4000)
+                        return "VARCHAR(MAX)";
+                    else
+                        return std::format("VARCHAR({})", type.size);
+                },
             },
             type);
     }

--- a/src/Lightweight/QueryFormatter/SqlServerFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/SqlServerFormatter.hpp
@@ -93,7 +93,7 @@ class SqlServerQueryFormatter final: public SQLiteQueryFormatter
                 [](Integer const&) -> std::string { return "INTEGER"; },
                 [](NChar const& type) -> std::string { return std::format("NCHAR({})", type.size); },
                 [](NVarchar const& type) -> std::string {
-                    if (type.size == 0 || type.size > 4000)
+                    if (type.size == 0 || type.size > SqlOptimalMaxColumnSize)
                         return "NVARCHAR(MAX)";
                     else
                         return std::format("NVARCHAR({})", type.size);
@@ -106,7 +106,7 @@ class SqlServerQueryFormatter final: public SQLiteQueryFormatter
                 [](Tinyint const&) -> std::string { return "TINYINT"; },
                 [](VarBinary const& type) -> std::string { return std::format("VARBINARY({})", type.size); },
                 [](Varchar const& type) -> std::string {
-                    if (type.size == 0 || type.size > 4000)
+                    if (type.size == 0 || type.size > SqlOptimalMaxColumnSize)
                         return "VARCHAR(MAX)";
                     else
                         return std::format("VARCHAR({})", type.size);

--- a/src/Lightweight/SqlDataBinder.hpp
+++ b/src/Lightweight/SqlDataBinder.hpp
@@ -8,6 +8,7 @@
 #include "DataBinder/SqlBinary.hpp"
 #include "DataBinder/SqlDate.hpp"
 #include "DataBinder/SqlDateTime.hpp"
+#include "DataBinder/SqlDynamicString.hpp"
 #include "DataBinder/SqlFixedString.hpp"
 #include "DataBinder/SqlGuid.hpp"
 #include "DataBinder/SqlNullValue.hpp"

--- a/src/Lightweight/SqlQuery/MigrationPlan.hpp
+++ b/src/Lightweight/SqlQuery/MigrationPlan.hpp
@@ -136,6 +136,20 @@ struct SqlColumnTypeDefinitionOf<SqlFixedString<N, CharT, SqlFixedStringMode::FI
     static constexpr auto value = SqlColumnTypeDefinitions::NChar { N };
 };
 
+template <size_t N, typename CharT>
+    requires(detail::OneOf<CharT, char>)
+struct SqlColumnTypeDefinitionOf<SqlDynamicString<N, CharT>>
+{
+    static constexpr auto value = SqlColumnTypeDefinitions::Varchar { N };
+};
+
+template <size_t N, typename CharT>
+    requires(detail::OneOf<CharT, char8_t, char16_t, char32_t, wchar_t>)
+struct SqlColumnTypeDefinitionOf<SqlDynamicString<N, CharT>>
+{
+    static constexpr auto value = SqlColumnTypeDefinitions::NVarchar { N };
+};
+
 template <typename T>
 struct SqlColumnTypeDefinitionOf<std::optional<T>>
 {

--- a/src/Lightweight/SqlQuery/Select.hpp
+++ b/src/Lightweight/SqlQuery/Select.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "../SqlQueryFormatter.hpp"
 #include "../Utils.hpp"
 #include "Core.hpp"
 

--- a/src/Lightweight/SqlStatement.cpp
+++ b/src/Lightweight/SqlStatement.cpp
@@ -2,6 +2,7 @@
 
 #include "SqlQuery.hpp"
 #include "SqlStatement.hpp"
+#include "Utils.hpp"
 
 struct SqlStatement::Data
 {
@@ -239,17 +240,7 @@ std::expected<bool, SqlErrorInfo> SqlStatement::TryFetchRow(std::source_location
 
 void SqlStatement::RequireSuccess(SQLRETURN error, std::source_location sourceLocation) const
 {
-    if (SQL_SUCCEEDED(error))
-        return;
-
-    auto errorInfo = LastError();
-    if (errorInfo.sqlState == "07009")
-    {
-        SqlLogger::GetLogger().OnError(errorInfo, sourceLocation);
-        throw std::invalid_argument(std::format("SQL error: {}", errorInfo));
-    }
-    else
-        throw SqlException(std::move(errorInfo));
+    ::RequireSuccess(m_hStmt, error, sourceLocation);
 }
 
 SqlQueryBuilder SqlStatement::Query(std::string_view const& table) const

--- a/src/Lightweight/Utils.cpp
+++ b/src/Lightweight/Utils.cpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "SqlError.hpp"
+#include "SqlLogger.hpp"
+#include "Utils.hpp"
+
+void LogIfFailed(SQLHSTMT hStmt, SQLRETURN error, std::source_location sourceLocation)
+{
+    if (SQL_SUCCEEDED(error))
+        return;
+
+    SqlLogger::GetLogger().OnError(SqlErrorInfo::fromStatementHandle(hStmt), sourceLocation);
+}
+
+void RequireSuccess(SQLHSTMT hStmt, SQLRETURN error, std::source_location sourceLocation)
+{
+    if (SQL_SUCCEEDED(error))
+        return;
+
+    auto errorInfo = SqlErrorInfo::fromStatementHandle(hStmt);
+    if (errorInfo.sqlState == "07009")
+    {
+        SqlLogger::GetLogger().OnError(errorInfo, sourceLocation);
+        throw std::invalid_argument(std::format("SQL error: {}", errorInfo));
+    }
+    else
+        throw SqlException(std::move(errorInfo));
+}

--- a/src/Lightweight/Utils.hpp
+++ b/src/Lightweight/Utils.hpp
@@ -1,12 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
+
+#include "Api.hpp"
 
 #include <reflection-cpp/reflection.hpp>
 
-#include <optional>
 #include <ranges>
+#include <source_location>
 #include <string_view>
 #include <type_traits>
 #include <utility>
+
+#include <sql.h>
 
 namespace detail
 {
@@ -201,3 +207,9 @@ template <auto ReferencedField>
 constexpr inline auto FullFieldNameOf = SqlRawColumnNameView {
     .value = detail::FullFieldNameOfImpl<ReferencedField>::value,
 };
+
+LIGHTWEIGHT_API void LogIfFailed(SQLHSTMT hStmt, SQLRETURN error, std::source_location sourceLocation);
+
+LIGHTWEIGHT_API void RequireSuccess(SQLHSTMT hStmt,
+                                    SQLRETURN error,
+                                    std::source_location sourceLocation = std::source_location::current());

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -12,6 +12,10 @@ endif()
 
 target_link_libraries(LightweightTest PRIVATE ${TEST_LIBRARIES})
 
+if(MSVC)
+    target_compile_options(LightweightTest PRIVATE /bigobj)
+endif()
+
 set(SOURCE_FILES
     CoreTests.cpp
     DataBinderTests.cpp

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -296,12 +296,6 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlVariant: SqlTime", "[SqlDataBinder],[SqlVar
 
 TEST_CASE_METHOD(SqlTestFixture, "InputParameter and GetColumn for very large values", "[SqlDataBinder]")
 {
-    auto const MakeLargeText = [](size_t size) {
-        auto text = std::string(size, '\0');
-        std::ranges::generate(text, [i = 0]() mutable { return char('A' + (i++ % 26)); });
-        return text;
-    };
-
     auto stmt = SqlStatement {};
     UNSUPPORTED_DATABASE(stmt, SqlServerType::ORACLE);
     auto const expectedText = MakeLargeText(8 * 1000);


### PR DESCRIPTION
## Importan notes

* We've added `SqlDynamicString<N, T>` for use with large string data (to be stored on heap). Large usually means for `N > 4000`.
* This is ONLY a problem for MS SQL Server, but having an explicit type for large data is still useful :)
* DataMapper was adapted to either bind the columns before `SQLFetch()`, or (fallback), to explictly get column data after the `SQLFetch()`-call.