### PR TITLE
Add support for NULL-able BelongsTo<> values.

### DIFF
--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -940,7 +940,7 @@ std::string DataMapper::Inspect(Record const& record)
 
         if constexpr (FieldWithStorage<Value>)
         {
-            if constexpr (Value::IsOptional && !(IsBelongsTo<Value>) )
+            if constexpr (Value::IsOptional)
             {
                 if (!value.Value().has_value())
                 {

--- a/src/Lightweight/DataMapper/HasMany.hpp
+++ b/src/Lightweight/DataMapper/HasMany.hpp
@@ -100,15 +100,20 @@ class HasMany
     [[nodiscard]] const_iterator begin() const noexcept;
     [[nodiscard]] const_iterator end() const noexcept;
 
-    constexpr std::weak_ordering operator<=>(HasMany<OtherRecord> const& other) const noexcept = default;
-    constexpr bool operator==(HasMany<OtherRecord> const& other) const noexcept = default;
-    constexpr bool operator!=(HasMany<OtherRecord> const& other) const noexcept = default;
+    constexpr std::weak_ordering operator<=>(HasMany const& other) const noexcept = default;
+    constexpr bool operator==(HasMany const& other) const noexcept = default;
+    constexpr bool operator!=(HasMany const& other) const noexcept = default;
 
     struct Loader
     {
         std::function<size_t()> count {};
         std::function<void()> all {};
         std::function<void(std::function<void(ReferencedRecord const&)>)> each {};
+
+        std::weak_ordering operator<=>(Loader const& /*other*/) const noexcept
+        {
+            return std::weak_ordering::equivalent; // Loader is not comparable, so we return equivalent
+        }
     };
 
     /// Used internally to configure on-demand loading of the records.

--- a/src/examples/test_chinook/entities/Customer.hpp
+++ b/src/examples/test_chinook/entities/Customer.hpp
@@ -22,6 +22,6 @@ struct Customer final
     Field<std::optional<SqlDynamicUtf16String<24>>, SqlRealName{"Phone"}> Phone;
     Field<std::optional<SqlDynamicUtf16String<24>>, SqlRealName{"Fax"}> Fax;
     Field<SqlDynamicUtf16String<60>, SqlRealName{"Email"}> Email;
-    BelongsTo<&Employee::EmployeeId, SqlRealName{"SupportRepId"}> SupportRepId;
+    BelongsTo<&Employee::EmployeeId, SqlRealName{"SupportRepId"}, SqlNullable::Null> SupportRepId;
 };
 

--- a/src/examples/test_chinook/entities/Track.hpp
+++ b/src/examples/test_chinook/entities/Track.hpp
@@ -14,9 +14,9 @@ struct Track final
 
     Field<int32_t, PrimaryKey::ServerSideAutoIncrement, SqlRealName{"TrackId"}> TrackId;
     Field<SqlDynamicUtf16String<200>, SqlRealName{"Name"}> Name;
-    BelongsTo<&Album::AlbumId, SqlRealName{"AlbumId"}> AlbumId;
+    BelongsTo<&Album::AlbumId, SqlRealName{"AlbumId"}, SqlNullable::Null> AlbumId;
     BelongsTo<&Mediatype::MediaTypeId, SqlRealName{"MediaTypeId"}> MediaTypeId;
-    BelongsTo<&Genre::GenreId, SqlRealName{"GenreId"}> GenreId;
+    BelongsTo<&Genre::GenreId, SqlRealName{"GenreId"}, SqlNullable::Null> GenreId;
     Field<std::optional<SqlDynamicUtf16String<220>>, SqlRealName{"Composer"}> Composer;
     Field<int32_t, SqlRealName{"Milliseconds"}> Milliseconds;
     Field<std::optional<int32_t>, SqlRealName{"Bytes"}> Bytes;

--- a/src/tests/DataMapperTests.cpp
+++ b/src/tests/DataMapperTests.cpp
@@ -1748,14 +1748,15 @@ TEST_CASE_METHOD(SqlTestFixture, "TestMessageStructTo", "[DataMapper]")
     auto dm = DataMapper {};
 
     dm.CreateTable<MessagesStruct>();
-    // create a table for MessageStructTo
-    // where foreign key can be null
-    SqlStatement(dm.Connection()).ExecuteDirect(R"SQL(
-                             CREATE TABLE MessageStructTo (
-                                 "primary_key" GUID PRIMARY KEY,
-                                 "log_key" GUID,
-                                 FOREIGN KEY ("log_key") REFERENCES MessagesStruct ("primary_key")
-                             ))SQL");
+
+    SqlStatement(dm.Connection()).MigrateDirect([](SqlMigrationQueryBuilder& migration) {
+        using namespace SqlColumnTypeDefinitions;
+        migration.CreateTable("MessageStructTo")
+            .PrimaryKey("primary_key", Guid {})
+            .ForeignKey("log_key",
+                        Guid {},
+                        SqlForeignKeyReferenceDefinition { .tableName = "MessagesStruct", .columnName = "primary_key" });
+    });
 
     MessagesStruct message {
         .id = SqlGuid::TryParse("B16BEF38-5839-11F0-D290-74563C35FB03").value(),

--- a/src/tests/DataMapperTests.cpp
+++ b/src/tests/DataMapperTests.cpp
@@ -1740,7 +1740,7 @@ TEST_CASE_METHOD(SqlTestFixture, "TestMessageStruct", "[DataMapper]")
 struct MessageStructTo
 {
     Field<SqlGuid, PrimaryKey::AutoAssign, SqlRealName { "primary_key" }> id;
-    BelongsTo<&MessagesStruct::id, SqlRealName { "log_key" }> log_message {};
+    BelongsTo<&MessagesStruct::id, SqlRealName { "log_key" }, SqlNullable::Null> log_message {};
 };
 
 TEST_CASE_METHOD(SqlTestFixture, "TestMessageStructTo", "[DataMapper]")
@@ -1758,23 +1758,32 @@ TEST_CASE_METHOD(SqlTestFixture, "TestMessageStructTo", "[DataMapper]")
                         SqlForeignKeyReferenceDefinition { .tableName = "MessagesStruct", .columnName = "primary_key" });
     });
 
-    MessagesStruct message {
+    // Create a message to test the BelongsTo relation
+    auto const message = MessagesStruct {
         .id = SqlGuid::TryParse("B16BEF38-5839-11F0-D290-74563C35FB03").value(),
         .timeStamp = SqlDateTime::Now(),
         .message = L"Hello, World!",
     };
-    dm.Create(message);
+    dm.CreateExplicit(message);
 
-    MessageStructTo to1 { .id = SqlGuid::Create(), .log_message = message.id.Value() };
-    dm.Create(to1);
-    SqlStatement(dm.Connection())
-        .ExecuteDirect(
-            R"SQL( INSERT INTO MessageStructTo (primary_key, log_key) VALUES ("B16BEF38-5839-11F0-D290-74563C35FB03", NULL) )SQL");
+    SECTION("Test BelongsTo with non-NULL relation")
+    {
+        auto const to = MessageStructTo { .id = SqlGuid::Create(), .log_message = message.id.Value() };
+        dm.CreateExplicit(to);
+        auto const queriedTo = dm.QuerySingle<MessageStructTo>(to.id).value();
+        REQUIRE(queriedTo.id.Value() == to.id.Value());
+        REQUIRE(queriedTo.log_message.Value().value() == message.id.Value());
+    }
 
-    REQUIRE(dm.QuerySingle<MessageStructTo>(to1.id).value().log_message->id.Value() == message.id.Value());
-
-    auto const guid = SqlGuid::TryParse("B16BEF38-5839-11F0-D290-74563C35FB03").value();
-    REQUIRE(dm.QuerySingle<MessageStructTo>(guid).value().id.Value() == guid);
+    SECTION("Test BelongsTo with NULL relation")
+    {
+        MessageStructTo to { .id = SqlGuid::Create(), .log_message = std::nullopt };
+        dm.Create(to);
+        auto const queriedTo = dm.QuerySingle<MessageStructTo>(to.id).value();
+        REQUIRE(queriedTo.id.Value() == to.id.Value());
+        REQUIRE(!queriedTo.log_message.IsLoaded());
+        REQUIRE(!queriedTo.log_message.Value().has_value());
+    }
 }
 
 // NOLINTEND(bugprone-unchecked-optional-access)

--- a/src/tests/DataMapperTests.cpp
+++ b/src/tests/DataMapperTests.cpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#include "Lightweight/DataBinder/SqlGuid.hpp"
 #include "Utils.hpp"
 
 #include <Lightweight/Lightweight.hpp>

--- a/src/tools/test_chinook.sh
+++ b/src/tools/test_chinook.sh
@@ -10,7 +10,12 @@ DDL2CPP="${DDL2CPP:-${BUILD_DIR}/src/tools/ddl2cpp}"
 
 run_test_chinook() {
     # run ddl2cpp to create files
-    ${DDL2CPP} --connection-string "${ODBC_CONNECTION_STRING}" --make-aliases --database LightweightTest --schema dbo  --output "${PROJECT_ROOT}/src/examples/test_chinook/entities_compare"
+    ${DDL2CPP} \
+        --connection-string "${ODBC_CONNECTION_STRING}" \
+        --make-aliases \
+        --database LightweightTest \
+        --schema dbo \
+        --output "${PROJECT_ROOT}/src/examples/test_chinook/entities_compare"
 
     # check the diff between the generated files and the expected files
     # list of files to check Album.hpp Artist.hpp Customer.hpp Employee.hpp Genre.hpp Invoice.hpp InvoiceLine.hpp MediaType.hpp Playlist.hpp PlaylistTrack.hpp Track.hpp
@@ -45,9 +50,6 @@ run_test_chinook() {
             echo "File ${file} not found"
         fi
     done
-
-
-
 }
 
 run_test_chinook


### PR DESCRIPTION
This pull request introduces enhancements to the `BelongsTo` relationship in the `DataMapper` library, adds new test cases to validate nullable foreign key behavior, and updates tools for code generation. The key changes include adding support for nullable foreign keys, improving type safety, and extending test coverage.

### Enhancements to `BelongsTo` relationship:

* [`src/Lightweight/DataMapper/BelongsTo.hpp`](diffhunk://#diff-b0d6cc785d8fd9c381b5848d50cd7f484d4fe78cdeeca9ed18e8b636b50ee3f4L37-R41): Added support for nullable foreign keys by introducing the `SqlNullable` parameter to the `BelongsTo` template. Updated the `ValueType` to conditionally use `std::optional` for nullable relationships and adjusted related type definitions and static assertions. [[1]](diffhunk://#diff-b0d6cc785d8fd9c381b5848d50cd7f484d4fe78cdeeca9ed18e8b636b50ee3f4L37-R41) [[2]](diffhunk://#diff-b0d6cc785d8fd9c381b5848d50cd7f484d4fe78cdeeca9ed18e8b636b50ee3f4L61-R69)
* [`src/Lightweight/DataMapper/BelongsTo.hpp`](diffhunk://#diff-b0d6cc785d8fd9c381b5848d50cd7f484d4fe78cdeeca9ed18e8b636b50ee3f4L211-R216): Simplified comparison operators (`operator<=>`, `operator==`, and `operator!=`) to work directly with `BelongsTo` instances without requiring template specialization for different referenced fields. [[1]](diffhunk://#diff-b0d6cc785d8fd9c381b5848d50cd7f484d4fe78cdeeca9ed18e8b636b50ee3f4L211-R216) [[2]](diffhunk://#diff-b0d6cc785d8fd9c381b5848d50cd7f484d4fe78cdeeca9ed18e8b636b50ee3f4L223-R232)

### Updates to code generation tools:

* [`src/tools/ddl2cpp.cpp`](diffhunk://#diff-d0994ad2281e5d01a9806f27b5cd586e09e99d78c83af34edf26200b2ccb4039L467-R478): Enhanced the `CxxModelPrinter` to generate `BelongsTo` relationships with nullable foreign keys by adding logic to handle the `SqlNullable::Null` parameter when columns are marked as nullable. [[1]](diffhunk://#diff-d0994ad2281e5d01a9806f27b5cd586e09e99d78c83af34edf26200b2ccb4039L467-R478) [[2]](diffhunk://#diff-d0994ad2281e5d01a9806f27b5cd586e09e99d78c83af34edf26200b2ccb4039L542-R558)

### Extended test coverage:

* [`src/tests/DataMapperTests.cpp`](diffhunk://#diff-75a153e62f4fee74880e5a693d0c5b380424f28c0722b947c45481282c04e26aR1717-R1787): Added new test cases to validate the behavior of nullable foreign keys in `BelongsTo` relationships. Tests include scenarios for both non-NULL and NULL foreign key values, ensuring proper handling of optional relationships.

These changes improve flexibility in database modeling, enhance code generation capabilities, and ensure correctness through comprehensive testing.