### PR TITLE
[dd2lcpp] Allow configuration of member name formatting through cli

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -92,3 +92,5 @@ CheckOptions:
     value:           'NULL'
   - key:             modernize-use-default-member-init.UseAssignment
     value:           '1'
+  - key:             readability-identifier-naming.FunctionCase
+    value:           CamelCase

--- a/src/Lightweight/Utils.cpp
+++ b/src/Lightweight/Utils.cpp
@@ -26,3 +26,45 @@ void RequireSuccess(SQLHSTMT hStmt, SQLRETURN error, std::source_location source
     else
         throw SqlException(std::move(errorInfo));
 }
+
+std::string formatName(std::string_view name, FormatType formatType)
+{
+    if (formatType == FormatType::existing)
+        return std::string { name };
+
+    const auto IsDelimiter = [](char c) {
+        return c == '_' || c == '-' || c == ' ';
+    };
+
+    std::string result;
+    result.reserve(name.size());
+
+    bool makeUpper = false;
+
+    for (auto const c: name)
+    {
+        if (IsDelimiter(c))
+        {
+            if (formatType == FormatType::snakeCase)
+            {
+                result += '_';
+            }
+            else if (formatType == FormatType::camelCase)
+            {
+                makeUpper = true;
+            }
+            continue;
+        }
+        if (makeUpper)
+        {
+            result += static_cast<char>(std::toupper(c));
+            makeUpper = false;
+        }
+        else
+        {
+            result += static_cast<char>(std::tolower(c));
+        }
+    }
+
+    return result;
+}

--- a/src/Lightweight/Utils.hpp
+++ b/src/Lightweight/Utils.hpp
@@ -213,3 +213,13 @@ LIGHTWEIGHT_API void LogIfFailed(SQLHSTMT hStmt, SQLRETURN error, std::source_lo
 LIGHTWEIGHT_API void RequireSuccess(SQLHSTMT hStmt,
                                     SQLRETURN error,
                                     std::source_location sourceLocation = std::source_location::current());
+
+enum class FormatType : uint8_t
+{
+    snakeCase,
+    camelCase,
+    existing,
+};
+
+/// @brief Converts a string to a format that is more suitable for C++ code.
+LIGHTWEIGHT_API std::string formatName(std::string_view name, FormatType formatType);

--- a/src/tests/CoreTests.cpp
+++ b/src/tests/CoreTests.cpp
@@ -40,6 +40,30 @@ int main(int argc, char** argv)
     return Catch::Session().run(argc, argv);
 }
 
+TEST_CASE_METHOD(SqlTestFixture, "NameFormatting", "[Format]")
+{
+
+    const std::array inputNames = {
+        "test", "TEST_NR", "TEST-NR", "TEST NR", "TESTNR", "TestNr",
+    };
+    const std::array expectedCamelCase = {
+        "test", "testNr", "testNr", "testNr", "testnr", "testnr",
+    };
+    const std::array expectedSnakeCase = {
+        "test", "test_nr", "test_nr", "test_nr", "testnr", "testnr",
+    };
+    const std::array expectedExisting = {
+        "test", "TEST_NR", "TEST-NR", "TEST NR", "TESTNR", "TestNr",
+    };
+
+    for (size_t i = 0; i < inputNames.size(); ++i)
+    {
+        CHECK(formatName(inputNames[i], FormatType::camelCase) == expectedCamelCase[i]);
+        CHECK(formatName(inputNames[i], FormatType::snakeCase) == expectedSnakeCase[i]);
+        CHECK(formatName(inputNames[i], FormatType::existing) == expectedExisting[i]);
+    }
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "SqlConnectionDataSource.FromConnectionString", "[SqlConnection]")
 {
     auto const connectionString = SqlConnectionString { "Dsn=Test;UID=TestUser;Pwd=TestPassword;Timeout=10" };


### PR DESCRIPTION
Added arguments to the dd2cpp to format members according to some formatting, implemented:
 * `camelCase` 
 *  `snake_case` 