### PR TITLE
Fixes mixed queries requiring pre-binding parameters and not pre-binding parameters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,9 +76,10 @@ jobs:
       run: |
         cmake --preset linux-clang-debug \
               -D CMAKE_CXX_COMPILER=clang++-20 \
-              -D CMAKE_C_COMPILER=clang-20
+              -D CMAKE_C_COMPILER=clang-20 \
+              -B build
     - name: "run clang-tidy"
-      run: run-clang-tidy -p ./out/build/linux-clang-debug -clang-tidy-binary clang-tidy-20
+      run: run-clang-tidy -p ./build -clang-tidy-binary clang-tidy-20
 
   # }}}
   # {{{ Windows

--- a/src/Lightweight/DataBinder/SqlDateTime.hpp
+++ b/src/Lightweight/DataBinder/SqlDateTime.hpp
@@ -238,6 +238,18 @@ struct std::formatter<SqlDateTime>: std::formatter<std::string>
 };
 
 template <>
+struct std::formatter<std::optional<SqlDateTime>>: std::formatter<std::string>
+{
+    LIGHTWEIGHT_FORCE_INLINE auto format(std::optional<SqlDateTime> const& value, std::format_context& ctx) const
+        -> std::format_context::iterator
+    {
+        if (!value.has_value())
+            return std::formatter<std::string>::format("nullopt", ctx);
+        return std::formatter<std::string>::format(std::format("{}", value.value()), ctx);
+    }
+};
+
+template <>
 struct SqlDataBinder<SqlDateTime::native_type>
 {
     static LIGHTWEIGHT_FORCE_INLINE SQLRETURN GetColumn(SQLHSTMT stmt,

--- a/src/Lightweight/DataBinder/SqlDynamicString.hpp
+++ b/src/Lightweight/DataBinder/SqlDynamicString.hpp
@@ -249,6 +249,19 @@ struct std::formatter<SqlDynamicString<N, T>>: std::formatter<std::string>
 };
 
 template <std::size_t N, typename T>
+struct std::formatter<std::optional<SqlDynamicString<N, T>>>: std::formatter<string>
+{
+    using value_type = std::optional<SqlDynamicString<N, T>>;
+
+    auto format(value_type const& text, format_context& ctx) const
+    {
+        if (!text.has_value())
+            return std::formatter<std::string>::format("nullopt", ctx);
+        return std::formatter<std::string>::format(std::format("{}", text.value()), ctx);
+    }
+};
+
+template <std::size_t N, typename T>
 struct SqlBasicStringOperations<SqlDynamicString<N, T>>
 {
     using CharType = T;

--- a/src/Lightweight/DataBinder/SqlNumeric.hpp
+++ b/src/Lightweight/DataBinder/SqlNumeric.hpp
@@ -160,6 +160,12 @@ struct SqlNumeric
     }
 };
 
+template <typename T>
+concept SqlNumericType = requires(T t) {
+    { T::Precision } -> std::convertible_to<std::size_t>;
+    { T::Scale } -> std::convertible_to<std::size_t>;
+} && std::same_as<T, SqlNumeric<T::Precision, T::Scale>>;
+
 // clang-format off
 template <std::size_t Precision, std::size_t Scale>
 struct SqlDataBinder<SqlNumeric<Precision, Scale>>
@@ -213,12 +219,12 @@ struct SqlDataBinder<SqlNumeric<Precision, Scale>>
 // clang-format off
 
 
-template <std::size_t Precision, std::size_t Scale>
-struct std::formatter<SqlNumeric<Precision, Scale>>: std::formatter<double>
+template <SqlNumericType Type>
+struct std::formatter<Type>: std::formatter<std::string>
 {
     template <typename FormatContext>
-    auto format(SqlNumeric<Precision, Scale> const& value, FormatContext& ctx)
+    auto format(Type const& value, FormatContext& ctx)
     {
-        return formatter<double>::format(value.ToDouble(), ctx);
+        return formatter<std::string>::format(value.ToString(), ctx);
     }
 };

--- a/src/Lightweight/DataMapper/Field.hpp
+++ b/src/Lightweight/DataMapper/Field.hpp
@@ -4,6 +4,7 @@
 #include "../DataBinder/Core.hpp"
 #include "../DataBinder/SqlDate.hpp"
 #include "../DataBinder/SqlDateTime.hpp"
+#include "../DataBinder/SqlNumeric.hpp"
 #include "../DataBinder/SqlText.hpp"
 #include "../DataBinder/SqlTime.hpp"
 
@@ -262,6 +263,8 @@ inline LIGHTWEIGHT_FORCE_INLINE std::string Field<T, P1, P2>::InspectValue() con
         return std::format("\'{}\'", _value.value);
     else if constexpr (std::is_same_v<T, SqlDateTime>)
         return std::format("\'{}\'", _value.value());
+    else if constexpr (SqlNumericType<T>)
+        return std::format("{}", _value.ToString());
     else if constexpr (requires { _value.has_value(); })
     {
         if (_value.has_value())

--- a/src/Lightweight/SqlStatement.cpp
+++ b/src/Lightweight/SqlStatement.cpp
@@ -145,6 +145,7 @@ void SqlStatement::Prepare(std::string_view query) &
     SqlLogger::GetLogger().OnPrepare(query);
 
     m_preparedQuery = std::string(query);
+    const_cast<SqlStatement*>(this)->m_numColumns.reset();
 
     m_data->postExecuteCallbacks.clear();
     m_data->postProcessOutputColumnCallbacks.clear();
@@ -164,6 +165,8 @@ void SqlStatement::ExecuteDirect(std::string_view const& query, std::source_loca
         return;
 
     m_preparedQuery.clear();
+    m_numColumns.reset();
+
     SqlLogger::GetLogger().OnExecuteDirect(query);
 
     RequireSuccess(SQLExecDirectA(m_hStmt, (SQLCHAR*) query.data(), (SQLINTEGER) query.size()), location);
@@ -195,9 +198,14 @@ size_t SqlStatement::NumRowsAffected() const
 // Retrieves the number of columns affected by the last query.
 size_t SqlStatement::NumColumnsAffected() const
 {
-    SQLSMALLINT numColumns {};
-    RequireSuccess(SQLNumResultCols(m_hStmt, &numColumns));
-    return numColumns;
+    if (!m_numColumns)
+    {
+        SQLSMALLINT numColumns {};
+        RequireSuccess(SQLNumResultCols(m_hStmt, &numColumns));
+        const_cast<SqlStatement*>(this)->m_numColumns = numColumns;
+    }
+
+    return *m_numColumns;
 }
 
 // Retrieves the last insert ID of the last query's primary key.

--- a/src/Lightweight/SqlStatement.cpp
+++ b/src/Lightweight/SqlStatement.cpp
@@ -167,6 +167,9 @@ void SqlStatement::ExecuteDirect(std::string_view const& query, std::source_loca
     m_preparedQuery.clear();
     m_numColumns.reset();
 
+    // Unbinds the columns, if any
+    RequireSuccess(SQLFreeStmt(m_hStmt, SQL_UNBIND));
+
     SqlLogger::GetLogger().OnExecuteDirect(query);
 
     RequireSuccess(SQLExecDirectA(m_hStmt, (SQLCHAR*) query.data(), (SQLINTEGER) query.size()), location);

--- a/src/Lightweight/SqlStatement.cpp
+++ b/src/Lightweight/SqlStatement.cpp
@@ -208,7 +208,7 @@ size_t SqlStatement::NumColumnsAffected() const
         const_cast<SqlStatement*>(this)->m_numColumns = numColumns;
     }
 
-    return *m_numColumns;
+    return m_numColumns.value(); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 // Retrieves the last insert ID of the last query's primary key.

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -268,6 +268,7 @@ class [[nodiscard]] SqlStatement final: public SqlDataBinderCallback
     SqlConnection* m_connection {};                // Pointer to the connection object
     SQLHSTMT m_hStmt {};                           // The native oDBC statement handle
     std::string m_preparedQuery;                   // The last prepared query
+    std::optional<SQLSMALLINT> m_numColumns;       // The number of columns in the result set, if known
     SQLSMALLINT m_expectedParameterCount {};       // The number of parameters expected by the query
 };
 

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -304,7 +304,10 @@ class [[nodiscard]] SqlResultCursor
     LIGHTWEIGHT_FORCE_INLINE ~SqlResultCursor()
     {
         if (m_stmt)
-            SQLCloseCursor(m_stmt->NativeHandle());
+        {
+            m_stmt->CloseCursor();
+            m_stmt = nullptr;
+        }
     }
 
     /// Retrieves the number of rows affected by the last query.

--- a/src/examples/test_chinook/README.md
+++ b/src/examples/test_chinook/README.md
@@ -28,5 +28,5 @@ sqlcmd -S localhost -U sa -P "Qwerty1." -C -d LightweightTest -i ./src/examples/
 Create header file for every table in the directory `./src/examples/test_chinook/entities` 
 
 ``` sh
-./build/src/tools/ddl2cpp --connection-string "DRIVER={ODBC Driver 18 for SQL Server};SERVER=localhost;UID=sa;PWD=QWERT1.qwerty;TrustServerCertificate=yes;DATABASE=LightweightExample" --make-aliases --database LightweightExample --schema dbo --output ./src/examples/test_chinook/entities
+./build/src/tools/ddl2cpp --connection-string "DRIVER={ODBC Driver 18 for SQL Server};SERVER=localhost;UID=sa;PWD=Qwerty1.;TrustServerCertificate=yes;DATABASE=LightweightExample" --make-aliases --database LightweightExample --schema dbo --output ./src/examples/test_chinook/entities
 ```

--- a/src/tests/DataMapperTests.cpp
+++ b/src/tests/DataMapperTests.cpp
@@ -1714,4 +1714,26 @@ TEST_CASE_METHOD(SqlTestFixture, "TestOptionalDynamicData", "[DataMapper]")
     checkSize(4000);
 }
 
+struct MessagesStruct
+{
+    Field<SqlGuid, PrimaryKey::AutoAssign, SqlRealName { "primary_key" }> id;
+    Field<SqlDateTime, SqlRealName { "time_stamp" }> timeStamp;
+    Field<SqlDynamicWideString<4000>, SqlRealName { "Message" }> message;
+};
+
+TEST_CASE_METHOD(SqlTestFixture, "TestMessageStruct", "[DataMapper]")
+{
+    auto dm = DataMapper {};
+    dm.CreateTable<MessagesStruct>();
+
+    MessagesStruct message {
+        .id = SqlGuid::Create(),
+        .timeStamp = SqlDateTime::Now(),
+        .message = L"Hello, World!",
+    };
+
+    dm.Create(message);
+    REQUIRE(message.id.Value());
+}
+
 // NOLINTEND(bugprone-unchecked-optional-access)

--- a/src/tools/ddl2cpp.cpp
+++ b/src/tools/ddl2cpp.cpp
@@ -288,25 +288,12 @@ class CxxModelPrinter
         std::stringstream exampleEntries;
 
         auto const tableName = aliasTableName(table.name);
-        exampleEntries << std::format("auto entries{} = dm.Query<{}>().All();\n", tableName, tableName);
+        exampleEntries << std::format("auto entries{} = dm.Query<{}>().First(10);\n", tableName, tableName);
 
         exampleEntries << std::format("for (auto const& entry: entries{})\n", tableName);
         exampleEntries << "{\n";
 
-        auto const column = table.columns[0];
-        auto const memberName = FormatName(column.name, _config.formatType);
-        if (column.isNullable)
-        {
-            exampleEntries << std::format("    if (entry.{}.Value())\n", memberName);
-            exampleEntries << "    {\n";
-            exampleEntries << std::format(
-                "        std::println(\"{}: {{}}\", entry.{}.Value().value());\n", memberName, memberName);
-            exampleEntries << "    }\n";
-        }
-        else
-        {
-            exampleEntries << std::format("    std::println(\"{{}}\", entry.{}.Value());\n", memberName);
-        }
+        exampleEntries << std::format("    std::println(\"{{}}\", DataMapper::Inspect(entry));\n");
 
         exampleEntries << "}\n";
 


### PR DESCRIPTION
This pull request introduces several enhancements and updates to the `Lightweight` library, focusing on formatting improvements, database interaction enhancements, and updates to example and test cases. The most significant changes include the addition of formatters for optional SQL types, improved handling of SQL statements, and updates to the example and test cases to better demonstrate library functionality.

### Formatting Enhancements

* Added custom formatters for `std::optional<SqlDateTime>` and `std::optional<SqlDynamicString<N, T>>` to properly handle optional values during formatting. These formatters return `"nullopt"` for empty values and format the contained value otherwise. (`[[1]](diffhunk://#diff-e23b7e2b389816742787588b84b20b2728ba9aae4d7f7f4072e5b7852acc1716R240-R251)`, `[[2]](diffhunk://#diff-73ed6be95c4755bbaaa4f8118f9a924890e13e5c863069149d22a0ee91dd2180R251-R263)`)
* Introduced the `SqlNumericType` concept to ensure type constraints for numeric SQL types and updated the formatter for `SqlNumeric` to use `ToString()` for consistent string formatting. (`[[1]](diffhunk://#diff-a5473bcb06f073bad409c43b4a3eacde16c51153e7fa8241817dc54c9d2a247eR163-R168)`, `[[2]](diffhunk://#diff-a5473bcb06f073bad409c43b4a3eacde16c51153e7fa8241817dc54c9d2a247eL216-R228)`)

### Database Interaction Enhancements

* Improved `SqlStatement` handling by adding a `std::optional` member to cache the number of columns affected by the last query and ensuring column unbinding during direct execution. (`[[1]](diffhunk://#diff-5642ceb28e4a081ecd1b77e48ae2682ab21437f3d14e422daa173c54d1be54aeR148)`, `[[2]](diffhunk://#diff-5642ceb28e4a081ecd1b77e48ae2682ab21437f3d14e422daa173c54d1be54aeR168-R172)`, `[[3]](diffhunk://#diff-9521ecee4619633fd939d5fb8a26a6c397750a3aad5444fb0407ef2b4cbc8623R271)`)
* Updated `SqlResultCursor` destructor to properly close the cursor and reset the associated statement pointer. (`[src/Lightweight/SqlStatement.hppL306-R310](diffhunk://#diff-9521ecee4619633fd939d5fb8a26a6c397750a3aad5444fb0407ef2b4cbc8623L306-R310)`)

### Example and Test Case Updates

* Enhanced the `main.cpp` example to iterate over all entities in the database and print their contents using the new `dumpTable` helper function. Added support for reading the ODBC connection string from environment variables. (`[[1]](diffhunk://#diff-dded0aef890edf270ac1f2710551ae60cdceb5b7802359b6297763851e7214abR1-R60)`, `[[2]](diffhunk://#diff-dded0aef890edf270ac1f2710551ae60cdceb5b7802359b6297763851e7214abR158-R170)`)
* Added a new test case for `MessagesStruct` to validate the creation and insertion of a table with fields including `SqlGuid`, `SqlDateTime`, and `SqlDynamicWideString`. (`[src/tests/DataMapperTests.cppR1717-R1738](diffhunk://#diff-75a153e62f4fee74880e5a693d0c5b380424f28c0722b947c45481282c04e26aR1717-R1738)`)

### Miscellaneous Updates

* Updated `ddl2cpp` tool to limit the number of queried entries to 10 and use `DataMapper::Inspect` for improved output formatting. (`[src/tools/ddl2cpp.cppL291-R296](diffhunk://#diff-d0994ad2281e5d01a9806f27b5cd586e09e99d78c83af34edf26200b2ccb4039L291-R296)`)
* Fixed connection string in `README.md` example to correct the password format. (`[src/examples/test_chinook/README.mdL31-R31](diffhunk://#diff-0c6d6c5577108ab2430addcf51aff5c4ebf3fb83debec9f3b1190cbd36d7f890L31-R31)`)