### PR TITLE
ddl2cpp: BelongsTo<> improvements (and some minor cleanups)

### DIFF
--- a/src/Lightweight/DataMapper/BelongsTo.hpp
+++ b/src/Lightweight/DataMapper/BelongsTo.hpp
@@ -20,7 +20,23 @@
 /// in the form of `&OtherRecord::Field`.
 /// Other Field must be a primary key.
 ///
+/// @tparam TheReferencedField The field in the other record that references the current record.
+/// @tparam ColumnNameOverrideString If not an empty string, this value will be used as the column name in the database.
+///
 /// @ingroup DataMapper
+///
+/// @code
+/// struct User {
+///     Field<SqlGuid, PrimaryKey::AutoAssign> id;
+///     Field<SqlAnsiString<30>> name;
+/// };
+/// struct Email {
+///     Field<SqlGuid, PrimaryKey::AutoAssign> id;
+///     Field<SqlAnsiString<40>> address;
+///     BelongsTo<&User::id>> user;
+///     BelongsTo<&User::id, SqlRealName<"the_user_id">> user; // also possible to customize the column name
+/// };
+/// @endcode
 template <auto TheReferencedField, auto ColumnNameOverrideString = std::nullopt>
 class BelongsTo
 {

--- a/src/Lightweight/DataMapper/BelongsTo.hpp
+++ b/src/Lightweight/DataMapper/BelongsTo.hpp
@@ -33,7 +33,7 @@
 /// struct Email {
 ///     Field<SqlGuid, PrimaryKey::AutoAssign> id;
 ///     Field<SqlAnsiString<40>> address;
-///     BelongsTo<&User::id>> user;
+///     BelongsTo<&User::id> user;
 ///     BelongsTo<&User::id, SqlRealName<"the_user_id">> user; // also possible to customize the column name
 /// };
 /// @endcode

--- a/src/tools/ddl2cpp.cpp
+++ b/src/tools/ddl2cpp.cpp
@@ -215,7 +215,7 @@ class CxxModelPrinter
     {
 
         std::stringstream output;
-        output << "// File is automatically generated automatically using ddl2cpp\n";
+        output << "// File is automatically generated using ddl2cpp.\n";
         output << "#pragma once\n";
         output << "\n";
         output << "#include <Lightweight/DataMapper/DataMapper.hpp>\n";

--- a/src/tools/ddl2cpp.cpp
+++ b/src/tools/ddl2cpp.cpp
@@ -215,23 +215,23 @@ class CxxModelPrinter
     {
 
         std::stringstream output;
-        output << "// File is generated automatically using ddl2cpp \n";
-        output << "// SPDX-License-Identifier: Apache-2.0\n";
+        output << "// File is automatically generated automatically using ddl2cpp\n";
         output << "#pragma once\n";
-        output << "#include <Lightweight/DataMapper/DataMapper.hpp>\n";
         output << "\n";
-        output << "using namespace std::string_view_literals;\n";
+        output << "#include <Lightweight/DataMapper/DataMapper.hpp>\n";
         output << "\n";
 
         auto requiredTables = _definitions[tableName].requiredTables;
         std::sort(requiredTables.begin(), requiredTables.end());
         for (auto const& requiredTable: requiredTables)
-        {
             output << std::format("#include \"{}.hpp\"\n", requiredTable);
-        }
+
+        if (!std::empty(requiredTables))
+            output << '\n';
 
         if (!modelNamespace.empty())
-            output << std::format("namespace {}\n{{\n\n", modelNamespace);
+            output << std::format("namespace {}\n{{\n", modelNamespace);
+
         output << "\n";
         output << _definitions[tableName].text.str();
         if (!modelNamespace.empty())
@@ -315,7 +315,7 @@ class CxxModelPrinter
         auto aliasRealTableName = [&](std::string_view name) {
             if (_config.makeAliases)
             {
-                return std::format("    static constexpr std::string_view TableName = \"{}\"sv;\n\n", name);
+                return std::format("    static constexpr std::string_view TableName = \"{}\";\n\n", name);
             }
             return std::string {};
         };

--- a/src/tools/ddl2cpp.cpp
+++ b/src/tools/ddl2cpp.cpp
@@ -360,12 +360,13 @@ class CxxModelPrinter
 
             definition.requiredTables.push_back(foreignTableName);
             std::string foreignKeyContraint = std::format(
-                "    BelongsTo<&{}> {};\n",
+                "    BelongsTo<&{}{}> {};\n",
                 [&]() {
                     return std::format("{}::{}",
                                        foreignTableName,
                                        FormatName(foreignKey.primaryKey.columns[0], _config.formatType)); // TODO
                 }(),
+                aliasName(foreignKey.foreignKey.column),
                 memberName);
 
             definition.text << foreignKeyContraint;


### PR DESCRIPTION
Addresses the findings of @FelixTheC wrt. BelongsTo<> missing column aliasing, as well as some minors in the C++ output that were bothering me a bit :)