### PR TITLE
ddl2cpp: Implement better primary key assignment declaration

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: update apt
         run: sudo apt -q update
       - name: install dependencies
-        run: sudo apt install -y cmake ninja-build catch2 unixodbc-dev sqlite3 libsqlite3-dev libsqliteodbc valgrind uuid-dev g++-14  doxygen
+        run: sudo apt install -y cmake ninja-build catch2 unixodbc-dev sqlite3 libsqlite3-dev libyaml-cpp-dev libsqliteodbc valgrind uuid-dev g++-14  doxygen
       - name: cmake configure
         run: cmake --preset linux-gcc-release
       - name: build

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ CMakeSettings.json
 compile_commands.json
 *.sqlite
 /html/
+.aider*
+/src/entities/
+/ddl2cpp.yml

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,4 @@ compile_commands.json
 *.sqlite
 /html/
 .aider*
-/src/entities/
 /ddl2cpp.yml

--- a/src/Lightweight/DataMapper/Field.hpp
+++ b/src/Lightweight/DataMapper/Field.hpp
@@ -2,8 +2,16 @@
 #pragma once
 
 #include "../DataBinder/Core.hpp"
+#include "../DataBinder/SqlDate.hpp"
+#include "../DataBinder/SqlDateTime.hpp"
+#include "../DataBinder/SqlText.hpp"
+#include "../DataBinder/SqlTime.hpp"
 
 #include <reflection-cpp/reflection.hpp>
+
+#include <iomanip>
+#include <optional>
+#include <sstream>
 
 /// @brief Tells the data mapper that this field is a primary key with given semantics, or not a primary key.
 enum class PrimaryKey : uint8_t


### PR DESCRIPTION
Closes #252.

Example ddl2cpp.yml now:

```yaml
ConnectionString: 'DSN=YourDSN;UID=YourUser;PWD=YourPassword;TIMEOUT=5'
OutputDirectory: 'src/entities'
MakeAliases: true
NamingConvention: CamelCase
ForceUnicodeTextColumns: true
PrimaryKeyAssignment: ClientSide
```