### PR TITLE
Add query single no relations function to load entry without relations

### DIFF
--- a/src/Lightweight/DataMapper/BelongsTo.hpp
+++ b/src/Lightweight/DataMapper/BelongsTo.hpp
@@ -117,10 +117,10 @@ class BelongsTo
     [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ValueType& MutableValue() noexcept { return _referencedFieldValue; }
 
     /// Retrieves a record from the relationship.
-    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord& Record() noexcept { RequireLoaded(); return _record.value(); }
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord& Record() { RequireLoaded(); return _record.value(); }
 
     /// Retrieves an immutable reference to the record from the relationship.
-    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord const& Record() const noexcept { RequireLoaded(); return _record.value(); }
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord const& Record() const { RequireLoaded(); return _record.value(); }
 
     /// Checks if the record is loaded into memory.
     [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr bool IsLoaded() const noexcept { return _loaded; }
@@ -135,10 +135,10 @@ class BelongsTo
     [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord const& operator*() const noexcept { RequireLoaded(); return _record.value(); }
 
     /// Retrieves the record from the relationship.
-    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord* operator->() noexcept { RequireLoaded(); return &_record.value(); }
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord* operator->() { RequireLoaded(); return &_record.value(); }
 
     /// Retrieves the record from the relationship.
-    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord const* operator->() const noexcept { RequireLoaded(); return &_record.value(); }
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord const* operator->() const { RequireLoaded(); return &_record.value(); }
 
     /// Checks if the field value is NULL.
     [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr bool operator!() const noexcept { return !_referencedFieldValue; }
@@ -150,6 +150,7 @@ class BelongsTo
     [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord& EmplaceRecord() { _loaded = true; return _record.emplace(); }
 
     LIGHTWEIGHT_FORCE_INLINE void BindOutputColumn(SQLSMALLINT outputIndex, SqlStatement& stmt) { stmt.BindOutputColumn(outputIndex, &_referencedFieldValue); }
+
     // clang-format on
 
     template <auto OtherReferencedField>

--- a/src/tests/Utils.hpp
+++ b/src/tests/Utils.hpp
@@ -634,3 +634,13 @@ inline auto MakeLargeText(size_t size)
     std::ranges::generate(text, [i = 0]() mutable { return static_cast<T>('A' + (i++ % 26)); });
     return text;
 }
+
+inline bool IsGithubActions()
+{
+#if defined(_WIN32) || defined(_WIN64)
+    char envBuffer[256];
+    return getenv_s(nullptr, envBuffer, sizeof(envBuffer), "GITHUB_ACTIONS") == 0 && std::string_view(envBuffer) == "true";
+#else
+    return std::getenv("GITHUB_ACTIONS") != nullptr && std::string_view(std::getenv("GITHUB_ACTIONS")) == "true";
+#endif
+}


### PR DESCRIPTION
Adds new function that can be used to avoid heavy template instantiation for some tables, main goal is to provide only one entry point for such behavior such that users are still encouraged to use laze evaluation of the relations when possible 