### PR TITLE
Fix Update function to respect SqlRealName

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_COLOR_DIAGNOSTICS ON)
 include(ClangTidy)
 include(PedanticCompiler)
 
-find_package(reflection-cpp 0.1.0)
+find_package(reflection-cpp 0.4.0)
 
 if(reflection-cpp_FOUND)
     message(STATUS "reflection-cpp found: ${reflection-cpp_INCLUDE_DIRS}")

--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -1107,13 +1107,14 @@ void DataMapper::Update(Record& record)
 
     auto query = _connection.Query(RecordTableName<Record>).Update();
 
-    Reflection::CallOnMembers(record, [&query]<typename Name, typename FieldType>(Name const& name, FieldType const& field) {
+    Reflection::CallOnMembersWithoutName(record, [&query]<size_t I, typename FieldType>(FieldType const& field) {
         if (field.IsModified())
-            query.Set(name, SqlWildcard);
-        if constexpr (FieldType::IsPrimaryKey)
+            query.Set(FieldNameAt<I, Record>, SqlWildcard);
+        if constexpr (IsPrimaryKey<FieldType>)
             if (!field.IsModified())
-                std::ignore = query.Where(name, SqlWildcard);
+                std::ignore = query.Where(FieldNameAt<I, Record>, SqlWildcard);
     });
+
 
     _stmt.Prepare(query);
 


### PR DESCRIPTION
In update function we need to respect naming of the columns in the structure that can originate from SqlRealName 