### PR TITLE
Make api of sql dynamic binary more restrictive to fix msvc compilatiion

### DIFF
--- a/src/examples/test_chinook/entities/Invoice.hpp
+++ b/src/examples/test_chinook/entities/Invoice.hpp
@@ -18,6 +18,6 @@ struct Invoice final
     Field<std::optional<SqlUtf16String<40>>, SqlRealName{"BillingState"}> BillingState;
     Field<std::optional<SqlUtf16String<40>>, SqlRealName{"BillingCountry"}> BillingCountry;
     Field<std::optional<SqlUtf16String<10>>, SqlRealName{"BillingPostalCode"}> BillingPostalCode;
-    Field<SqlNumeric<12, 2>, SqlRealName{"Total"}> Total;
+    Field<SqlNumeric<10, 2>, SqlRealName{"Total"}> Total;
 };
 

--- a/src/examples/test_chinook/entities/Invoiceline.hpp
+++ b/src/examples/test_chinook/entities/Invoiceline.hpp
@@ -14,7 +14,7 @@ struct Invoiceline final
     Field<int32_t, PrimaryKey::ServerSideAutoIncrement, SqlRealName{"InvoiceLineId"}> InvoiceLineId;
     BelongsTo<&Invoice::InvoiceId, SqlRealName{"InvoiceId"}> InvoiceId;
     BelongsTo<&Track::TrackId, SqlRealName{"TrackId"}> TrackId;
-    Field<SqlNumeric<12, 2>, SqlRealName{"UnitPrice"}> UnitPrice;
+    Field<SqlNumeric<10, 2>, SqlRealName{"UnitPrice"}> UnitPrice;
     Field<int32_t, SqlRealName{"Quantity"}> Quantity;
 };
 

--- a/src/examples/test_chinook/entities/Track.hpp
+++ b/src/examples/test_chinook/entities/Track.hpp
@@ -20,6 +20,6 @@ struct Track final
     Field<std::optional<SqlUtf16String<220>>, SqlRealName{"Composer"}> Composer;
     Field<int32_t, SqlRealName{"Milliseconds"}> Milliseconds;
     Field<std::optional<int32_t>, SqlRealName{"Bytes"}> Bytes;
-    Field<SqlNumeric<12, 2>, SqlRealName{"UnitPrice"}> UnitPrice;
+    Field<SqlNumeric<10, 2>, SqlRealName{"UnitPrice"}> UnitPrice;
 };
 

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -786,8 +786,8 @@ template <>
 struct TestTypeTraits<std::u8string>
 {
     static auto constexpr sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::NVarchar { 50 };
-    static auto const inline inputValue = u8"Hell\xc3\xb6"s;
-    static auto const inline expectedOutputValue = u8"Hell\xc3\xb6"s;
+    static auto const inline inputValue = u8"Hell\u00F6"s;
+    static auto const inline expectedOutputValue = u8"Hell\u00F6"s;
     static auto const inline outputInitializer = &MakeStringOuputInitializer<std::u8string>;
 };
 
@@ -795,8 +795,8 @@ template <>
 struct TestTypeTraits<std::u8string_view>
 {
     static constexpr auto sqlColumnTypeNameOverride = SqlColumnTypeDefinitions::NVarchar { 50 };
-    static auto const inline inputValue = std::u8string_view { u8"Hell\xc3\xb6" };
-    static auto const inline expectedOutputValue = std::u8string_view { u8"Hell\xc3\xb6" };
+    static auto const inline inputValue = std::u8string_view { u8"Hell\u00F6" };
+    static auto const inline expectedOutputValue = std::u8string_view { u8"Hell\u00F6" };
     static auto const inline outputInitializer = &MakeStringOuputInitializer<std::u8string>;
     using GetColumnTypeOverride = std::u8string;
 };

--- a/src/tools/ddl2cpp.cpp
+++ b/src/tools/ddl2cpp.cpp
@@ -54,70 +54,68 @@ std::string MakeType(SqlSchema::Column const& column, bool forceUnicodeTextColum
     };
 
     using namespace SqlColumnTypeDefinitions;
-    return optional(
-        std::visit(detail::overloaded {
-                       [](Bigint const&) -> std::string { return "int64_t"; },
-                       [](Binary const& type) -> std::string { return std::format("SqlBinary", type.size); },
-                       [](Bool const&) -> std::string { return "bool"; },
-                       [&](Char const& type) -> std::string {
-                           if (type.size == 1)
-                           {
-                               if (forceUnicodeTextColumn)
-                                   return "wchar_t";
-                               else
-                                   return "char";
-                           }
-                           else
-                           {
-                               if (forceUnicodeTextColumn)
-                                   return std::format("SqlWideString<{}>", type.size);
-                               else
-                                   return std::format("SqlAnsiString<{}>", type.size);
-                           }
-                       },
-                       [](Date const&) -> std::string { return "SqlDate"; },
-                       [](DateTime const&) -> std::string { return "SqlDateTime"; },
-                       [](Decimal const& type) -> std::string {
-                           return std::format("SqlNumeric<{}, {}>", type.precision + type.scale, type.precision);
-                       },
-                       [](Guid const&) -> std::string { return "SqlGuid"; },
-                       [](Integer const&) -> std::string { return "int32_t"; },
-                       [](NChar const& type) -> std::string {
-                           if (type.size == 1)
-                               return "char16_t";
-                           return std::format("SqlUtf16String<{}>", type.size);
-                       },
-                       [](NVarchar const& type) -> std::string { return std::format("SqlUtf16String<{}>", type.size); },
-                       [](Real const&) -> std::string { return "float"; },
-                       [](Smallint const&) -> std::string { return "int16_t"; },
-                       [=](Text const& type) -> std::string {
-                           if (forceUnicodeTextColumn)
-                               return std::format("SqlWideString<{}>", type.size);
-                           else
-                               return std::format("SqlAnsiString<{}>", type.size);
-                       },
-                       [](Time const&) -> std::string { return "SqlTime"; },
-                       [](Timestamp const&) -> std::string { return "SqlDateTime"; },
-                       [](Tinyint const&) -> std::string { return "uint8_t"; },
-                       [](VarBinary const& type) -> std::string { return std::format("SqlDynamicBinary<{}>", type.size); },
-                       [=](Varchar const& type) -> std::string {
-                           if (type.size > 0 && type.size <= SqlOptimalMaxColumnSize)
-                           {
-                               if (forceUnicodeTextColumn)
-                                   return std::format("SqlWideString<{}>", type.size);
-                               else
-                                   return std::format("SqlAnsiString<{}>", type.size);
-                           }
-                           else
-                           {
-                               if (forceUnicodeTextColumn)
-                                   return std::format("SqlDynamicWideString<{}>", type.size);
-                               else
-                                   return std::format("SqlDynamicAnsiString<{}>", type.size);
-                           }
-                       },
-                   },
-                   column.type));
+    return optional(std::visit(
+        detail::overloaded {
+            [](Bigint const&) -> std::string { return "int64_t"; },
+            [](Binary const& type) -> std::string { return std::format("SqlBinary", type.size); },
+            [](Bool const&) -> std::string { return "bool"; },
+            [&](Char const& type) -> std::string {
+                if (type.size == 1)
+                {
+                    if (forceUnicodeTextColumn)
+                        return "wchar_t";
+                    else
+                        return "char";
+                }
+                else
+                {
+                    if (forceUnicodeTextColumn)
+                        return std::format("SqlWideString<{}>", type.size);
+                    else
+                        return std::format("SqlAnsiString<{}>", type.size);
+                }
+            },
+            [](Date const&) -> std::string { return "SqlDate"; },
+            [](DateTime const&) -> std::string { return "SqlDateTime"; },
+            [](Decimal const& type) -> std::string { return std::format("SqlNumeric<{}, {}>", type.scale, type.precision); },
+            [](Guid const&) -> std::string { return "SqlGuid"; },
+            [](Integer const&) -> std::string { return "int32_t"; },
+            [](NChar const& type) -> std::string {
+                if (type.size == 1)
+                    return "char16_t";
+                return std::format("SqlUtf16String<{}>", type.size);
+            },
+            [](NVarchar const& type) -> std::string { return std::format("SqlUtf16String<{}>", type.size); },
+            [](Real const&) -> std::string { return "float"; },
+            [](Smallint const&) -> std::string { return "int16_t"; },
+            [=](Text const& type) -> std::string {
+                if (forceUnicodeTextColumn)
+                    return std::format("SqlWideString<{}>", type.size);
+                else
+                    return std::format("SqlAnsiString<{}>", type.size);
+            },
+            [](Time const&) -> std::string { return "SqlTime"; },
+            [](Timestamp const&) -> std::string { return "SqlDateTime"; },
+            [](Tinyint const&) -> std::string { return "uint8_t"; },
+            [](VarBinary const& type) -> std::string { return std::format("SqlDynamicBinary<{}>", type.size); },
+            [=](Varchar const& type) -> std::string {
+                if (type.size > 0 && type.size <= SqlOptimalMaxColumnSize)
+                {
+                    if (forceUnicodeTextColumn)
+                        return std::format("SqlWideString<{}>", type.size);
+                    else
+                        return std::format("SqlAnsiString<{}>", type.size);
+                }
+                else
+                {
+                    if (forceUnicodeTextColumn)
+                        return std::format("SqlDynamicWideString<{}>", type.size);
+                    else
+                        return std::format("SqlDynamicAnsiString<{}>", type.size);
+                }
+            },
+        },
+        column.type));
 }
 
 // "user_id" into "UserId"


### PR DESCRIPTION
do not inherit from vector and do not expose implicit casts into std::span that are problematic for msvc sfinae 