### PR TITLE
Do not export std::formatters

### DIFF
--- a/src/Lightweight/DataBinder/SqlVariant.hpp
+++ b/src/Lightweight/DataBinder/SqlVariant.hpp
@@ -337,7 +337,7 @@ struct SqlVariant
 using SqlVariantRow = std::vector<SqlVariant>;
 
 template <>
-struct LIGHTWEIGHT_API std::formatter<SqlVariant>: formatter<string>
+struct std::formatter<SqlVariant>: formatter<string>
 {
     auto format(SqlVariant const& value, format_context& ctx) const -> format_context::iterator
     {

--- a/src/Lightweight/SqlConnectInfo.hpp
+++ b/src/Lightweight/SqlConnectInfo.hpp
@@ -53,7 +53,7 @@ struct [[nodiscard]] SqlConnectionDataSource
 using SqlConnectInfo = std::variant<SqlConnectionDataSource, SqlConnectionString>;
 
 template <>
-struct LIGHTWEIGHT_API std::formatter<SqlConnectInfo>: std::formatter<std::string>
+struct std::formatter<SqlConnectInfo>: std::formatter<std::string>
 {
     auto format(SqlConnectInfo const& info, format_context& ctx) const -> format_context::iterator
     {

--- a/src/Lightweight/SqlError.hpp
+++ b/src/Lightweight/SqlError.hpp
@@ -154,7 +154,7 @@ inline std::error_code make_error_code(SqlError e)
 }
 
 template <>
-struct LIGHTWEIGHT_API std::formatter<SqlError>: formatter<std::string>
+struct std::formatter<SqlError>: formatter<std::string>
 {
     auto format(SqlError value, format_context& ctx) const -> format_context::iterator
     {
@@ -164,7 +164,7 @@ struct LIGHTWEIGHT_API std::formatter<SqlError>: formatter<std::string>
 };
 
 template <>
-struct LIGHTWEIGHT_API std::formatter<SqlErrorInfo>: formatter<std::string>
+struct std::formatter<SqlErrorInfo>: formatter<std::string>
 {
     auto format(SqlErrorInfo const& info, format_context& ctx) const -> format_context::iterator
     {

--- a/src/Lightweight/SqlSchema.hpp
+++ b/src/Lightweight/SqlSchema.hpp
@@ -173,7 +173,7 @@ LIGHTWEIGHT_API std::vector<ForeignKeyConstraint> AllForeignKeysFrom(SqlStatemen
 } // namespace SqlSchema
 
 template <>
-struct LIGHTWEIGHT_API std::formatter<SqlSchema::FullyQualifiedTableName>: std::formatter<std::string>
+struct std::formatter<SqlSchema::FullyQualifiedTableName>: std::formatter<std::string>
 {
     auto format(SqlSchema::FullyQualifiedTableName const& value, format_context& ctx) const -> format_context::iterator
     {
@@ -190,7 +190,7 @@ struct LIGHTWEIGHT_API std::formatter<SqlSchema::FullyQualifiedTableName>: std::
 };
 
 template <>
-struct LIGHTWEIGHT_API std::formatter<SqlSchema::FullyQualifiedTableColumn>: std::formatter<std::string>
+struct std::formatter<SqlSchema::FullyQualifiedTableColumn>: std::formatter<std::string>
 {
     auto format(SqlSchema::FullyQualifiedTableColumn const& value, format_context& ctx) const -> format_context::iterator
     {
@@ -203,7 +203,7 @@ struct LIGHTWEIGHT_API std::formatter<SqlSchema::FullyQualifiedTableColumn>: std
 };
 
 template <>
-struct LIGHTWEIGHT_API std::formatter<SqlSchema::FullyQualifiedTableColumnSequence>: std::formatter<std::string>
+struct std::formatter<SqlSchema::FullyQualifiedTableColumnSequence>: std::formatter<std::string>
 {
     auto format(SqlSchema::FullyQualifiedTableColumnSequence const& value, format_context& ctx) const
         -> format_context::iterator

--- a/src/Lightweight/SqlServerType.hpp
+++ b/src/Lightweight/SqlServerType.hpp
@@ -18,7 +18,7 @@ enum class SqlServerType : uint8_t
 };
 
 template <>
-struct LIGHTWEIGHT_API std::formatter<SqlServerType>: std::formatter<std::string_view>
+struct std::formatter<SqlServerType>: std::formatter<std::string_view>
 {
     auto format(SqlServerType type, format_context& ctx) const -> format_context::iterator
     {

--- a/src/Lightweight/SqlTransaction.hpp
+++ b/src/Lightweight/SqlTransaction.hpp
@@ -151,7 +151,7 @@ inline SqlConnection& SqlTransaction::Connection() noexcept
 }
 
 template <>
-struct LIGHTWEIGHT_API std::formatter<SqlTransactionMode>: std::formatter<std::string_view>
+struct std::formatter<SqlTransactionMode>: std::formatter<std::string_view>
 {
     auto format(SqlTransactionMode value, format_context& ctx) const -> format_context::iterator
     {
@@ -174,7 +174,7 @@ struct LIGHTWEIGHT_API std::formatter<SqlTransactionMode>: std::formatter<std::s
 };
 
 template <>
-struct LIGHTWEIGHT_API std::formatter<SqlIsolationMode>: std::formatter<std::string_view>
+struct std::formatter<SqlIsolationMode>: std::formatter<std::string_view>
 {
     auto format(SqlIsolationMode value, format_context& ctx) const -> format_context::iterator
     {


### PR DESCRIPTION
We should not export std::formattters in the library since this will cause to create definitions for std::formatter for all needed structures, char for instance and then it will cause linking error because linker see two definitions of the same symbol in the application 