### PR TITLE
Make sure to use config file for the clang-tidy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
               -D CMAKE_C_COMPILER=clang-20 \
               -B build
     - name: "run clang-tidy"
-      run: run-clang-tidy -p ./build -clang-tidy-binary clang-tidy-20
+      run: run-clang-tidy -p ./build -clang-tidy-binary clang-tidy-20 -config-file ./.clang-tidy
 
   # }}}
   # {{{ Windows


### PR DESCRIPTION
I noticed that we are not running clang-tidy against all enabled check in our config file, this PR fixes this 