### PR TITLE
Fix BelongsTo<> (when used with SqlRealName) relations and related findings

### DIFF
--- a/.vimspector.json
+++ b/.vimspector.json
@@ -5,8 +5,9 @@
             "adapter": "vscode-cpptools",
             "configuration": {
                 "request": "launch",
-                "program": "${workspaceRoot}/out/build/linux-gcc-debug/src/tests/LightweightTest",
+                "program": "${workspaceRoot}/out/build/linux-clang-debug/src/tests/LightweightTest",
                 "args": [
+                    "--trace-sql", "BelongsTo"
                 ],
                 "cwd": "${workspaceRoot}",
                 "externalConsole": true,
@@ -24,7 +25,7 @@
             "adapter": "vscode-cpptools",
             "configuration": {
                 "request": "launch",
-                "program": "${workspaceRoot}/out/build/linux-gcc-debug/src/tests/LightweightTest",
+                "program": "${workspaceRoot}/out/build/linux-clang-debug/src/tests/LightweightTest",
                 "args": [
                 ],
                 "environment": [
@@ -49,7 +50,7 @@
             "adapter": "vscode-cpptools",
             "configuration": {
                 "request": "launch",
-                "program": "${workspaceRoot}/out/build/linux-gcc-debug/src/tests/LightweightTest",
+                "program": "${workspaceRoot}/out/build/linux-clang-debug/src/tests/LightweightTest",
                 "args": [
                 ],
                 "environment": [
@@ -74,7 +75,7 @@
             "adapter": "vscode-cpptools",
             "configuration": {
                 "request": "launch",
-                "program": "${workspaceRoot}/out/build/linux-gcc-debug/src/tests/LightweightTest",
+                "program": "${workspaceRoot}/out/build/linux-clang-debug/src/tests/LightweightTest",
                 "args": [
                 ],
                 "environment": [

--- a/src/Lightweight/CMakeLists.txt
+++ b/src/Lightweight/CMakeLists.txt
@@ -53,7 +53,6 @@ set(HEADER_FILES
     DataMapper/HasMany.hpp
     DataMapper/HasManyThrough.hpp
     DataMapper/HasOneThrough.hpp
-    DataMapper/RecordId.hpp
 
     SqlConnectInfo.hpp
     SqlConnection.hpp

--- a/src/Lightweight/CMakeLists.txt
+++ b/src/Lightweight/CMakeLists.txt
@@ -79,6 +79,7 @@ set(SOURCE_FILES
     SqlLogger.cpp
     SqlMigration.cpp
     SqlQuery.cpp
+    SqlQuery/Core.cpp
     SqlQuery/Migrate.cpp
     SqlQuery/MigrationPlan.cpp
     SqlQuery/Select.cpp

--- a/src/Lightweight/DataBinder/BasicStringBinder.hpp
+++ b/src/Lightweight/DataBinder/BasicStringBinder.hpp
@@ -134,7 +134,7 @@ SQLRETURN OutputColumnNonUtf16Unicode(
 // SqlDataBinder<> specialization for ANSI character strings
 template <typename AnsiStringType>
     requires SqlBasicStringBinderConcept<AnsiStringType, char>
-struct LIGHTWEIGHT_API SqlDataBinder<AnsiStringType>
+struct SqlDataBinder<AnsiStringType>
 {
     using ValueType = AnsiStringType;
     using CharType = char;
@@ -304,7 +304,7 @@ template <typename Utf16StringType>
     requires(SqlBasicStringBinderConcept<Utf16StringType, char16_t>
              || (SqlBasicStringBinderConcept<Utf16StringType, unsigned short>)
              || (SqlBasicStringBinderConcept<Utf16StringType, wchar_t> && sizeof(wchar_t) == 2))
-struct LIGHTWEIGHT_API SqlDataBinder<Utf16StringType>
+struct SqlDataBinder<Utf16StringType>
 {
     using ValueType = Utf16StringType;
     using CharType = std::remove_cvref_t<decltype(std::declval<Utf16StringType>()[0])>;
@@ -415,7 +415,7 @@ template <typename Utf32StringType>
     requires(SqlBasicStringBinderConcept<Utf32StringType, char32_t>
              || (SqlBasicStringBinderConcept<Utf32StringType, uint32_t>)
              || (SqlBasicStringBinderConcept<Utf32StringType, wchar_t> && sizeof(wchar_t) == 4))
-struct LIGHTWEIGHT_API SqlDataBinder<Utf32StringType>
+struct SqlDataBinder<Utf32StringType>
 {
     using ValueType = Utf32StringType;
     using CharType = typename Utf32StringType::value_type;
@@ -504,7 +504,7 @@ struct LIGHTWEIGHT_API SqlDataBinder<Utf32StringType>
 // SqlDataBinder<> specialization for UTF-8 strings
 template <typename Utf8StringType>
     requires SqlBasicStringBinderConcept<Utf8StringType, char8_t>
-struct LIGHTWEIGHT_API SqlDataBinder<Utf8StringType>
+struct SqlDataBinder<Utf8StringType>
 {
     using ValueType = Utf8StringType;
     using CharType = char8_t;

--- a/src/Lightweight/DataBinder/MFCStringLike.hpp
+++ b/src/Lightweight/DataBinder/MFCStringLike.hpp
@@ -14,12 +14,12 @@ concept MFCStringLike = requires(T const& t) {
 
 template <typename T>
     requires(MFCStringLike<T>)
-struct LIGHTWEIGHT_API SqlDataBinder<T>
+struct SqlDataBinder<T>
 {
-    static SQLRETURN InputParameter(SQLHSTMT stmt,
-                                    SQLUSMALLINT column,
-                                    T const& value,
-                                    SqlDataBinderCallback& /*cb*/) noexcept
+    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN InputParameter(SQLHSTMT stmt,
+                                                             SQLUSMALLINT column,
+                                                             T const& value,
+                                                             SqlDataBinderCallback& /*cb*/) noexcept
     {
         return SQLBindParameter(stmt,
                                 column,

--- a/src/Lightweight/DataBinder/SqlBinary.hpp
+++ b/src/Lightweight/DataBinder/SqlBinary.hpp
@@ -25,7 +25,7 @@ class SqlBinary final: public std::vector<uint8_t>
 };
 
 template <>
-struct LIGHTWEIGHT_API SqlDataBinder<SqlBinary>
+struct SqlDataBinder<SqlBinary>
 {
     static constexpr auto ColumnType = SqlColumnTypeDefinitions::Binary { 255 };
 

--- a/src/Lightweight/DataBinder/SqlDate.hpp
+++ b/src/Lightweight/DataBinder/SqlDate.hpp
@@ -9,7 +9,7 @@
 #include <format>
 
 /// Represents a date to efficiently write to or read from a database.
-struct LIGHTWEIGHT_API SqlDate
+struct SqlDate
 {
     SQL_DATE_STRUCT sqlValue {};
 
@@ -87,7 +87,7 @@ struct std::formatter<SqlDate>: std::formatter<std::string>
 };
 
 template <>
-struct LIGHTWEIGHT_API SqlDataBinder<SqlDate>
+struct SqlDataBinder<SqlDate>
 {
     static constexpr auto ColumnType = SqlColumnTypeDefinitions::Date {};
 

--- a/src/Lightweight/DataBinder/SqlGuid.hpp
+++ b/src/Lightweight/DataBinder/SqlGuid.hpp
@@ -91,9 +91,9 @@ constexpr SqlGuid SqlGuid::UnsafeParse(std::string_view const& text) noexcept
 }
 
 template <>
-struct LIGHTWEIGHT_API std::formatter<SqlGuid>: std::formatter<std::string>
+struct std::formatter<SqlGuid>: std::formatter<std::string>
 {
-    auto format(SqlGuid const& guid, format_context& ctx) const -> format_context::iterator
+    LIGHTWEIGHT_FORCE_INLINE auto format(SqlGuid const& guid, format_context& ctx) const -> format_context::iterator
     {
         // clang-format off
         return formatter<std::string>::format(std::format(

--- a/src/Lightweight/DataBinder/SqlVariant.hpp
+++ b/src/Lightweight/DataBinder/SqlVariant.hpp
@@ -38,7 +38,6 @@ overloaded(Ts...) -> overloaded<Ts...>;
 /// Use this class with care. Always prefer native types when possible, in order to avoid any unnecessary overhead.
 struct SqlVariant
 {
-
     /// @brief The inner type of the variant.
     ///
     /// This type is a variant of all the supported SQL data types.

--- a/src/Lightweight/DataMapper/BelongsTo.hpp
+++ b/src/Lightweight/DataMapper/BelongsTo.hpp
@@ -190,7 +190,8 @@ class BelongsTo
         if (_loaded)
             return;
 
-        _loader.loadReference();
+        if (_loader.loadReference)
+            _loader.loadReference();
 
         if (!_loaded)
             throw SqlRequireLoadedError(Reflection::TypeNameOf<std::remove_cvref_t<decltype(*this)>>);
@@ -216,10 +217,11 @@ struct IsBelongsTo: std::false_type
 {
 };
 
-template <auto ReferencedField>
-struct IsBelongsTo<BelongsTo<ReferencedField>>: std::true_type
+template <auto ReferencedField, auto ColumnNameOverrideString>
+struct IsBelongsTo<BelongsTo<ReferencedField, ColumnNameOverrideString>>: std::true_type
 {
 };
+
 } // namespace detail
 
 template <typename T>

--- a/src/Lightweight/DataMapper/Record.hpp
+++ b/src/Lightweight/DataMapper/Record.hpp
@@ -7,6 +7,7 @@
 #include <reflection-cpp/reflection.hpp>
 
 #include <concepts>
+#include <limits>
 
 /// @brief Represents a record type that can be used with the DataMapper.
 ///
@@ -38,7 +39,8 @@ constexpr std::optional<size_t> FindPrimaryKeyIndex()
 
 /// Declare RecordPrimaryKeyIndex<Record> to retrieve the primary key index of the given record.
 template <typename Record>
-constexpr size_t RecordPrimaryKeyIndex = detail::FindPrimaryKeyIndex<0, Record>().value_or(static_cast<size_t>(-1));
+constexpr size_t RecordPrimaryKeyIndex =
+    detail::FindPrimaryKeyIndex<0, Record>().value_or(std::numeric_limits<size_t>::max());
 
 /// Retrieves a reference to the given record's primary key.
 template <typename Record>
@@ -49,6 +51,23 @@ decltype(auto) RecordPrimaryKeyOf(Record&& record)
     return Reflection::GetMemberAt<RecordPrimaryKeyIndex<std::remove_cvref_t<Record>>>(std::forward<Record>(record));
 }
 
+namespace details {
+
+template <typename Record>
+struct RecordPrimaryKeyTypeHelper
+{
+    using type = void;
+};
+
+template <typename Record>
+    requires(RecordPrimaryKeyIndex<Record> < Reflection::CountMembers<Record>)
+struct RecordPrimaryKeyTypeHelper<Record>
+{
+    using type = typename Reflection::MemberTypeOf<RecordPrimaryKeyIndex<Record>, Record>::ValueType;
+};
+
+} // namespace details
+
 /// Reflects the primary key type of the given record.
 template <typename Record>
-using RecordPrimaryKeyType = typename Reflection::MemberTypeOf<RecordPrimaryKeyIndex<Record>, Record>::ValueType;
+using RecordPrimaryKeyType = typename details::RecordPrimaryKeyTypeHelper<Record>::type;

--- a/src/Lightweight/DataMapper/RecordId.hpp
+++ b/src/Lightweight/DataMapper/RecordId.hpp
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-#pragma once
-
-struct RecordId
-{
-    unsigned long long value {};
-};

--- a/src/Lightweight/QueryFormatter/OracleFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/OracleFormatter.hpp
@@ -119,13 +119,12 @@ class OracleSqlQueryFormatter final: public SQLiteQueryFormatter
 
         if (column.primaryKey == SqlPrimaryKeyType::AUTO_INCREMENT)
             sqlQueryString << " GENERATED ALWAYS AS IDENTITY";
-        else if (column.unique && !column.index)
+        else if (column.primaryKey == SqlPrimaryKeyType::NONE && !column.index && column.unique)
             sqlQueryString << " UNIQUE";
 
-        if (column.primaryKey == SqlPrimaryKeyType::AUTO_INCREMENT)
-        {
+        if (column.primaryKey != SqlPrimaryKeyType::NONE)
             sqlQueryString << ",\n    PRIMARY KEY (\"" << column.name << "\")";
-        }
+
         return sqlQueryString.str();
     }
 };

--- a/src/Lightweight/QueryFormatter/PostgreSqlFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/PostgreSqlFormatter.hpp
@@ -35,8 +35,7 @@ class PostgreSqlFormatter final: public SQLiteQueryFormatter
 
         if (column.primaryKey == SqlPrimaryKeyType::AUTO_INCREMENT)
             sqlQueryString << " PRIMARY KEY";
-
-        if (column.unique && !column.index)
+        else if (column.primaryKey == SqlPrimaryKeyType::NONE && !column.index && column.unique)
             sqlQueryString << " UNIQUE";
 
         return sqlQueryString.str();

--- a/src/Lightweight/QueryFormatter/SQLiteFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/SQLiteFormatter.hpp
@@ -174,7 +174,7 @@ class SQLiteQueryFormatter: public SqlQueryFormatter
 
         if (column.primaryKey == SqlPrimaryKeyType::AUTO_INCREMENT)
             sqlQueryString << " PRIMARY KEY AUTOINCREMENT";
-        else if (column.unique && !column.index)
+        else if (column.primaryKey == SqlPrimaryKeyType::NONE && !column.index && column.unique)
             sqlQueryString << " UNIQUE";
 
         return sqlQueryString.str();
@@ -208,7 +208,7 @@ class SQLiteQueryFormatter: public SqlQueryFormatter
                 ++currentColumn;
                 sqlQueryString << "\n    ";
                 sqlQueryString << BuildColumnDefinition(column);
-                if (column.primaryKey == SqlPrimaryKeyType::MANUAL)
+                if (column.primaryKey == SqlPrimaryKeyType::MANUAL || column.primaryKey == SqlPrimaryKeyType::GUID)
                 {
                     if (!primaryKeyColumns.empty())
                         primaryKeyColumns += ", ";

--- a/src/Lightweight/QueryFormatter/SqlServerFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/SqlServerFormatter.hpp
@@ -115,8 +115,7 @@ class SqlServerQueryFormatter final: public SQLiteQueryFormatter
 
         if (column.primaryKey == SqlPrimaryKeyType::AUTO_INCREMENT)
             sqlQueryString << " IDENTITY(1,1) PRIMARY KEY";
-
-        if (column.unique && !column.index)
+        else if (column.primaryKey == SqlPrimaryKeyType::NONE && !column.index && column.unique)
             sqlQueryString << " UNIQUE";
 
         return sqlQueryString.str();

--- a/src/Lightweight/SqlQuery/Core.cpp
+++ b/src/Lightweight/SqlQuery/Core.cpp
@@ -1,0 +1,46 @@
+#include "Core.hpp"
+
+std::string detail::ComposedQuery::ToSql() const
+{
+    switch (selectType)
+    {
+        case SelectType::All:
+            return formatter->SelectAll(distinct,
+                                        fields,
+                                        searchCondition.tableName,
+                                        searchCondition.tableAlias,
+                                        searchCondition.tableJoins,
+                                        searchCondition.condition,
+                                        orderBy,
+                                        groupBy);
+        case SelectType::First:
+            return formatter->SelectFirst(distinct,
+                                          fields,
+                                          searchCondition.tableName,
+                                          searchCondition.tableAlias,
+                                          searchCondition.tableJoins,
+                                          searchCondition.condition,
+                                          orderBy,
+                                          limit);
+        case SelectType::Range:
+            return formatter->SelectRange(distinct,
+                                          fields,
+                                          searchCondition.tableName,
+                                          searchCondition.tableAlias,
+                                          searchCondition.tableJoins,
+                                          searchCondition.condition,
+                                          orderBy,
+                                          groupBy,
+                                          offset,
+                                          limit);
+        case SelectType::Count:
+            return formatter->SelectCount(distinct,
+                                          searchCondition.tableName,
+                                          searchCondition.tableAlias,
+                                          searchCondition.tableJoins,
+                                          searchCondition.condition);
+        case SelectType::Undefined:
+            break;
+    }
+    return "";
+}

--- a/src/Lightweight/SqlQuery/Core.hpp
+++ b/src/Lightweight/SqlQuery/Core.hpp
@@ -349,52 +349,51 @@ enum class SqlResultOrdering : uint8_t
 
 namespace detail
 {
-    enum class SelectType : std::uint8_t
-    {
-        Undefined,
-        Count,
-        All,
-        First,
-        Range
-    };
+enum class SelectType : std::uint8_t
+{
+    Undefined,
+    Count,
+    All,
+    First,
+    Range
+};
 
-    struct ComposedQuery
-    {
-        SelectType selectType = SelectType::Undefined;
-        SqlQueryFormatter const* formatter = nullptr;
+struct ComposedQuery
+{
+    SelectType selectType = SelectType::Undefined;
+    SqlQueryFormatter const* formatter = nullptr;
 
-        bool distinct = false;
-        SqlSearchCondition searchCondition {};
+    bool distinct = false;
+    SqlSearchCondition searchCondition {};
 
-        std::string fields;
+    std::string fields;
 
-        std::string orderBy;
-        std::string groupBy;
+    std::string orderBy;
+    std::string groupBy;
 
-        size_t offset = 0;
-        size_t limit = (std::numeric_limits<size_t>::max)();
+    size_t offset = 0;
+    size_t limit = (std::numeric_limits<size_t>::max)();
 
-        [[nodiscard]] LIGHTWEIGHT_API std::string ToSql() const;
-    };
-}
+    [[nodiscard]] LIGHTWEIGHT_API std::string ToSql() const;
+};
+} // namespace detail
 
 template <typename Derived>
 class [[nodiscard]] SqlBasicSelectQueryBuilder: public SqlWhereClauseBuilder<Derived>
 {
   public:
     /// Adds a DISTINCT clause to the SELECT query.
-    LIGHTWEIGHT_API Derived& Distinct() noexcept;
+    Derived& Distinct() noexcept;
 
     /// Constructs or extends a ORDER BY clause.
-    LIGHTWEIGHT_API Derived& OrderBy(SqlQualifiedTableColumnName const& columnName,
-                                     SqlResultOrdering ordering = SqlResultOrdering::ASCENDING);
+    Derived& OrderBy(SqlQualifiedTableColumnName const& columnName,
+                     SqlResultOrdering ordering = SqlResultOrdering::ASCENDING);
 
     /// Constructs or extends a ORDER BY clause.
-    LIGHTWEIGHT_API Derived& OrderBy(std::string_view columnName,
-                                     SqlResultOrdering ordering = SqlResultOrdering::ASCENDING);
+    Derived& OrderBy(std::string_view columnName, SqlResultOrdering ordering = SqlResultOrdering::ASCENDING);
 
     /// Constructs or extends a GROUP BY clause.
-    LIGHTWEIGHT_API Derived& GroupBy(std::string_view columnName);
+    Derived& GroupBy(std::string_view columnName);
 
     using ComposedQuery = detail::ComposedQuery;
 
@@ -403,14 +402,15 @@ class [[nodiscard]] SqlBasicSelectQueryBuilder: public SqlWhereClauseBuilder<Der
 };
 
 template <typename Derived>
-Derived& SqlBasicSelectQueryBuilder<Derived>::Distinct() noexcept
+inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlBasicSelectQueryBuilder<Derived>::Distinct() noexcept
 {
     _query.distinct = true;
     return static_cast<Derived&>(*this);
 }
 
 template <typename Derived>
-Derived& SqlBasicSelectQueryBuilder<Derived>::OrderBy(std::string_view columnName, SqlResultOrdering ordering)
+inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlBasicSelectQueryBuilder<Derived>::OrderBy(std::string_view columnName,
+                                                                                      SqlResultOrdering ordering)
 {
     if (_query.orderBy.empty())
         _query.orderBy += "\n ORDER BY ";
@@ -430,8 +430,8 @@ Derived& SqlBasicSelectQueryBuilder<Derived>::OrderBy(std::string_view columnNam
 }
 
 template <typename Derived>
-Derived& SqlBasicSelectQueryBuilder<Derived>::OrderBy(SqlQualifiedTableColumnName const& columnName,
-                                                      SqlResultOrdering ordering)
+inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlBasicSelectQueryBuilder<Derived>::OrderBy(
+    SqlQualifiedTableColumnName const& columnName, SqlResultOrdering ordering)
 {
     if (_query.orderBy.empty())
         _query.orderBy += "\n ORDER BY ";
@@ -453,7 +453,7 @@ Derived& SqlBasicSelectQueryBuilder<Derived>::OrderBy(SqlQualifiedTableColumnNam
 }
 
 template <typename Derived>
-Derived& SqlBasicSelectQueryBuilder<Derived>::GroupBy(std::string_view columnName)
+inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlBasicSelectQueryBuilder<Derived>::GroupBy(std::string_view columnName)
 {
     if (_query.groupBy.empty())
         _query.groupBy += "\n GROUP BY ";

--- a/src/Lightweight/SqlQuery/Select.cpp
+++ b/src/Lightweight/SqlQuery/Select.cpp
@@ -2,25 +2,19 @@
 
 #include "Select.hpp"
 
-SqlSelectQueryBuilder& SqlSelectQueryBuilder::Distinct() noexcept
-{
-    m_query.distinct = true;
-    return *this;
-}
-
 SqlSelectQueryBuilder& SqlSelectQueryBuilder::Field(std::string_view const& fieldName)
 {
-    if (!m_query.fields.empty())
-        m_query.fields += ", ";
+    if (!_query.fields.empty())
+        _query.fields += ", ";
 
     if (fieldName == "*")
-        m_query.fields += fieldName;
+        _query.fields += fieldName;
     else
     {
-        m_query.fields += '"';
-        m_query.fields += fieldName;
-        m_query.fields += '"';
-        m_aliasAllowed = true;
+        _query.fields += '"';
+        _query.fields += fieldName;
+        _query.fields += '"';
+        _aliasAllowed = true;
     }
 
     return *this;
@@ -28,19 +22,19 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::Field(std::string_view const& fiel
 
 SqlSelectQueryBuilder& SqlSelectQueryBuilder::Field(SqlQualifiedTableColumnName const& fieldName)
 {
-    if (!m_query.fields.empty())
-        m_query.fields += ", ";
+    if (!_query.fields.empty())
+        _query.fields += ", ";
 
-    m_query.fields += '"';
-    m_query.fields += fieldName.tableName;
+    _query.fields += '"';
+    _query.fields += fieldName.tableName;
     if (fieldName.columnName == "*")
-        m_query.fields += "\".*";
+        _query.fields += "\".*";
     else
     {
-        m_query.fields += "\".\"";
-        m_query.fields += fieldName.columnName;
-        m_query.fields += '"';
-        m_aliasAllowed = true;
+        _query.fields += "\".\"";
+        _query.fields += fieldName.columnName;
+        _query.fields += '"';
+        _aliasAllowed = true;
     }
 
     return *this;
@@ -48,37 +42,37 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::Field(SqlQualifiedTableColumnName 
 
 SqlSelectQueryBuilder& SqlSelectQueryBuilder::Field(SqlFieldExpression const& fieldExpression)
 {
-    if (!m_query.fields.empty())
-        m_query.fields += ", ";
+    if (!_query.fields.empty())
+        _query.fields += ", ";
 
-    m_query.fields += fieldExpression.expression;
-    m_aliasAllowed = true;
+    _query.fields += fieldExpression.expression;
+    _aliasAllowed = true;
 
     return *this;
 }
 
 SqlSelectQueryBuilder& SqlSelectQueryBuilder::As(std::string_view alias)
 {
-    assert(m_aliasAllowed);
+    assert(_aliasAllowed);
 
-    m_aliasAllowed = false;
-    m_query.fields += " AS \"";
-    m_query.fields += alias;
-    m_query.fields += "\"";
+    _aliasAllowed = false;
+    _query.fields += " AS \"";
+    _query.fields += alias;
+    _query.fields += "\"";
 
     return *this;
 }
 
 SqlSelectQueryBuilder& SqlSelectQueryBuilder::FieldAs(std::string_view const& fieldName, std::string_view const& alias)
 {
-    if (!m_query.fields.empty())
-        m_query.fields += ", ";
+    if (!_query.fields.empty())
+        _query.fields += ", ";
 
-    m_query.fields += '"';
-    m_query.fields += fieldName;
-    m_query.fields += "\" AS \"";
-    m_query.fields += alias;
-    m_query.fields += '"';
+    _query.fields += '"';
+    _query.fields += fieldName;
+    _query.fields += "\" AS \"";
+    _query.fields += alias;
+    _query.fields += '"';
 
     return *this;
 }
@@ -86,16 +80,16 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::FieldAs(std::string_view const& fi
 SqlSelectQueryBuilder& SqlSelectQueryBuilder::FieldAs(SqlQualifiedTableColumnName const& fieldName,
                                                       std::string_view const& alias)
 {
-    if (!m_query.fields.empty())
-        m_query.fields += ", ";
+    if (!_query.fields.empty())
+        _query.fields += ", ";
 
-    m_query.fields += '"';
-    m_query.fields += fieldName.tableName;
-    m_query.fields += "\".\"";
-    m_query.fields += fieldName.columnName;
-    m_query.fields += "\" AS \"";
-    m_query.fields += alias;
-    m_query.fields += '"';
+    _query.fields += '"';
+    _query.fields += fieldName.tableName;
+    _query.fields += "\".\"";
+    _query.fields += fieldName.columnName;
+    _query.fields += "\" AS \"";
+    _query.fields += alias;
+    _query.fields += '"';
 
     return *this;
 }
@@ -104,12 +98,12 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::Fields(std::vector<std::string_vie
 {
     for (auto const& fieldName: fieldNames)
     {
-        if (!m_query.fields.empty())
-            m_query.fields += ", ";
+        if (!_query.fields.empty())
+            _query.fields += ", ";
 
-        m_query.fields += '"';
-        m_query.fields += fieldName;
-        m_query.fields += '"';
+        _query.fields += '"';
+        _query.fields += fieldName;
+        _query.fields += '"';
     }
     return *this;
 }
@@ -119,14 +113,14 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::Fields(std::vector<std::string_vie
 {
     for (auto const& fieldName: fieldNames)
     {
-        if (!m_query.fields.empty())
-            m_query.fields += ", ";
+        if (!_query.fields.empty())
+            _query.fields += ", ";
 
-        m_query.fields += '"';
-        m_query.fields += tableName;
-        m_query.fields += "\".\"";
-        m_query.fields += fieldName;
-        m_query.fields += '"';
+        _query.fields += '"';
+        _query.fields += tableName;
+        _query.fields += "\".\"";
+        _query.fields += fieldName;
+        _query.fields += '"';
     }
     return *this;
 }
@@ -136,155 +130,57 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::Fields(std::initializer_list<std::
 {
     for (auto const& fieldName: fieldNames)
     {
-        if (!m_query.fields.empty())
-            m_query.fields += ", ";
+        if (!_query.fields.empty())
+            _query.fields += ", ";
 
-        m_query.fields += '"';
-        m_query.fields += tableName;
-        m_query.fields += "\".\"";
-        m_query.fields += fieldName;
-        m_query.fields += '"';
+        _query.fields += '"';
+        _query.fields += tableName;
+        _query.fields += "\".\"";
+        _query.fields += fieldName;
+        _query.fields += '"';
     }
-    return *this;
-}
-
-SqlSelectQueryBuilder& SqlSelectQueryBuilder::OrderBy(std::string_view columnName, SqlResultOrdering ordering)
-{
-    if (m_query.orderBy.empty())
-        m_query.orderBy += "\n ORDER BY ";
-    else
-        m_query.orderBy += ", ";
-
-    m_query.orderBy += '"';
-    m_query.orderBy += columnName;
-    m_query.orderBy += '"';
-
-    if (ordering == SqlResultOrdering::DESCENDING)
-        m_query.orderBy += " DESC";
-    else if (ordering == SqlResultOrdering::ASCENDING)
-        m_query.orderBy += " ASC";
-    return *this;
-}
-
-SqlSelectQueryBuilder& SqlSelectQueryBuilder::OrderBy(SqlQualifiedTableColumnName const& columnName,
-                                                      SqlResultOrdering ordering)
-{
-    if (m_query.orderBy.empty())
-        m_query.orderBy += "\n ORDER BY ";
-    else
-        m_query.orderBy += ", ";
-
-    m_query.orderBy += '"';
-    m_query.orderBy += columnName.tableName;
-    m_query.orderBy += "\".\"";
-    m_query.orderBy += columnName.columnName;
-    m_query.orderBy += '"';
-
-    if (ordering == SqlResultOrdering::DESCENDING)
-        m_query.orderBy += " DESC";
-    else if (ordering == SqlResultOrdering::ASCENDING)
-        m_query.orderBy += " ASC";
-    return *this;
-}
-
-SqlSelectQueryBuilder& SqlSelectQueryBuilder::GroupBy(std::string_view columnName)
-{
-    if (m_query.groupBy.empty())
-        m_query.groupBy += "\n GROUP BY ";
-    else
-        m_query.groupBy += ", ";
-
-    m_query.groupBy += '"';
-    m_query.groupBy += columnName;
-    m_query.groupBy += '"';
-
     return *this;
 }
 
 SqlSelectQueryBuilder::ComposedQuery SqlSelectQueryBuilder::Count()
 {
-    m_query.selectType = SelectType::Count;
+    _query.selectType = SelectType::Count;
 
-    if (m_mode == SqlQueryBuilderMode::Fluent)
-        return std::move(m_query);
+    if (_mode == SqlQueryBuilderMode::Fluent)
+        return std::move(_query);
     else
-        return m_query;
+        return _query;
 }
 
 SqlSelectQueryBuilder::ComposedQuery SqlSelectQueryBuilder::All()
 {
-    m_query.selectType = SelectType::All;
+    _query.selectType = SelectType::All;
 
-    if (m_mode == SqlQueryBuilderMode::Fluent)
-        return std::move(m_query);
+    if (_mode == SqlQueryBuilderMode::Fluent)
+        return std::move(_query);
     else
-        return m_query;
+        return _query;
 }
 
 SqlSelectQueryBuilder::ComposedQuery SqlSelectQueryBuilder::First(size_t count)
 {
-    m_query.selectType = SelectType::First;
-    m_query.limit = count;
+    _query.selectType = SelectType::First;
+    _query.limit = count;
 
-    if (m_mode == SqlQueryBuilderMode::Fluent)
-        return std::move(m_query);
+    if (_mode == SqlQueryBuilderMode::Fluent)
+        return std::move(_query);
     else
-        return m_query;
+        return _query;
 }
 
 SqlSelectQueryBuilder::ComposedQuery SqlSelectQueryBuilder::Range(std::size_t offset, std::size_t limit)
 {
-    m_query.selectType = SelectType::Range;
-    m_query.offset = offset;
-    m_query.limit = limit;
+    _query.selectType = SelectType::Range;
+    _query.offset = offset;
+    _query.limit = limit;
 
-    if (m_mode == SqlQueryBuilderMode::Fluent)
-        return std::move(m_query);
+    if (_mode == SqlQueryBuilderMode::Fluent)
+        return std::move(_query);
     else
-        return m_query;
-}
-
-std::string SqlSelectQueryBuilder::ComposedQuery::ToSql() const
-{
-    switch (selectType)
-    {
-        case SelectType::All:
-            return formatter->SelectAll(distinct,
-                                        fields,
-                                        searchCondition.tableName,
-                                        searchCondition.tableAlias,
-                                        searchCondition.tableJoins,
-                                        searchCondition.condition,
-                                        orderBy,
-                                        groupBy);
-        case SelectType::First:
-            return formatter->SelectFirst(distinct,
-                                          fields,
-                                          searchCondition.tableName,
-                                          searchCondition.tableAlias,
-                                          searchCondition.tableJoins,
-                                          searchCondition.condition,
-                                          orderBy,
-                                          limit);
-        case SelectType::Range:
-            return formatter->SelectRange(distinct,
-                                          fields,
-                                          searchCondition.tableName,
-                                          searchCondition.tableAlias,
-                                          searchCondition.tableJoins,
-                                          searchCondition.condition,
-                                          orderBy,
-                                          groupBy,
-                                          offset,
-                                          limit);
-        case SelectType::Count:
-            return formatter->SelectCount(distinct,
-                                          searchCondition.tableName,
-                                          searchCondition.tableAlias,
-                                          searchCondition.tableJoins,
-                                          searchCondition.condition);
-        case SelectType::Undefined:
-            break;
-    }
-    return "";
+        return _query;
 }

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -758,11 +758,8 @@ inline bool SqlStatement::GetColumn(SQLUSMALLINT column, T* result) const
 namespace detail
 {
 
-// is_specialization_of<> is inspired by:
-// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2098r1.pdf
-
 template <typename T>
-concept SqlNullableType = (std::same_as<T, SqlVariant> || is_specialization_of<std::optional, T>::value);
+concept SqlNullableType = (std::same_as<T, SqlVariant> || IsSpecializationOf<std::optional, T>);
 
 } // end namespace detail
 

--- a/src/Lightweight/Utils.hpp
+++ b/src/Lightweight/Utils.hpp
@@ -31,6 +31,9 @@ constexpr auto Finally(auto&& cleanupRoutine) noexcept
     return Finally { std::forward<decltype(cleanupRoutine)>(cleanupRoutine) };
 }
 
+// is_specialization_of<> is inspired by:
+// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2098r1.pdf
+
 template <template <typename...> class T, typename U>
 struct is_specialization_of: std::false_type
 {

--- a/src/tests/DataMapperTests.cpp
+++ b/src/tests/DataMapperTests.cpp
@@ -267,17 +267,21 @@ TEST_CASE_METHOD(SqlTestFixture, "Query.Range", "[DataMapper]")
     auto dm = DataMapper {};
 
     auto expectedPersons = std::array {
-        Person { .id = SqlGuid::Create(), .name = "John Doe", .is_active = true, .age = 42 },
-        Person { .id = SqlGuid::Create(), .name = "Jimmy John", .is_active = false, .age = 24 },
         Person { .id = SqlGuid::Create(), .name = "Jane Doe", .is_active = true, .age = 36 },
         Person { .id = SqlGuid::Create(), .name = "Jimbo Jones", .is_active = false, .age = 69 },
+        Person { .id = SqlGuid::Create(), .name = "Jimmy John", .is_active = false, .age = 24 },
+        Person { .id = SqlGuid::Create(), .name = "John Doe", .is_active = true, .age = 42 },
     };
 
     dm.CreateTable<Person>();
     for (auto& person: expectedPersons)
         dm.Create(person);
 
-    auto const records = dm.Query<Person>().Range(1, 2);
+    // clang-format off
+    auto const records = dm.Query<Person>()
+                           .OrderBy(FieldNameOf<&Person::name>, SqlResultOrdering::ASCENDING)
+                           .Range(1, 2);
+    // clang-format on
 
     CHECK(records.size() == 2);
     CHECK(records[0] == expectedPersons[1]);
@@ -346,18 +350,22 @@ TEST_CASE_METHOD(SqlTestFixture, "QuerySparse.Range", "[DataMapper]")
     auto dm = DataMapper {};
 
     dm.CreateTable<Person>();
-    dm.CreateExplicit(Person { .id = SqlGuid::Create(), .name = "John Doe", .is_active = true, .age = 42 });
-    dm.CreateExplicit(Person { .id = SqlGuid::Create(), .name = "Jimmy John", .is_active = false, .age = 24 });
     dm.CreateExplicit(Person { .id = SqlGuid::Create(), .name = "Jane Doe", .is_active = true, .age = 36 });
     dm.CreateExplicit(Person { .id = SqlGuid::Create(), .name = "Jimbo Jones", .is_active = false, .age = 69 });
+    dm.CreateExplicit(Person { .id = SqlGuid::Create(), .name = "Jimmy John", .is_active = false, .age = 24 });
+    dm.CreateExplicit(Person { .id = SqlGuid::Create(), .name = "John Doe", .is_active = true, .age = 42 });
 
-    auto const records = dm.QuerySparse<Person, &Person::name, &Person::age>().Range(1, 2);
+    // clang-format off
+    auto const records = dm.QuerySparse<Person, &Person::name, &Person::age>()
+                           .OrderBy(FieldNameOf<&Person::name>, SqlResultOrdering::ASCENDING)
+                           .Range(1, 2);
+    // clang-format on
 
     CHECK(records.size() == 2);
-    CHECK(records[0].name == "Jimmy John");
-    CHECK(records[0].age == 24);
-    CHECK(records[1].name == "Jane Doe");
-    CHECK(records[1].age == 36);
+    CHECK(records[0].name == "Jimbo Jones");
+    CHECK(records[0].age == 69);
+    CHECK(records[1].name == "Jimmy John");
+    CHECK(records[1].age == 24);
 }
 
 TEST_CASE_METHOD(SqlTestFixture, "Constructor with connection string", "[DataMapper]")


### PR DESCRIPTION
### Rough Changes
- [x] Ensure `BelongsTo<>` works as auto-loading relation when `SqlRealName` is changing its underlying column name
- [x] Fix `IsBelongsTo<>` wrt. `SqlRealName`-uses
- [x] Fix and move `GetPrimaryKeyField(...)` into global scope
- [x] Fix DataMapper.Create and DataMapper.CreateExplicit for GUID primary key uses
- [x] Mak emore use of GUID primary keys in DataMapper test cases
- [x] Add `constexpr bool HasPrimaryKey<Record>`
- [x] Fix `DataMapper::ConfigureRelationAutoLoading()` wrt `BelongsTo` fields
- [x] Fix `RecordPrimaryKeyType<Record>`
- [x] QueryFormatter: Fix CREATE TABLE syntax for GUID primary key cases
- [x] Also allow GroupBy/OrderBy/Distinct calls in DataMapper builtin query building.