### PR TITLE
SqlDynamicString: add str() to make type interchangable with SqlFixedString

### DIFF
--- a/src/Lightweight/DataBinder/SqlDynamicString.hpp
+++ b/src/Lightweight/DataBinder/SqlDynamicString.hpp
@@ -59,6 +59,12 @@ class SqlDynamicString
     {
     }
 
+    /// Returns a string view of the string.
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr std::basic_string_view<T> str() const noexcept
+    {
+        return std::basic_string_view<T> { data(), size() };
+    }
+
     /// Retrieves the string's inner value (std::basic_string<T>).
     [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE string_type const& value() const noexcept
     {


### PR DESCRIPTION
Internally, we are using SqlFixedString a lot, currently, but we may be SqlDynamicString for any column larger than N (e.g. 32), so it should be possible to use both types interchangibly, i.e., the API should look as similar as possible.

I *think*, the only thing missing is `str()` though. :)