### PR TITLE
Adds SqlFixedStringMaxSize configuration key to allow tweaking the limit of fixed-string columns. Dynamic string allocation is used otherwise.

### DIFF
--- a/src/examples/test_chinook/entities/Album.hpp
+++ b/src/examples/test_chinook/entities/Album.hpp
@@ -11,7 +11,7 @@ struct Album final
     static constexpr std::string_view TableName = "Album";
 
     Field<int32_t, PrimaryKey::ServerSideAutoIncrement, SqlRealName{"AlbumId"}> AlbumId;
-    Field<SqlUtf16String<160>, SqlRealName{"Title"}> Title;
+    Field<SqlDynamicUtf16String<160>, SqlRealName{"Title"}> Title;
     BelongsTo<&Artist::ArtistId, SqlRealName{"ArtistId"}> ArtistId;
 };
 

--- a/src/examples/test_chinook/entities/Artist.hpp
+++ b/src/examples/test_chinook/entities/Artist.hpp
@@ -9,6 +9,6 @@ struct Artist final
     static constexpr std::string_view TableName = "Artist";
 
     Field<int32_t, PrimaryKey::ServerSideAutoIncrement, SqlRealName{"ArtistId"}> ArtistId;
-    Field<std::optional<SqlUtf16String<120>>, SqlRealName{"Name"}> Name;
+    Field<std::optional<SqlDynamicUtf16String<120>>, SqlRealName{"Name"}> Name;
 };
 

--- a/src/examples/test_chinook/entities/Customer.hpp
+++ b/src/examples/test_chinook/entities/Customer.hpp
@@ -11,17 +11,17 @@ struct Customer final
     static constexpr std::string_view TableName = "Customer";
 
     Field<int32_t, PrimaryKey::ServerSideAutoIncrement, SqlRealName{"CustomerId"}> CustomerId;
-    Field<SqlUtf16String<40>, SqlRealName{"FirstName"}> FirstName;
-    Field<SqlUtf16String<20>, SqlRealName{"LastName"}> LastName;
-    Field<std::optional<SqlUtf16String<80>>, SqlRealName{"Company"}> Company;
-    Field<std::optional<SqlUtf16String<70>>, SqlRealName{"Address"}> Address;
-    Field<std::optional<SqlUtf16String<40>>, SqlRealName{"City"}> City;
-    Field<std::optional<SqlUtf16String<40>>, SqlRealName{"State"}> State;
-    Field<std::optional<SqlUtf16String<40>>, SqlRealName{"Country"}> Country;
-    Field<std::optional<SqlUtf16String<10>>, SqlRealName{"PostalCode"}> PostalCode;
-    Field<std::optional<SqlUtf16String<24>>, SqlRealName{"Phone"}> Phone;
-    Field<std::optional<SqlUtf16String<24>>, SqlRealName{"Fax"}> Fax;
-    Field<SqlUtf16String<60>, SqlRealName{"Email"}> Email;
+    Field<SqlDynamicUtf16String<40>, SqlRealName{"FirstName"}> FirstName;
+    Field<SqlDynamicUtf16String<20>, SqlRealName{"LastName"}> LastName;
+    Field<std::optional<SqlDynamicUtf16String<80>>, SqlRealName{"Company"}> Company;
+    Field<std::optional<SqlDynamicUtf16String<70>>, SqlRealName{"Address"}> Address;
+    Field<std::optional<SqlDynamicUtf16String<40>>, SqlRealName{"City"}> City;
+    Field<std::optional<SqlDynamicUtf16String<40>>, SqlRealName{"State"}> State;
+    Field<std::optional<SqlDynamicUtf16String<40>>, SqlRealName{"Country"}> Country;
+    Field<std::optional<SqlDynamicUtf16String<10>>, SqlRealName{"PostalCode"}> PostalCode;
+    Field<std::optional<SqlDynamicUtf16String<24>>, SqlRealName{"Phone"}> Phone;
+    Field<std::optional<SqlDynamicUtf16String<24>>, SqlRealName{"Fax"}> Fax;
+    Field<SqlDynamicUtf16String<60>, SqlRealName{"Email"}> Email;
     BelongsTo<&Employee::EmployeeId, SqlRealName{"SupportRepId"}> SupportRepId;
 };
 

--- a/src/examples/test_chinook/entities/Employee.hpp
+++ b/src/examples/test_chinook/entities/Employee.hpp
@@ -9,19 +9,19 @@ struct Employee final
     static constexpr std::string_view TableName = "Employee";
 
     Field<int32_t, PrimaryKey::ServerSideAutoIncrement, SqlRealName{"EmployeeId"}> EmployeeId;
-    Field<SqlUtf16String<20>, SqlRealName{"LastName"}> LastName;
-    Field<SqlUtf16String<20>, SqlRealName{"FirstName"}> FirstName;
-    Field<std::optional<SqlUtf16String<30>>, SqlRealName{"Title"}> Title;
+    Field<SqlDynamicUtf16String<20>, SqlRealName{"LastName"}> LastName;
+    Field<SqlDynamicUtf16String<20>, SqlRealName{"FirstName"}> FirstName;
+    Field<std::optional<SqlDynamicUtf16String<30>>, SqlRealName{"Title"}> Title;
     Field<std::optional<int32_t>, SqlRealName{"ReportsTo"}> ReportsTo; // NB: This is also a foreign key
     Field<std::optional<SqlDateTime>, SqlRealName{"BirthDate"}> BirthDate;
     Field<std::optional<SqlDateTime>, SqlRealName{"HireDate"}> HireDate;
-    Field<std::optional<SqlUtf16String<70>>, SqlRealName{"Address"}> Address;
-    Field<std::optional<SqlUtf16String<40>>, SqlRealName{"City"}> City;
-    Field<std::optional<SqlUtf16String<40>>, SqlRealName{"State"}> State;
-    Field<std::optional<SqlUtf16String<40>>, SqlRealName{"Country"}> Country;
-    Field<std::optional<SqlUtf16String<10>>, SqlRealName{"PostalCode"}> PostalCode;
-    Field<std::optional<SqlUtf16String<24>>, SqlRealName{"Phone"}> Phone;
-    Field<std::optional<SqlUtf16String<24>>, SqlRealName{"Fax"}> Fax;
-    Field<std::optional<SqlUtf16String<60>>, SqlRealName{"Email"}> Email;
+    Field<std::optional<SqlDynamicUtf16String<70>>, SqlRealName{"Address"}> Address;
+    Field<std::optional<SqlDynamicUtf16String<40>>, SqlRealName{"City"}> City;
+    Field<std::optional<SqlDynamicUtf16String<40>>, SqlRealName{"State"}> State;
+    Field<std::optional<SqlDynamicUtf16String<40>>, SqlRealName{"Country"}> Country;
+    Field<std::optional<SqlDynamicUtf16String<10>>, SqlRealName{"PostalCode"}> PostalCode;
+    Field<std::optional<SqlDynamicUtf16String<24>>, SqlRealName{"Phone"}> Phone;
+    Field<std::optional<SqlDynamicUtf16String<24>>, SqlRealName{"Fax"}> Fax;
+    Field<std::optional<SqlDynamicUtf16String<60>>, SqlRealName{"Email"}> Email;
 };
 

--- a/src/examples/test_chinook/entities/Genre.hpp
+++ b/src/examples/test_chinook/entities/Genre.hpp
@@ -9,6 +9,6 @@ struct Genre final
     static constexpr std::string_view TableName = "Genre";
 
     Field<int32_t, PrimaryKey::ServerSideAutoIncrement, SqlRealName{"GenreId"}> GenreId;
-    Field<std::optional<SqlUtf16String<120>>, SqlRealName{"Name"}> Name;
+    Field<std::optional<SqlDynamicUtf16String<120>>, SqlRealName{"Name"}> Name;
 };
 

--- a/src/examples/test_chinook/entities/Invoice.hpp
+++ b/src/examples/test_chinook/entities/Invoice.hpp
@@ -13,11 +13,11 @@ struct Invoice final
     Field<int32_t, PrimaryKey::ServerSideAutoIncrement, SqlRealName{"InvoiceId"}> InvoiceId;
     BelongsTo<&Customer::CustomerId, SqlRealName{"CustomerId"}> CustomerId;
     Field<SqlDateTime, SqlRealName{"InvoiceDate"}> InvoiceDate;
-    Field<std::optional<SqlUtf16String<70>>, SqlRealName{"BillingAddress"}> BillingAddress;
-    Field<std::optional<SqlUtf16String<40>>, SqlRealName{"BillingCity"}> BillingCity;
-    Field<std::optional<SqlUtf16String<40>>, SqlRealName{"BillingState"}> BillingState;
-    Field<std::optional<SqlUtf16String<40>>, SqlRealName{"BillingCountry"}> BillingCountry;
-    Field<std::optional<SqlUtf16String<10>>, SqlRealName{"BillingPostalCode"}> BillingPostalCode;
+    Field<std::optional<SqlDynamicUtf16String<70>>, SqlRealName{"BillingAddress"}> BillingAddress;
+    Field<std::optional<SqlDynamicUtf16String<40>>, SqlRealName{"BillingCity"}> BillingCity;
+    Field<std::optional<SqlDynamicUtf16String<40>>, SqlRealName{"BillingState"}> BillingState;
+    Field<std::optional<SqlDynamicUtf16String<40>>, SqlRealName{"BillingCountry"}> BillingCountry;
+    Field<std::optional<SqlDynamicUtf16String<10>>, SqlRealName{"BillingPostalCode"}> BillingPostalCode;
     Field<SqlNumeric<10, 2>, SqlRealName{"Total"}> Total;
 };
 

--- a/src/examples/test_chinook/entities/Mediatype.hpp
+++ b/src/examples/test_chinook/entities/Mediatype.hpp
@@ -9,6 +9,6 @@ struct Mediatype final
     static constexpr std::string_view TableName = "MediaType";
 
     Field<int32_t, PrimaryKey::ServerSideAutoIncrement, SqlRealName{"MediaTypeId"}> MediaTypeId;
-    Field<std::optional<SqlUtf16String<120>>, SqlRealName{"Name"}> Name;
+    Field<std::optional<SqlDynamicUtf16String<120>>, SqlRealName{"Name"}> Name;
 };
 

--- a/src/examples/test_chinook/entities/Playlist.hpp
+++ b/src/examples/test_chinook/entities/Playlist.hpp
@@ -9,6 +9,6 @@ struct Playlist final
     static constexpr std::string_view TableName = "Playlist";
 
     Field<int32_t, PrimaryKey::ServerSideAutoIncrement, SqlRealName{"PlaylistId"}> PlaylistId;
-    Field<std::optional<SqlUtf16String<120>>, SqlRealName{"Name"}> Name;
+    Field<std::optional<SqlDynamicUtf16String<120>>, SqlRealName{"Name"}> Name;
 };
 

--- a/src/examples/test_chinook/entities/Track.hpp
+++ b/src/examples/test_chinook/entities/Track.hpp
@@ -13,11 +13,11 @@ struct Track final
     static constexpr std::string_view TableName = "Track";
 
     Field<int32_t, PrimaryKey::ServerSideAutoIncrement, SqlRealName{"TrackId"}> TrackId;
-    Field<SqlUtf16String<200>, SqlRealName{"Name"}> Name;
+    Field<SqlDynamicUtf16String<200>, SqlRealName{"Name"}> Name;
     BelongsTo<&Album::AlbumId, SqlRealName{"AlbumId"}> AlbumId;
     BelongsTo<&Mediatype::MediaTypeId, SqlRealName{"MediaTypeId"}> MediaTypeId;
     BelongsTo<&Genre::GenreId, SqlRealName{"GenreId"}> GenreId;
-    Field<std::optional<SqlUtf16String<220>>, SqlRealName{"Composer"}> Composer;
+    Field<std::optional<SqlDynamicUtf16String<220>>, SqlRealName{"Composer"}> Composer;
     Field<int32_t, SqlRealName{"Milliseconds"}> Milliseconds;
     Field<std::optional<int32_t>, SqlRealName{"Bytes"}> Bytes;
     Field<SqlNumeric<10, 2>, SqlRealName{"UnitPrice"}> UnitPrice;

--- a/src/examples/test_chinook/main.cpp
+++ b/src/examples/test_chinook/main.cpp
@@ -13,8 +13,8 @@ int main()
 
     SqlConnection::SetDefaultConnectionString(SqlConnectionString {
         "DRIVER={ODBC Driver 18 for SQL "
-          "Server};SERVER=localhost;UID=SA;PWD=Qwerty1.;TrustServerCertificate=yes;DATABASE=LightweightTest" });
-   //"Server};SERVER=localhost;UID=SA;PWD=BlahThat.;TrustServerCertificate=yes;DATABASE=LightweightTest" });
+    //       "Server};SERVER=localhost;UID=SA;PWD=Qwerty1.;TrustServerCertificate=yes;DATABASE=LightweightTest" });
+  "Server};SERVER=localhost;UID=SA;PWD=BlahThat.;TrustServerCertificate=yes;DATABASE=LightweightTest" });
     auto dm = DataMapper();
 
     // helper function to create std::string from string_view<char16_t>


### PR DESCRIPTION
Relevant for reducing memory footprint of super large tables