### PR TITLE
[ddl2cpp] Better handling of the name collision

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,7 +244,7 @@ jobs:
           bash ./.github/prepare-test-run.sh "MS SQL Server 2022" "./src/examples/test_chinook/Chinook_Sqlite.sql"
       - name: "Run ddl2cpp on Chinook db"
         run: |
-          /usr/local/bin/ddl2cpp --connection-string "${{ steps.setup.outputs.ODBC_CONNECTION_STRING }}" --make-aliases --database LightweightTest --schema dbo --foreign-key-collision-prefix fk_ --output ./src/examples/test_chinook/entities_compare
+          /usr/local/bin/ddl2cpp --connection-string "${{ steps.setup.outputs.ODBC_CONNECTION_STRING }}" --make-aliases --database LightweightTest --schema dbo --output ./src/examples/test_chinook/entities_compare
       - name: Compare files
         run: |
           declare -a files_to_compare=(

--- a/src/Lightweight/SqlDataBinder.hpp
+++ b/src/Lightweight/SqlDataBinder.hpp
@@ -21,3 +21,4 @@
 #include "DataBinder/StdString.hpp"
 #include "DataBinder/StdStringView.hpp"
 #include "DataBinder/StringLiteral.hpp"
+#include "DataBinder/UnicodeConverter.hpp"

--- a/src/Lightweight/Utils.hpp
+++ b/src/Lightweight/Utils.hpp
@@ -10,6 +10,7 @@
 #include <source_location>
 #include <string_view>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 
 #include <sql.h>
@@ -75,7 +76,6 @@ struct RecordTableNameImpl
             }();
     }();
 };
-
 
 // specialization for the case when we use tuple as
 // a record, then we usethe first element of the tuple
@@ -248,4 +248,24 @@ enum class FormatType : uint8_t
 };
 
 /// @brief Converts a string to a format that is more suitable for C++ code.
+LIGHTWEIGHT_API std::string FormatName(std::string const& name, FormatType formatType);
+
+/// @brief Converts a string to a format that is more suitable for C++ code.
 LIGHTWEIGHT_API std::string FormatName(std::string_view name, FormatType formatType);
+
+/// Maintains collisions to create unique names
+class UniqueNameBuilder
+{
+  public:
+    /// Tests if the given name is already registered.
+    [[nodiscard]] LIGHTWEIGHT_API bool IsColliding(std::string const& name) const noexcept;
+
+    /// Tries to declare a name and returns it, otherwise returns std::nullopt.
+    [[nodiscard]] LIGHTWEIGHT_API std::optional<std::string> TryDeclareName(std::string name);
+
+    /// Creates a name that is definitely not colliding.
+    [[nodiscard]] LIGHTWEIGHT_API std::string DeclareName(std::string name);
+
+  private:
+    std::unordered_map<std::string, size_t> _collisionMap;
+};

--- a/src/examples/test_chinook/README.md
+++ b/src/examples/test_chinook/README.md
@@ -28,5 +28,5 @@ sqlcmd -S localhost -U sa -P "QWERT1.qwerty" -C -d LightweightExample -i ./src/e
 Create header file for every table in the directory `./src/examples/test_chinook/entities` 
 
 ``` sh
-./build/src/tools/ddl2cpp --connection-string "DRIVER={ODBC Driver 18 for SQL Server};SERVER=localhost;UID=sa;PWD=QWERT1.qwerty;TrustServerCertificate=yes;DATABASE=LightweightExample" --make-aliases --database LightweightExample --schema dbo --foreign-key-collision-prefix fk_ --output ./src/examples/test_chinook/entities
+./build/src/tools/ddl2cpp --connection-string "DRIVER={ODBC Driver 18 for SQL Server};SERVER=localhost;UID=sa;PWD=QWERT1.qwerty;TrustServerCertificate=yes;DATABASE=LightweightExample" --make-aliases --database LightweightExample --schema dbo --output ./src/examples/test_chinook/entities
 ```

--- a/src/examples/test_chinook/main.cpp
+++ b/src/examples/test_chinook/main.cpp
@@ -15,10 +15,8 @@ int main()
 
     // helper function to create std::string from string_view<char16_t>
     auto const toString = [](std::basic_string_view<char16_t> str) {
-        std::string result;
-        result.reserve(str.size());
-        std::ranges::copy(str, std::back_inserter(result));
-        return result;
+        auto const u8Str = ToUtf8(str);
+        return std::string(reinterpret_cast<char const*>(u8Str.data()), u8Str.size());
     };
 
     // get all employees

--- a/src/tests/CoreTests.cpp
+++ b/src/tests/CoreTests.cpp
@@ -37,13 +37,13 @@ TEST_CASE_METHOD(SqlTestFixture, "NameFormatting", "[Format]")
 {
 
     const std::array inputNames = {
-        "test", "TEST_NR", "TEST-NR", "TEST NR", "TESTNR", "TestNr",
+        "test"sv, "TEST_NR"sv, "TEST-NR"sv, "TEST NR"sv, "TESTNR"sv, "TestNr"sv,
     };
     const std::array expectedCamelCase = {
-        "test", "testNr", "testNr", "testNr", "testnr", "testnr",
+        "test"sv, "testNr"sv, "testNr"sv, "testNr"sv, "testnr"sv, "testnr"sv,
     };
     const std::array expectedSnakeCase = {
-        "test", "test_nr", "test_nr", "test_nr", "testnr", "testnr",
+        "test"sv, "test_nr"sv, "test_nr"sv, "test_nr"sv, "testnr"sv, "testnr"sv,
     };
 
     for (size_t i = 0; i < inputNames.size(); ++i)
@@ -52,6 +52,25 @@ TEST_CASE_METHOD(SqlTestFixture, "NameFormatting", "[Format]")
         CHECK(FormatName(inputNames[i], FormatType::snakeCase) == expectedSnakeCase[i]);
         CHECK(FormatName(inputNames[i], FormatType::preserve) == inputNames[i]);
     }
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "UniqueNameBuilder", "[Utils]")
+{
+    UniqueNameBuilder uniqueNameBuilder;
+    REQUIRE(!uniqueNameBuilder.IsColliding("foo"));
+    REQUIRE(uniqueNameBuilder.DeclareName("foo") == "foo");
+    REQUIRE(uniqueNameBuilder.IsColliding("foo"));
+    REQUIRE(uniqueNameBuilder.DeclareName("foo") == "foo_2");
+    REQUIRE(uniqueNameBuilder.IsColliding("foo"));
+
+    REQUIRE(!uniqueNameBuilder.IsColliding("bar"));
+    REQUIRE(uniqueNameBuilder.DeclareName("bar") == "bar");
+    REQUIRE(uniqueNameBuilder.IsColliding("bar"));
+    REQUIRE(uniqueNameBuilder.DeclareName("foo") == "foo_3");
+
+    REQUIRE(uniqueNameBuilder.TryDeclareName("foo") == std::nullopt);
+    REQUIRE(uniqueNameBuilder.TryDeclareName("baz").value_or("error") == "baz");
+    REQUIRE(uniqueNameBuilder.TryDeclareName("baz") == std::nullopt);
 }
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlConnectionDataSource.FromConnectionString", "[SqlConnection]")

--- a/src/tools/ddl2cpp.cpp
+++ b/src/tools/ddl2cpp.cpp
@@ -209,8 +209,14 @@ class CxxModelPrinter
              << "#pragma once\n"
              << "\n";
 
+        std::vector<std::string> includes;
         for (auto const& [tableName, definition]: _definitions)
-            file << std::format("#include \"{}.hpp\"\n", aliasTableName(tableName));
+            includes.emplace_back(aliasTableName(std::format("{}.hpp", tableName)));
+
+        std::ranges::sort(includes);
+
+        for (auto const& include: includes)
+            file << std::format("#include \"{}\"\n", include);
 
         return {};
     }


### PR DESCRIPTION
* for plain data members use internal collision prefix `_c`
* for foreign keys use prefix defined by the user


### Changes

@Yaraslaut I've heavily updated this PR to some of the following:

* multi foreign key detection fixed
* foreign key (`ForeignKeyConstraint`) printing fixed/improved in std::formatter
* Fixes #268 
* Closes #272 
* .... more to be filled once having more time .....

```yaml
# Example on how to override column naming
ColumnNameOverrides:
    YOUR_WEIRD_TABLE_NAME:
        ABCDE_DEAD_BEAF: 'ActuallyReadableName'
        ANOTHER_COLUMN_NAME_THAT_IS_WEIRD: 'another_name'
```