### PR TITLE
Improve support of SqlDateTime for MS SQL server via SQLSRV32.DLL (legacy)

### DIFF
--- a/src/Lightweight/DataBinder/Core.hpp
+++ b/src/Lightweight/DataBinder/Core.hpp
@@ -38,7 +38,9 @@ class LIGHTWEIGHT_API SqlDataBinderCallback
 
     virtual void PlanPostExecuteCallback(std::function<void()>&&) = 0;
     virtual void PlanPostProcessOutputColumn(std::function<void()>&&) = 0;
+
     [[nodiscard]] virtual SqlServerType ServerType() const noexcept = 0;
+    [[nodiscard]] virtual std::string const& DriverName() const noexcept = 0;
 };
 
 template <typename>

--- a/src/Lightweight/DataBinder/SqlDateTime.hpp
+++ b/src/Lightweight/DataBinder/SqlDateTime.hpp
@@ -7,6 +7,7 @@
 
 #include <chrono>
 #include <format>
+#include <string_view>
 
 #include <sql.h>
 #include <sqlext.h>
@@ -268,13 +269,14 @@ struct LIGHTWEIGHT_API SqlDataBinder<SqlDateTime>
 #if defined(_WIN32) || defined(_WIN64)
         // Microsoft Windows also chips with SQLSRV32.DLL, which is legacy, but seems to be used sometimes.
         // See: https://learn.microsoft.com/en-us/sql/connect/connect-history
-        if (cb.ServerType() == SqlServerType::MICROSOFT_SQL)
+        using namespace std::string_view_literals;
+        if (cb.ServerType() == SqlServerType::MICROSOFT_SQL && cb.DriverName() == "SQLSRV32.DLL"sv)
         {
             struct
             {
-                SQLSMALLINT sqlType {};
-                SQLULEN paramSize {};
-                SQLSMALLINT decimalDigits {};
+                SQLSMALLINT sqlType { SQL_TYPE_TIMESTAMP };
+                SQLULEN paramSize { 23 };
+                SQLSMALLINT decimalDigits { 3 };
                 SQLSMALLINT nullable {};
             } hints;
             auto const sqlDescribeParamResult =

--- a/src/Lightweight/SqlConnection.cpp
+++ b/src/Lightweight/SqlConnection.cpp
@@ -225,6 +225,16 @@ void SqlConnection::PostConnect()
     }
 
     m_queryFormatter = SqlQueryFormatter::Get(m_serverType);
+
+    // Get the driver name from the connection handle.
+    {
+        SQLCHAR driverName[128] {};
+        SQLSMALLINT driverNameLen = 0;
+
+        if (auto ret = SQLGetInfo(m_hDbc, SQL_DRIVER_NAME, driverName, sizeof(driverName), &driverNameLen);
+            SQL_SUCCEEDED(ret))
+            m_driverName = std::string(reinterpret_cast<char const*>(driverName), driverNameLen);
+    }
 }
 
 SqlErrorInfo SqlConnection::LastError() const

--- a/src/Lightweight/SqlConnection.hpp
+++ b/src/Lightweight/SqlConnection.hpp
@@ -33,7 +33,7 @@ class SqlMigrationQueryBuilder;
 class SqlQueryFormatter;
 
 /// @brief Represents a connection to a SQL database.
-class LIGHTWEIGHT_API SqlConnection final
+class SqlConnection final
 {
   public:
     /// @brief Constructs a new SQL connection to the default connection.
@@ -41,38 +41,38 @@ class LIGHTWEIGHT_API SqlConnection final
     /// The default connection is set via SetDefaultConnectInfo.
     /// In case the default connection is not set, the connection will fail.
     /// And in case the connection fails, the last error will be set.
-    SqlConnection();
+    LIGHTWEIGHT_API SqlConnection();
 
     /// @brief Constructs a new SQL connection to the given connect informaton.
     ///
     /// @param connectInfo The connection information to use. If not provided,
     ///                    no connection will be established.
-    explicit SqlConnection(std::optional<SqlConnectionString> connectInfo);
+    LIGHTWEIGHT_API explicit SqlConnection(std::optional<SqlConnectionString> connectInfo);
 
-    SqlConnection(SqlConnection&& /*other*/) noexcept;
-    SqlConnection& operator=(SqlConnection&& /*other*/) noexcept;
+    LIGHTWEIGHT_API SqlConnection(SqlConnection&& /*other*/) noexcept;
+    LIGHTWEIGHT_API SqlConnection& operator=(SqlConnection&& /*other*/) noexcept;
     SqlConnection(SqlConnection const& /*other*/) = delete;
     SqlConnection& operator=(SqlConnection const& /*other*/) = delete;
 
     /// Destructs this SQL connection object,
-    ~SqlConnection() noexcept;
+    LIGHTWEIGHT_API ~SqlConnection() noexcept;
 
     /// Retrieves the default connection information.
-    static SqlConnectionString const& DefaultConnectionString() noexcept;
+    LIGHTWEIGHT_API static SqlConnectionString const& DefaultConnectionString() noexcept;
 
     /// Sets the default connection information.
     ///
     /// @param connectionString The connection information to use.
-    static void SetDefaultConnectionString(SqlConnectionString const& connectionString) noexcept;
+    LIGHTWEIGHT_API static void SetDefaultConnectionString(SqlConnectionString const& connectionString) noexcept;
 
     /// Sets the default connection information as SqlConnectionDataSource.
-    static void SetDefaultDataSource(SqlConnectionDataSource const& dataSource) noexcept;
+    LIGHTWEIGHT_API static void SetDefaultDataSource(SqlConnectionDataSource const& dataSource) noexcept;
 
     /// Sets a callback to be called after each connection being established.
-    static void SetPostConnectedHook(std::function<void(SqlConnection&)> hook);
+    LIGHTWEIGHT_API static void SetPostConnectedHook(std::function<void(SqlConnection&)> hook);
 
     /// Resets the post connected hook.
-    static void ResetPostConnectedHook();
+    LIGHTWEIGHT_API static void ResetPostConnectedHook();
 
     /// @brief Retrieves the connection ID.
     ///
@@ -84,37 +84,40 @@ class LIGHTWEIGHT_API SqlConnection final
     }
 
     /// Closes the connection (attempting to put it back into the connect[[ion pool).
-    void Close() noexcept;
+    LIGHTWEIGHT_API void Close() noexcept;
 
     /// Connects to the given database with the given username and password.
     ///
     /// @retval true if the connection was successful.
     /// @retval false if the connection failed. Use LastError() to retrieve the error information.
-    bool Connect(SqlConnectionDataSource const& info) noexcept;
+    LIGHTWEIGHT_API bool Connect(SqlConnectionDataSource const& info) noexcept;
 
     /// Connects to the given database with the given username and password.
     ///
     /// @retval true if the connection was successful.
     /// @retval false if the connection failed. Use LastError() to retrieve the error information.
-    bool Connect(SqlConnectionString sqlConnectionString) noexcept;
+    LIGHTWEIGHT_API bool Connect(SqlConnectionString sqlConnectionString) noexcept;
 
     /// Retrieves the last error information with respect to this SQL connection handle.
-    [[nodiscard]] SqlErrorInfo LastError() const;
+    [[nodiscard]] LIGHTWEIGHT_API SqlErrorInfo LastError() const;
 
     /// Retrieves the name of the database in use.
-    [[nodiscard]] std::string DatabaseName() const;
+    [[nodiscard]] LIGHTWEIGHT_API std::string DatabaseName() const;
 
     /// Retrieves the name of the user.
-    [[nodiscard]] std::string UserName() const;
+    [[nodiscard]] LIGHTWEIGHT_API std::string UserName() const;
 
     /// Retrieves the name of the server.
-    [[nodiscard]] std::string ServerName() const;
+    [[nodiscard]] LIGHTWEIGHT_API std::string ServerName() const;
 
     /// Retrieves the reported server version.
-    [[nodiscard]] std::string ServerVersion() const;
+    [[nodiscard]] LIGHTWEIGHT_API std::string ServerVersion() const;
 
     /// Retrieves the type of the server.
     [[nodiscard]] SqlServerType ServerType() const noexcept;
+
+    /// Retrieves the name of the driver used for this connection.
+    [[nodiscard]] std::string const& DriverName() const noexcept;
 
     /// Retrieves a query formatter suitable for the SQL server being connected.
     [[nodiscard]] SqlQueryFormatter const& QueryFormatter() const noexcept;
@@ -123,28 +126,29 @@ class LIGHTWEIGHT_API SqlConnection final
     ///
     /// @param table The table to query.
     ///              If not provided, the query will be a generic query builder.
-    [[nodiscard]] SqlQueryBuilder Query(std::string_view const& table = {}) const;
+    [[nodiscard]] LIGHTWEIGHT_API SqlQueryBuilder Query(std::string_view const& table = {}) const;
 
     /// Creates a new query builder for the given table with an alias, compatible with the current connection.
     ///
     /// @param table The table to query.
     /// @param tableAlias The alias to use for the table.
-    [[nodiscard]] SqlQueryBuilder QueryAs(std::string_view const& table, std::string_view const& tableAlias) const;
+    [[nodiscard]] LIGHTWEIGHT_API SqlQueryBuilder QueryAs(std::string_view const& table,
+                                                          std::string_view const& tableAlias) const;
 
     /// Creates a new migration query builder, compatible the current connection.
-    [[nodiscard]] SqlMigrationQueryBuilder Migration() const;
+    [[nodiscard]] LIGHTWEIGHT_API SqlMigrationQueryBuilder Migration() const;
 
     /// Tests if a transaction is active.
-    [[nodiscard]] bool TransactionActive() const noexcept;
+    [[nodiscard]] LIGHTWEIGHT_API bool TransactionActive() const noexcept;
 
     /// Tests if transactions are allowed.
-    [[nodiscard]] bool TransactionsAllowed() const noexcept;
+    [[nodiscard]] LIGHTWEIGHT_API bool TransactionsAllowed() const noexcept;
 
     /// Tests if the connection is still active.
-    [[nodiscard]] bool IsAlive() const noexcept;
+    [[nodiscard]] LIGHTWEIGHT_API bool IsAlive() const noexcept;
 
     /// Retrieves the connection information.
-    [[nodiscard]] SqlConnectionString const& ConnectionString() const noexcept;
+    [[nodiscard]] LIGHTWEIGHT_API SqlConnectionString const& ConnectionString() const noexcept;
 
     /// Retrieves the native handle.
     [[nodiscard]] SQLHDBC NativeHandle() const noexcept
@@ -153,13 +157,14 @@ class LIGHTWEIGHT_API SqlConnection final
     }
 
     /// Retrieves the last time the connection was used.
-    [[nodiscard]] std::chrono::steady_clock::time_point LastUsed() const noexcept;
+    [[nodiscard]] LIGHTWEIGHT_API std::chrono::steady_clock::time_point LastUsed() const noexcept;
 
     /// Sets the last time the connection was used.
-    void SetLastUsed(std::chrono::steady_clock::time_point lastUsed) noexcept;
+    LIGHTWEIGHT_API void SetLastUsed(std::chrono::steady_clock::time_point lastUsed) noexcept;
 
     /// Checks the result of an SQL operation, and throws an exception if it is not successful.
-    void RequireSuccess(SQLRETURN sqlResult, std::source_location sourceLocation = std::source_location::current()) const;
+    LIGHTWEIGHT_API void RequireSuccess(SQLRETURN sqlResult,
+                                        std::source_location sourceLocation = std::source_location::current()) const;
 
   private:
     void PostConnect();
@@ -170,6 +175,7 @@ class LIGHTWEIGHT_API SqlConnection final
     uint64_t m_connectionId;
     SqlServerType m_serverType = SqlServerType::UNKNOWN;
     SqlQueryFormatter const* m_queryFormatter {};
+    std::string m_driverName;
 
     struct Data;
     Data* m_data {};
@@ -178,6 +184,11 @@ class LIGHTWEIGHT_API SqlConnection final
 inline SqlServerType SqlConnection::ServerType() const noexcept
 {
     return m_serverType;
+}
+
+inline std::string const& SqlConnection::DriverName() const noexcept
+{
+    return m_driverName;
 }
 
 inline SqlQueryFormatter const& SqlConnection::QueryFormatter() const noexcept

--- a/src/Lightweight/SqlStatement.cpp
+++ b/src/Lightweight/SqlStatement.cpp
@@ -56,6 +56,11 @@ SqlServerType SqlStatement::ServerType() const noexcept
     return m_connection->ServerType();
 }
 
+std::string const& SqlStatement::DriverName() const noexcept
+{
+    return m_connection->DriverName();
+}
+
 SqlStatement::SqlStatement():
     m_data { new Data {
                  .ownedConnection = SqlConnection(),

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -256,6 +256,7 @@ class [[nodiscard]] SqlStatement final: public SqlDataBinderCallback
     LIGHTWEIGHT_API void PlanPostExecuteCallback(std::function<void()>&& cb) override;
     LIGHTWEIGHT_API void PlanPostProcessOutputColumn(std::function<void()>&& cb) override;
     [[nodiscard]] LIGHTWEIGHT_API SqlServerType ServerType() const noexcept override;
+    [[nodiscard]] LIGHTWEIGHT_API std::string const& DriverName() const noexcept override;
     LIGHTWEIGHT_API void ProcessPostExecuteCallbacks();
 
     LIGHTWEIGHT_API void RequireIndicators();


### PR DESCRIPTION
This pull request introduces several enhancements and updates to the `Lightweight` SQL library, focusing on improving driver-specific handling, extending API functionality, and ensuring consistent visibility of exported functions and classes. Below is a summary of the most important changes, grouped by theme:

### Driver-Specific Enhancements:
* Added a new `DriverName()` method to `SqlConnection` and `SqlStatement` to retrieve the name of the SQL driver being used. This enables more precise handling of driver-specific behaviors. (`src/Lightweight/SqlConnection.hpp` [[1]](diffhunk://#diff-ab16d2e8579f827be5bf0a0bccf6f10cd4f47a4b9c1beaaf09f18c45cfe4c219R176) [[2]](diffhunk://#diff-ab16d2e8579f827be5bf0a0bccf6f10cd4f47a4b9c1beaaf09f18c45cfe4c219R187-R191); `src/Lightweight/SqlStatement.cpp` [[3]](diffhunk://#diff-5642ceb28e4a081ecd1b77e48ae2682ab21437f3d14e422daa173c54d1be54aeR59-R63); `src/Lightweight/SqlStatement.hpp` [[4]](diffhunk://#diff-9521ecee4619633fd939d5fb8a26a6c397750a3aad5444fb0407ef2b4cbc8623L258-R259)
* Updated the `SqlDataBinderCallback` interface to include the `DriverName()` method, allowing derived classes to access driver details. (`src/Lightweight/DataBinder/Core.hpp` [src/Lightweight/DataBinder/Core.hppR41-R43](diffhunk://#diff-344738c04a3e9e66046fd8b5ec5659370d16fd357b5a7093a4c9d93bb9d64595R41-R43))
* Modified the `SqlDataBinder<SqlDateTime>` implementation to handle the legacy `SQLSRV32.DLL` driver specifically when connecting to Microsoft SQL servers. (`src/Lightweight/DataBinder/SqlDateTime.hpp` [src/Lightweight/DataBinder/SqlDateTime.hppL267-R269](diffhunk://#diff-e23b7e2b389816742787588b84b20b2728ba9aae4d7f7f4072e5b7852acc1716L267-R269))

### API Visibility and Consistency:
* Standardized the use of the `LIGHTWEIGHT_API` macro for all public methods and constructors in the `SqlConnection` class to ensure proper symbol export in shared library builds. (`src/Lightweight/SqlConnection.hpp` [[1]](diffhunk://#diff-ab16d2e8579f827be5bf0a0bccf6f10cd4f47a4b9c1beaaf09f18c45cfe4c219L36-R75) [[2]](diffhunk://#diff-ab16d2e8579f827be5bf0a0bccf6f10cd4f47a4b9c1beaaf09f18c45cfe4c219L87-R150) [[3]](diffhunk://#diff-ab16d2e8579f827be5bf0a0bccf6f10cd4f47a4b9c1beaaf09f18c45cfe4c219L156-R165)

### Functional Improvements:
* Enhanced the `PostConnect()` method in `SqlConnection` to retrieve and store the driver name from the connection handle, improving runtime introspection capabilities. (`src/Lightweight/SqlConnection.cpp` [src/Lightweight/SqlConnection.cppR228-R236](diffhunk://#diff-bfc77c166d6fdefe7325d13385502208d89c25a10680697a1eade182a7b71e9cR228-R236))

### Minor Updates:
* Added a missing `#include <string_view>` directive in `SqlDateTime.hpp` to support the use of `std::string_view`. (`src/Lightweight/DataBinder/SqlDateTime.hpp` [src/Lightweight/DataBinder/SqlDateTime.hppR10](diffhunk://#diff-e23b7e2b389816742787588b84b20b2728ba9aae4d7f7f4072e5b7852acc1716R10))
* Adjusted the SQL type used in parameter binding for `SqlDateTime` to `SQL_TYPE_TIMESTAMP` for improved compatibility. (`src/Lightweight/DataBinder/SqlDateTime.hpp` [src/Lightweight/DataBinder/SqlDateTime.hppL284-R286](diffhunk://#diff-e23b7e2b389816742787588b84b20b2728ba9aae4d7f7f4072e5b7852acc1716L284-R286))

These changes collectively enhance the library's flexibility, maintainability, and compatibility with especially SQLSRV32.DLL driver (legacy!) on Windows for MS SQL Server.