### PR TITLE
ddl2cpp: Add ability to force Unicode on text columns

### DIFF
--- a/src/Lightweight/DataBinder/SqlFixedString.hpp
+++ b/src/Lightweight/DataBinder/SqlFixedString.hpp
@@ -144,7 +144,7 @@ class SqlFixedString
     }
 
     /// Assigns a string view to the string.
-    LIGHTWEIGHT_FORCE_INLINE constexpr void assign(std::string_view s) noexcept
+    LIGHTWEIGHT_FORCE_INLINE constexpr void assign(std::basic_string_view<T> s) noexcept
     {
         _size = (std::min)(N, s.size());
         std::copy_n(s.data(), _size, _data);


### PR DESCRIPTION
Closes #250 

This pull request introduces enhancements to the `ddl2cpp` tool, focusing on improved handling of text column types and configurability. The most significant changes include adding support for forcing Unicode text column generation, updating the `MakeType` function to handle this new feature, and modifying the configuration handling to support the new option.

### Enhancements to Text Column Handling:
* Updated the `MakeType` function in `src/tools/ddl2cpp.cpp` to accept a new `forceUnicodeTextColumn` parameter. This allows conditional generation of `SqlWideString` or `SqlAnsiString` for `Text` and `Varchar` column types based on the configuration. [[1]](diffhunk://#diff-d0994ad2281e5d01a9806f27b5cd586e09e99d78c83af34edf26200b2ccb4039L42-R42) [[2]](diffhunk://#diff-d0994ad2281e5d01a9806f27b5cd586e09e99d78c83af34edf26200b2ccb4039L76-R98)

### Configuration Updates:
* Added a new `forceUnicodeTextColumns` field to the `Configuration` struct and `_config` member in the `CxxModelPrinter` class. This enables users to specify whether Unicode text columns should be forced. [[1]](diffhunk://#diff-d0994ad2281e5d01a9806f27b5cd586e09e99d78c83af34edf26200b2ccb4039R151) [[2]](diffhunk://#diff-d0994ad2281e5d01a9806f27b5cd586e09e99d78c83af34edf26200b2ccb4039R437)
* Updated the `LoadConfigFile` function to load the `ForceUnicodeTextColumns` option from the configuration file.

### Integration with Main Workflow:
* Modified the `main` function to propagate the `forceUnicodeTextColumns` configuration to the `CxxModelPrinter` instance.
* Updated the `CxxModelPrinter` logic to pass the `forceUnicodeTextColumns` option to the `MakeType` function when generating column definitions.

### Minor Improvements:
* Refactored the `SqlFixedString` class in `src/Lightweight/DataBinder/SqlFixedString.hpp` to use a template-based `std::basic_string_view` instead of `std::string_view` for improved type flexibility.


@FelixTheC This PR is doing it on ALL columns, because I don't think we'll need that incrementally (at least I think it's the right way to go, also for us internally).
