### PR TITLE
[clang-tidy] Fix some reports or actively ignore some others (std C++ naming related)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,11 +3,11 @@ Checks: >-
   -*,
   bugprone-*,
   -bugprone-branch-clone,
+  -bugprone-crtp-constructor-accessibility,
   -bugprone-exception-escape,
   -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-reserved-identifier,
   -bugprone-suspicious-include,
-  -bugprone-crtp-constructor-accessibility,
   -bugprone-chained-comparison,
   clang-analyzer-core.*,
   clang-analyzer-cplusplus.*,
@@ -44,7 +44,6 @@ Checks: >-
   -readability-braces-around-statements,
   -readability-else-after-return,
   -readability-identifier-length,
-  -readability-identifier-naming,
   -readability-implicit-bool-conversion,
   -readability-magic-numbers,
   -readability-redundant-access-specifiers,
@@ -93,3 +92,5 @@ CheckOptions:
     value:           '1'
   - key:             readability-identifier-naming.FunctionCase
     value:           CamelCase
+  - key:             readability-identifier-naming.FunctionIgnoredRegexp
+    value:           '^(main|begin|end|push_back|pop_back|data|str|get|size|resize|empty|clear|value|c_str|capacity|to_string|assign|at|reserve|substr)$'

--- a/src/Lightweight/DataBinder/SqlDateTime.hpp
+++ b/src/Lightweight/DataBinder/SqlDateTime.hpp
@@ -7,7 +7,6 @@
 
 #include <chrono>
 #include <format>
-#include <string_view>
 
 #include <sql.h>
 #include <sqlext.h>
@@ -95,6 +94,8 @@ struct SqlDateTime
     {
     }
 
+    // NOLINTBEGIN(readability-identifier-naming)
+
     /// Returns the year of this date-time object.
     [[nodiscard]] constexpr LIGHTWEIGHT_FORCE_INLINE std::chrono::year year() const noexcept
     {
@@ -136,6 +137,8 @@ struct SqlDateTime
     {
         return std::chrono::nanoseconds(static_cast<unsigned>(sqlValue.fraction));
     }
+
+    // NOLINTEND(readability-identifier-naming)
 
     LIGHTWEIGHT_FORCE_INLINE constexpr operator native_type() const noexcept
     {

--- a/src/Lightweight/DataBinder/SqlDynamicBinary.hpp
+++ b/src/Lightweight/DataBinder/SqlDynamicBinary.hpp
@@ -75,33 +75,31 @@ class SqlDynamicBinary final
     constexpr auto operator<=>(SqlDynamicBinary<N> const&) const noexcept = default;
 
     /// Retrieves the size of the string.
-    // NOLINTNEXTLINE(readability-identifier-naming)
     [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr std::size_t size() const noexcept
     {
         return _base.size();
     }
 
     /// Resizes the underlying data storage to the given size.
-    void LIGHTWEIGHT_FORCE_INLINE resize(std::size_t newSize) // NOLINT(readability-identifier-naming)
+    void LIGHTWEIGHT_FORCE_INLINE resize(std::size_t newSize)
     {
         _base.resize(newSize);
     }
 
     /// Tests if the stored data is empty.
-    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr bool empty() const noexcept // NOLINT(readability-identifier-naming)
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr bool empty() const noexcept
     {
         return _base.empty();
     }
 
     /// Retrieves the pointer to the string data.
-    // NOLINTNEXTLINE(readability-identifier-naming)
     [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr decltype(auto) data(this auto&& self) noexcept
     {
         return self._base.data();
     }
 
     /// Clears the storad data.
-    LIGHTWEIGHT_FORCE_INLINE void clear() noexcept // NOLINT(readability-identifier-naming)
+    LIGHTWEIGHT_FORCE_INLINE void clear() noexcept
     {
         _base.clear();
     }

--- a/src/Lightweight/DataBinder/SqlFixedString.hpp
+++ b/src/Lightweight/DataBinder/SqlFixedString.hpp
@@ -107,6 +107,7 @@ class SqlFixedString
         return _size;
     }
 
+    // NOLINTNEXTLINE(readability-identifier-naming)
     LIGHTWEIGHT_FORCE_INLINE /*TODO constexpr*/ void setsize(std::size_t n) noexcept
     {
         auto const newSize = (std::min) (n, N);

--- a/src/Lightweight/DataBinder/SqlNumeric.hpp
+++ b/src/Lightweight/DataBinder/SqlNumeric.hpp
@@ -4,14 +4,12 @@
 
 #include "../SqlColumnTypeDefinitions.hpp"
 #include "../SqlError.hpp"
-#include "../SqlLogger.hpp"
 #include "Primitives.hpp"
 
 #include <cmath>
 #include <compare>
 #include <concepts>
 #include <cstring>
-#include <print>
 #include <source_location>
 
 namespace Lightweight
@@ -182,7 +180,7 @@ struct SqlDataBinder<SqlNumeric<Precision, Scale>>
         if (SQL_SUCCEEDED(error))
             return;
 
-        throw SqlException(SqlErrorInfo::fromStatementHandle(stmt), sourceLocation);
+        throw SqlException(SqlErrorInfo::FromStatementHandle(stmt), sourceLocation);
     }
 
     static LIGHTWEIGHT_FORCE_INLINE SQLRETURN InputParameter(SQLHSTMT stmt, SQLUSMALLINT column, ValueType const& value, SqlDataBinderCallback& /*cb*/) noexcept

--- a/src/Lightweight/DataMapper/CollectDifferences.hpp
+++ b/src/Lightweight/DataMapper/CollectDifferences.hpp
@@ -20,7 +20,7 @@ struct DifferenceView
     }
 
     template <typename Callback>
-    void iterate(Callback const& callback) noexcept
+    void Iterate(Callback const& callback) noexcept
     {
         Reflection::template_for<0, Reflection::CountMembers<Record>>([&]<auto I>() {
             if (std::find(indexes.begin(), indexes.end(), I) != indexes.end())

--- a/src/Lightweight/DataMapper/Field.hpp
+++ b/src/Lightweight/DataMapper/Field.hpp
@@ -7,6 +7,7 @@
 #include "../DataBinder/SqlNumeric.hpp"
 #include "../DataBinder/SqlText.hpp"
 #include "../DataBinder/SqlTime.hpp"
+#include "../Utils.hpp"
 
 #include <reflection-cpp/reflection.hpp>
 
@@ -363,6 +364,7 @@ template <Lightweight::detail::FieldElementType T, auto P1, auto P2>
 struct std::formatter<Lightweight::Field<T, P1, P2>>: std::formatter<T>
 {
     template <typename FormatContext>
+    // NOLINTNEXTLINE(readability-identifier-naming)
     auto format(Lightweight::Field<T, P1, P2> const& field, FormatContext& ctx)
     {
         return formatter<T>::format(field.InspectValue(), ctx);

--- a/src/Lightweight/DataMapper/HasManyThrough.hpp
+++ b/src/Lightweight/DataMapper/HasManyThrough.hpp
@@ -4,7 +4,6 @@
 
 #include "../Utils.hpp"
 #include "Error.hpp"
-#include "Record.hpp"
 
 #include <reflection-cpp/reflection.hpp>
 

--- a/src/Lightweight/SqlConnection.cpp
+++ b/src/Lightweight/SqlConnection.cpp
@@ -242,7 +242,7 @@ void SqlConnection::PostConnect()
 
 SqlErrorInfo SqlConnection::LastError() const
 {
-    return SqlErrorInfo::fromConnectionHandle(m_hDbc);
+    return SqlErrorInfo::FromConnectionHandle(m_hDbc);
 }
 
 void SqlConnection::Close() noexcept

--- a/src/Lightweight/SqlError.cpp
+++ b/src/Lightweight/SqlError.cpp
@@ -18,7 +18,7 @@ void SqlErrorInfo::RequireStatementSuccess(SQLRETURN result, SQLHSTMT hStmt, std
     if (result == SQL_SUCCESS || result == SQL_SUCCESS_WITH_INFO) [[likely]]
         return;
 
-    throw std::runtime_error { std::format("{}: {}", message, fromStatementHandle(hStmt)) };
+    throw std::runtime_error { std::format("{}: {}", message, FromStatementHandle(hStmt)) };
 }
 
 } // namespace Lightweight

--- a/src/Lightweight/SqlError.hpp
+++ b/src/Lightweight/SqlError.hpp
@@ -35,22 +35,22 @@ struct SqlErrorInfo
     std::string message;
 
     /// Constructs an ODBC error info object from the given ODBC connection handle.
-    static SqlErrorInfo fromConnectionHandle(SQLHDBC hDbc)
+    static SqlErrorInfo FromConnectionHandle(SQLHDBC hDbc)
     {
-        return fromHandle(SQL_HANDLE_DBC, hDbc);
+        return FromHandle(SQL_HANDLE_DBC, hDbc);
     }
 
     /// Constructs an ODBC error info object from the given ODBC statement handle.
-    static SqlErrorInfo fromStatementHandle(SQLHSTMT hStmt)
+    static SqlErrorInfo FromStatementHandle(SQLHSTMT hStmt)
     {
-        return fromHandle(SQL_HANDLE_STMT, hStmt);
+        return FromHandle(SQL_HANDLE_STMT, hStmt);
     }
 
     /// Asserts that the given result is a success code, otherwise throws an exception.
     static void RequireStatementSuccess(SQLRETURN result, SQLHSTMT hStmt, std::string_view message);
 
   private:
-    static SqlErrorInfo fromHandle(SQLSMALLINT handleType, SQLHANDLE handle)
+    static SqlErrorInfo FromHandle(SQLSMALLINT handleType, SQLHANDLE handle)
     {
         SqlErrorInfo info {};
         info.message = std::string(1024, '\0');
@@ -75,6 +75,7 @@ class SqlException: public std::runtime_error
     LIGHTWEIGHT_API explicit SqlException(SqlErrorInfo info,
                                           std::source_location location = std::source_location::current());
 
+    // NOLINTNEXTLINE(readability-identifier-naming)
     [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE SqlErrorInfo const& info() const noexcept
     {
         return _info;
@@ -102,11 +103,13 @@ enum class SqlError : std::int16_t
 
 struct SqlErrorCategory: std::error_category
 {
+    // NOLINTNEXTLINE(readability-identifier-naming)
     static SqlErrorCategory const& get() noexcept
     {
         static SqlErrorCategory const category;
         return category;
     }
+
     [[nodiscard]] char const* name() const noexcept override
     {
         return "Lightweight";
@@ -152,7 +155,8 @@ struct std::is_error_code_enum<Lightweight::SqlError>: public std::true_type
 {
 };
 
-// Tells the compiler that MyErr pairs with MyCategory
+/// Tells the compiler that MyErr pairs with MyCategory
+// NOLINTNEXTLINE(readability-identifier-naming)
 inline std::error_code make_error_code(Lightweight::SqlError e)
 {
     return { static_cast<int>(e), Lightweight::SqlErrorCategory::get() };

--- a/src/Lightweight/SqlRealName.hpp
+++ b/src/Lightweight/SqlRealName.hpp
@@ -51,6 +51,7 @@ struct SqlRealName
 
     [[nodiscard]] constexpr auto operator<=>(SqlRealName const&) const = default;
 
+    // NOLINTNEXTLINE(readability-identifier-naming)
     [[nodiscard]] constexpr std::string_view sv() const noexcept
     {
         return { value, length };

--- a/src/Lightweight/SqlSchema.hpp
+++ b/src/Lightweight/SqlSchema.hpp
@@ -20,6 +20,7 @@ namespace SqlSchema
 
     namespace detail
     {
+        // NOLINTNEXTLINE(readability-identifier-naming)
         constexpr std::string_view rtrim(std::string_view value) noexcept
         {
             while (!value.empty() && (std::isspace(value.back()) || value.back() == '\0'))

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -597,7 +597,7 @@ inline LIGHTWEIGHT_FORCE_INLINE SqlConnection const& SqlStatement::Connection() 
 
 inline LIGHTWEIGHT_FORCE_INLINE SqlErrorInfo SqlStatement::LastError() const
 {
-    return SqlErrorInfo::fromStatementHandle(m_hStmt);
+    return SqlErrorInfo::FromStatementHandle(m_hStmt);
 }
 
 inline LIGHTWEIGHT_FORCE_INLINE SQLHSTMT SqlStatement::NativeHandle() const noexcept
@@ -693,7 +693,7 @@ void SqlStatement::Execute(Args const&... args)
     auto const result = SQLExecute(m_hStmt);
 
     if (result != SQL_NO_DATA && result != SQL_SUCCESS && result != SQL_SUCCESS_WITH_INFO)
-        throw SqlException(SqlErrorInfo::fromStatementHandle(m_hStmt), std::source_location::current());
+        throw SqlException(SqlErrorInfo::FromStatementHandle(m_hStmt), std::source_location::current());
 
     ProcessPostExecuteCallbacks();
 }

--- a/src/Lightweight/SqlTransaction.cpp
+++ b/src/Lightweight/SqlTransaction.cpp
@@ -53,14 +53,14 @@ bool SqlTransaction::TryRollback() noexcept
     SQLRETURN sqlReturn = SQLEndTran(SQL_HANDLE_DBC, NativeHandle(), SQL_ROLLBACK);
     if (sqlReturn != SQL_SUCCESS && sqlReturn != SQL_SUCCESS_WITH_INFO)
     {
-        SqlLogger::GetLogger().OnError(SqlErrorInfo::fromConnectionHandle(NativeHandle()), m_location);
+        SqlLogger::GetLogger().OnError(SqlErrorInfo::FromConnectionHandle(NativeHandle()), m_location);
         return false;
     }
 
     sqlReturn = SQLSetConnectAttr(NativeHandle(), SQL_ATTR_AUTOCOMMIT, (SQLPOINTER) SQL_AUTOCOMMIT_ON, SQL_IS_UINTEGER);
     if (sqlReturn != SQL_SUCCESS && sqlReturn != SQL_SUCCESS_WITH_INFO)
     {
-        SqlLogger::GetLogger().OnError(SqlErrorInfo::fromConnectionHandle(NativeHandle()), m_location);
+        SqlLogger::GetLogger().OnError(SqlErrorInfo::FromConnectionHandle(NativeHandle()), m_location);
         return false;
     }
 
@@ -74,14 +74,14 @@ bool SqlTransaction::TryCommit() noexcept
     SQLRETURN sqlReturn = SQLEndTran(SQL_HANDLE_DBC, NativeHandle(), SQL_COMMIT);
     if (sqlReturn != SQL_SUCCESS && sqlReturn != SQL_SUCCESS_WITH_INFO)
     {
-        SqlLogger::GetLogger().OnError(SqlErrorInfo::fromConnectionHandle(NativeHandle()), m_location);
+        SqlLogger::GetLogger().OnError(SqlErrorInfo::FromConnectionHandle(NativeHandle()), m_location);
         return false;
     }
 
     sqlReturn = SQLSetConnectAttr(NativeHandle(), SQL_ATTR_AUTOCOMMIT, (SQLPOINTER) SQL_AUTOCOMMIT_ON, SQL_IS_UINTEGER);
     if (sqlReturn != SQL_SUCCESS && sqlReturn != SQL_SUCCESS_WITH_INFO)
     {
-        SqlLogger::GetLogger().OnError(SqlErrorInfo::fromConnectionHandle(NativeHandle()), m_location);
+        SqlLogger::GetLogger().OnError(SqlErrorInfo::FromConnectionHandle(NativeHandle()), m_location);
         return false;
     }
 

--- a/src/Lightweight/Tools/CxxModelPrinter.cpp
+++ b/src/Lightweight/Tools/CxxModelPrinter.cpp
@@ -157,7 +157,7 @@ std::string CxxModelPrinter::FormatTableName(std::string_view name)
     return result;
 }
 
-std::string CxxModelPrinter::aliasTableName(std::string_view name) const
+std::string CxxModelPrinter::AliasTableName(std::string_view name) const
 {
     if (_config.makeAliases)
         return FormatTableName(name);
@@ -181,7 +181,7 @@ std::string CxxModelPrinter::aliasTableName(std::string_view name) const
     auto includes = std::vector<std::string> {};
     includes.reserve(_definitions.size());
     for (auto const& [tableName, definition]: _definitions)
-        includes.emplace_back(std::format("{}.hpp", aliasTableName(tableName)));
+        includes.emplace_back(std::format("{}.hpp", AliasTableName(tableName)));
 
     std::ranges::sort(includes);
 
@@ -191,22 +191,22 @@ std::string CxxModelPrinter::aliasTableName(std::string_view name) const
     return {};
 }
 
-void CxxModelPrinter::printToFiles(std::string_view modelNamespace, std::string_view outputDirectory)
+void CxxModelPrinter::PrintToFiles(std::string_view modelNamespace, std::string_view outputDirectory)
 {
     for (auto const& [tableName, definition]: _definitions)
     {
-        auto const fileName = std::format("{}/{}.hpp", outputDirectory, aliasTableName(tableName));
+        auto const fileName = std::format("{}/{}.hpp", outputDirectory, AliasTableName(tableName));
         auto file = std::ofstream(fileName);
         if (!file)
         {
             std::println("Failed to create file {}.", fileName);
             continue;
         }
-        file << headerFileForTheTable(modelNamespace, tableName);
+        file << HeaderFileForTheTable(modelNamespace, tableName);
     }
 }
 
-std::string CxxModelPrinter::headerFileForTheTable(std::string_view modelNamespace,
+std::string CxxModelPrinter::HeaderFileForTheTable(std::string_view modelNamespace,
                                                    std::string const& tableName) // NOLINT(readability-identifier-naming)
 {
     std::stringstream output;
@@ -601,12 +601,12 @@ std::string CxxModelPrinter::ToString(std::string_view modelNamespace)
     for (auto const& [tableName, definition]: _definitions)
     {
         result += std::format("// file: {}.hpp\n", tableName);
-        result += headerFileForTheTable(modelNamespace, tableName);
+        result += HeaderFileForTheTable(modelNamespace, tableName);
     }
     return result;
 }
 
-std::string CxxModelPrinter::tableIncludes() const
+std::string CxxModelPrinter::TableIncludes() const
 {
 
     std::string result;
@@ -617,11 +617,11 @@ std::string CxxModelPrinter::tableIncludes() const
     return result;
 }
 
-std::string CxxModelPrinter::example(SqlSchema::Table const& table) const
+std::string CxxModelPrinter::Example(SqlSchema::Table const& table) const
 {
     std::stringstream exampleEntries;
 
-    auto const tableName = aliasTableName(table.name);
+    auto const tableName = AliasTableName(table.name);
 
     exampleEntries << std::format("auto entries{} = dm.Query<{}>().First(10);\n", tableName, tableName);
     exampleEntries << std::format("for (auto const& entry: entries{})\n", tableName);

--- a/src/Lightweight/Tools/CxxModelPrinter.hpp
+++ b/src/Lightweight/Tools/CxxModelPrinter.hpp
@@ -39,19 +39,18 @@ class CxxModelPrinter
 
     std::string ToString(std::string_view modelNamespace);
 
-    std::string tableIncludes() const;
+    std::string TableIncludes() const;
 
-    std::string aliasTableName(std::string_view name) const;
+    std::string AliasTableName(std::string_view name) const;
 
     [[nodiscard]] std::expected<void, std::string> PrintCumulativeHeaderFile(
         std::filesystem::path const& outputDirectory, std::filesystem::path const& cumulativeHeaderFile);
 
-    void printToFiles(std::string_view modelNamespace, std::string_view outputDirectory);
+    void PrintToFiles(std::string_view modelNamespace, std::string_view outputDirectory);
 
-    std::string headerFileForTheTable(std::string_view modelNamespace,
-                                      std::string const& tableName); // NOLINT(readability-identifier-naming)
+    std::string HeaderFileForTheTable(std::string_view modelNamespace, std::string const& tableName);
 
-    std::string example(SqlSchema::Table const& table) const;
+    std::string Example(SqlSchema::Table const& table) const;
 
     auto StripSuffix(std::string name) -> std::string;
 

--- a/src/Lightweight/Utils.cpp
+++ b/src/Lightweight/Utils.cpp
@@ -12,7 +12,7 @@ void LogIfFailed(SQLHSTMT hStmt, SQLRETURN error, std::source_location sourceLoc
     if (SQL_SUCCEEDED(error))
         return;
 
-    SqlLogger::GetLogger().OnError(SqlErrorInfo::fromStatementHandle(hStmt), sourceLocation);
+    SqlLogger::GetLogger().OnError(SqlErrorInfo::FromStatementHandle(hStmt), sourceLocation);
 }
 
 void RequireSuccess(SQLHSTMT hStmt, SQLRETURN error, std::source_location sourceLocation)
@@ -20,7 +20,7 @@ void RequireSuccess(SQLHSTMT hStmt, SQLRETURN error, std::source_location source
     if (SQL_SUCCEEDED(error))
         return;
 
-    auto errorInfo = SqlErrorInfo::fromStatementHandle(hStmt);
+    auto errorInfo = SqlErrorInfo::FromStatementHandle(hStmt);
     if (errorInfo.sqlState == "07009")
     {
         SqlLogger::GetLogger().OnError(errorInfo, sourceLocation);

--- a/src/benchmark/benchmark.cpp
+++ b/src/benchmark/benchmark.cpp
@@ -71,7 +71,7 @@ class SqlTestFixture
         if (!sqlConnection.IsAlive())
         {
             std::println("Failed to connect to the database: {}",
-                         SqlErrorInfo::fromConnectionHandle(sqlConnection.NativeHandle()));
+                         SqlErrorInfo::FromConnectionHandle(sqlConnection.NativeHandle()));
             std::abort();
         }
 
@@ -169,7 +169,7 @@ class SqlTestFixture
     std::vector<std::string> m_createdTables;
 };
 
-void longQuery()
+void LongQuery()
 {
     auto stmt = SqlStatement {};
     stmt.ExecuteDirect("SELECT user_id, COUNT(movie_id) FROM \"ratings\" GROUP "
@@ -184,7 +184,7 @@ void longQuery()
     }
 }
 
-void count()
+void Count()
 {
     auto stmt = SqlStatement {};
 
@@ -212,7 +212,7 @@ void count()
     // count_and_compare("ratings", 15520005); // TODO fix this
 }
 
-void iterate()
+void Iterate()
 {
     auto dm = DataMapper();
     [[maybe_unused]] int count = 0;
@@ -222,7 +222,7 @@ void iterate()
     }
 }
 
-void run()
+void Run()
 {
     auto measureTime = [](auto&& f, std::string_view name, size_t measured) {
         auto start = std::chrono::high_resolution_clock::now();
@@ -233,9 +233,9 @@ void run()
                      std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count(),
                      measured);
     };
-    measureTime(count, "count", 15);
-    measureTime(longQuery, "longQuery", 4018);
-    measureTime(iterate, "iterate", 0);
+    measureTime(Count, "count", 15);
+    measureTime(LongQuery, "longQuery", 4018);
+    measureTime(Iterate, "iterate", 0);
 }
 
 int main(int argc, char** argv)
@@ -246,6 +246,6 @@ int main(int argc, char** argv)
         return *exitCode;
     std::tie(argc, argv) = std::get<SqlTestFixture::MainProgramArgs>(result);
 
-    run();
+    Run();
     return 0;
 }

--- a/src/examples/test_chinook/main.cpp
+++ b/src/examples/test_chinook/main.cpp
@@ -40,7 +40,7 @@ static std::string GetEnvironmentVariable(std::string const& name)
 }
 
 template <typename Entity>
-void dumpTable(DataMapper& dm, size_t limit = 1)
+void DumpTable(DataMapper& dm, size_t limit = 1)
 {
     auto entries = dm.Query<Entity>().First(limit);
     for (auto const& entry: entries)
@@ -159,15 +159,15 @@ int main()
     }
 
     // Iterate over all entities in the database and print ther content
-    dumpTable<Album>(dm);
-    dumpTable<Artist>(dm);
-    dumpTable<Customer>(dm);
-    dumpTable<Employee>(dm);
-    dumpTable<Genre>(dm);
-    dumpTable<Invoice>(dm);
-    dumpTable<Invoiceline>(dm);
-    dumpTable<Mediatype>(dm);
-    dumpTable<Playlist>(dm);
-    dumpTable<Playlisttrack>(dm);
-    dumpTable<Track>(dm);
+    DumpTable<Album>(dm);
+    DumpTable<Artist>(dm);
+    DumpTable<Customer>(dm);
+    DumpTable<Employee>(dm);
+    DumpTable<Genre>(dm);
+    DumpTable<Invoice>(dm);
+    DumpTable<Invoiceline>(dm);
+    DumpTable<Mediatype>(dm);
+    DumpTable<Playlist>(dm);
+    DumpTable<Playlisttrack>(dm);
+    DumpTable<Track>(dm);
 }

--- a/src/tests/DataMapper/MiscTests.cpp
+++ b/src/tests/DataMapper/MiscTests.cpp
@@ -218,7 +218,7 @@ TEST_CASE_METHOD(SqlTestFixture, "Test DifferenceView", "[DataMapper]")
     auto difference = CollectDifferences(persons[0], persons[1]);
 
     auto differenceCount = 0;
-    difference.iterate([&](auto& lhs, auto& rhs) {
+    difference.Iterate([&](auto& lhs, auto& rhs) {
         CHECK(lhs.Value() != rhs.Value());
         ++differenceCount;
     });

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -41,7 +41,7 @@ auto EraseLinefeeds(std::string str) noexcept -> std::string
 
 template <typename TheSqlQuery>
     requires(std::is_invocable_v<TheSqlQuery, SqlQueryBuilder&>)
-void checkSqlQueryBuilder(TheSqlQuery const& sqlQueryBuilder,
+void CheckSqlQueryBuilder(TheSqlQuery const& sqlQueryBuilder,
                           QueryExpectations const& expectations,
                           std::function<void()> const& postCheck = {},
                           std::source_location const& location = std::source_location::current())
@@ -79,7 +79,7 @@ struct QueryBuilderCheck
     };
 };
 
-void runSqlQueryBuilder(QueryBuilderCheck const& info,
+void RunSqlQueryBuilder(QueryBuilderCheck const& info,
                         std::source_location const& location = std::source_location::current())
 {
     INFO(std::format("Test source location: {}:{}", location.file_name(), location.line()));
@@ -106,13 +106,13 @@ void runSqlQueryBuilder(QueryBuilderCheck const& info,
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.Count", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder([](SqlQueryBuilder& q) { return q.FromTable("Table").Select().Count(); },
+    CheckSqlQueryBuilder([](SqlQueryBuilder& q) { return q.FromTable("Table").Select().Count(); },
                          QueryExpectations::All("SELECT COUNT(*) FROM \"Table\""));
 }
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.All", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             return q.FromTable("That").Select().Fields("a", "b").Field("c").GroupBy("a").OrderBy("b").All();
         },
@@ -124,7 +124,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.All", "[SqlQueryBuilder
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.Distinct.All", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             return q.FromTable("That").Select().Distinct().Fields("a", "b").Field("c").GroupBy("a").OrderBy("b").All();
         },
@@ -136,7 +136,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.Distinct.All", "[SqlQue
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.OrderBy fully qualified", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             return q.FromTable("That")
                 .Select()
@@ -153,7 +153,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.OrderBy fully qualified
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.First", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) { return q.FromTable("That").Select().Field("field1").OrderBy("id").First(); },
         QueryExpectations {
             .sqlite = R"(SELECT "field1" FROM "That"
@@ -169,7 +169,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.First", "[SqlQueryBuild
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.Range", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) { return q.FromTable("That").Select().Fields("foo", "bar").OrderBy("id").Range(200, 50); },
         QueryExpectations {
             .sqlite = R"(SELECT "foo", "bar" FROM "That"
@@ -185,7 +185,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.Range", "[SqlQueryBuild
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.Aggregate", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             // clang-format off
             return q.FromTable("Table")
@@ -196,7 +196,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.Aggregate", "[SqlQueryB
         },
         QueryExpectations::All(R"(SELECT MIN("field1") AS "aggregateValue" FROM "Table")"));
 
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             return q.FromTable("Table")
                 .Select()
@@ -223,10 +223,10 @@ struct Orders
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Fields", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder([](SqlQueryBuilder& q) { return q.FromTable("Users").Select().Fields<Users>().All(); },
+    CheckSqlQueryBuilder([](SqlQueryBuilder& q) { return q.FromTable("Users").Select().Fields<Users>().All(); },
                          QueryExpectations::All(R"(SELECT "id", "name", "address" FROM "Users")"));
 
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             // clang-format off
             return q.FromTable(RecordTableName<Users>)
@@ -249,7 +249,7 @@ struct UsersFields
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.FieldsForFieldMembers", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder([](SqlQueryBuilder& q) { return q.FromTable("Users").Select().Fields<UsersFields>().First(); },
+    CheckSqlQueryBuilder([](SqlQueryBuilder& q) { return q.FromTable("Users").Select().Fields<UsersFields>().First(); },
                          QueryExpectations {
                              .sqlite = R"(SELECT "name", "address" FROM "Users" LIMIT 1)",
                              .postgres = R"(SELECT "name", "address" FROM "Users" LIMIT 1)",
@@ -266,7 +266,7 @@ struct QueryBuilderTestEmail
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.FieldsWithBelongsTo", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             return q.FromTable("QueryBuilderTestEmail").Select().Fields<QueryBuilderTestEmail>().First();
         },
@@ -288,7 +288,7 @@ struct QueryBuilderTestEmailWithAliases
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.FieldsWithBelongsToAndAliases", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             return q.FromTable("QueryBuilderTestEmail").Select().Fields<QueryBuilderTestEmailWithAliases>().First();
         },
@@ -303,7 +303,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.FieldsWithBelongsToAndAliases"
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.ComplexOR", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             using namespace std::string_view_literals;
             return q.FromTable("Table1")
@@ -328,7 +328,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.ComplexOR", "[SqlQueryBuilder]
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.WhereNotNull", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             // clang-format off
             return q.FromTable("Table")
@@ -343,7 +343,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.WhereNotNull", "[SqlQuer
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.WhereNull", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             // clang-format off
             return q.FromTable("Table")
@@ -358,7 +358,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.WhereNull", "[SqlQueryBu
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.Junctors", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             // clang-format off
             return q.FromTable("Table")
@@ -378,19 +378,19 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.Junctors", "[SqlQueryBui
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn", "[SqlQueryBuilder]")
 {
     // Check functionality of container overloads for IN
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) { return q.FromTable("That").Delete().WhereIn("foo", std::vector { 1, 2, 3 }); },
         QueryExpectations::All(R"(DELETE FROM "That"
                                   WHERE "foo" IN (1, 2, 3))"));
 
     // Check functionality of an lvalue input range
     auto const values = std::set { 1, 2, 3 };
-    checkSqlQueryBuilder([&](SqlQueryBuilder& q) { return q.FromTable("That").Delete().WhereIn("foo", values); },
+    CheckSqlQueryBuilder([&](SqlQueryBuilder& q) { return q.FromTable("That").Delete().WhereIn("foo", values); },
                          QueryExpectations::All(R"(DELETE FROM "That"
                                                    WHERE "foo" IN (1, 2, 3))"));
 
     // Check functionality of the initializer_list overload for IN
-    checkSqlQueryBuilder([](SqlQueryBuilder& q) { return q.FromTable("That").Delete().WhereIn("foo", { 1, 2, 3 }); },
+    CheckSqlQueryBuilder([](SqlQueryBuilder& q) { return q.FromTable("That").Delete().WhereIn("foo", { 1, 2, 3 }); },
                          QueryExpectations::All(R"(DELETE FROM "That"
                                                    WHERE "foo" IN (1, 2, 3))"));
 }
@@ -400,7 +400,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn with strings", "[SqlQu
     using namespace std::string_view_literals;
 
     // Check functionality of container overloads for IN
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             return q.FromTable("That").Delete().WhereIn("foo", std::vector { "foo"sv, "bar"sv, "com"sv });
         },
@@ -409,12 +409,12 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn with strings", "[SqlQu
 
     // Check functionality of an lvalue input range
     auto const values = std::set { "foo"sv, "bar"sv, "com"sv }; // will be alphabetically sorted on iteration
-    checkSqlQueryBuilder([&](SqlQueryBuilder& q) { return q.FromTable("That").Delete().WhereIn("foo", values); },
+    CheckSqlQueryBuilder([&](SqlQueryBuilder& q) { return q.FromTable("That").Delete().WhereIn("foo", values); },
                          QueryExpectations::All(R"(DELETE FROM "That"
                                                    WHERE "foo" IN ('bar', 'com', 'foo'))"));
 
     // Check functionality of the initializer_list overload for IN
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) { return q.FromTable("That").Delete().WhereIn("foo", { "foo"sv, "bar"sv, "com"sv }); },
         QueryExpectations::All(R"(DELETE FROM "That"
                                                    WHERE "foo" IN ('foo', 'bar', 'com'))"));
@@ -422,7 +422,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn with strings", "[SqlQu
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Join", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             return q.FromTable("That").Select().Fields("foo", "bar").InnerJoin("Other", "id", "that_id").All();
         },
@@ -430,7 +430,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Join", "[SqlQueryBuilder]")
             R"(SELECT "foo", "bar" FROM "That"
                INNER JOIN "Other" ON "Other"."id" = "That"."that_id")"));
 
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             return q.FromTable("That").Select().Fields("foo", "bar").LeftOuterJoin("Other", "id", "that_id").All();
         },
@@ -438,7 +438,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Join", "[SqlQueryBuilder]")
             R"(SELECT "foo", "bar" FROM "That"
                LEFT OUTER JOIN "Other" ON "Other"."id" = "That"."that_id")"));
 
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             using namespace std::string_view_literals;
             return q.FromTable("Table_A")
@@ -455,7 +455,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Join", "[SqlQueryBuilder]")
                                " LEFT OUTER JOIN \"Table_B\" ON \"Table_B\".\"id\" = \"Table_A\".\"that_id\"\n"
                                " WHERE \"Table_A\".\"foo\" = 42"));
 
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             using namespace std::string_view_literals;
             return q.FromTable("Table_A")
@@ -477,7 +477,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Join", "[SqlQueryBuilder]")
                INNER JOIN "Table_B" ON "Table_B"."id" = "Table_A"."that_id" AND "Table_B"."that_foo" = "Table_A"."foo"
                WHERE "Table_A"."foo" = 42)"));
 
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             using namespace std::string_view_literals;
             return q.FromTable("Table_A")
@@ -504,7 +504,7 @@ TEST_CASE_METHOD(SqlTestFixture, "Join with table aliasing", "[SqlQueryBuilder]"
 {
     SECTION("simple case")
     {
-        checkSqlQueryBuilder(
+        CheckSqlQueryBuilder(
             [](SqlQueryBuilder& q) {
                 return q.FromTable("That")
                     .Select()
@@ -520,7 +520,7 @@ TEST_CASE_METHOD(SqlTestFixture, "Join with table aliasing", "[SqlQueryBuilder]"
     SECTION("Join multiple times to self")
     {
         // clang-format off
-        checkSqlQueryBuilder(
+        CheckSqlQueryBuilder(
             [](SqlQueryBuilder& q) {
                 using namespace std::string_view_literals;
                 return q.FromTableAs("That", "A")
@@ -578,7 +578,7 @@ struct JoinTestC
 
 TEST_CASE_METHOD(SqlTestFixture, "Query Join", "[DataMapper]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             // clang-format off
             return q.FromTable(RecordTableName<JoinTestA>)
@@ -598,7 +598,7 @@ TEST_CASE_METHOD(SqlTestFixture, "Query Join", "[DataMapper]")
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.Field", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) { return q.FromTable("That").Select().Field("foo").Field("bar").All(); },
         QueryExpectations::All(R"(SELECT "foo", "bar" FROM "That")"));
 }
@@ -607,14 +607,14 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.Field", "[SqlQueryBuild
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.SelectAs", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) { return q.FromTable("That").Select().Field("foo").As("F").Field("bar").As("B").All(); },
         QueryExpectations::All(R"(SELECT "foo" AS "F", "bar" AS "B" FROM "That")"));
 }
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.FromTableAs", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             return q.FromTableAs("Other", "O")
                 .Select()
@@ -628,7 +628,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.FromTableAs", "[SqlQueryBuilde
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Insert", "[SqlQueryBuilder]")
 {
     std::vector<SqlVariant> boundValues;
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [&](SqlQueryBuilder& q) {
             return q.FromTableAs("Other", "O")
                 .Insert(&boundValues)
@@ -648,7 +648,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Insert", "[SqlQueryBuilder]")
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Update", "[SqlQueryBuilder]")
 {
     std::vector<SqlVariant> boundValues;
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [&](SqlQueryBuilder& q) {
             return q.FromTableAs("Other", "O").Update(&boundValues).Set("foo", 42).Set("bar", "baz").Where("id", 123);
         },
@@ -665,7 +665,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Update", "[SqlQueryBuilder]")
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.Lambda", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             return q.FromTable("That")
                 .Select()
@@ -680,7 +680,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.Lambda", "[SqlQueryBuild
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereColumn", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             return q.FromTable("That").Select().Field("foo").WhereColumn("left", "=", "right").All();
         },
@@ -692,7 +692,7 @@ TEST_CASE_METHOD(SqlTestFixture,
                  "Where: SqlQualifiedTableColumnName OP SqlQualifiedTableColumnName",
                  "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             return q.FromTable("That")
                 .Select()
@@ -708,7 +708,7 @@ TEST_CASE_METHOD(SqlTestFixture,
 
 TEST_CASE_METHOD(SqlTestFixture, "Where: left IS NULL", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             return q.FromTable("That")
                 .Select()
@@ -720,7 +720,7 @@ TEST_CASE_METHOD(SqlTestFixture, "Where: left IS NULL", "[SqlQueryBuilder]")
         QueryExpectations::All(R"(SELECT "foo" FROM "That"
                                   WHERE "Left1" IS NULL AND "Left2" IS NULL)"));
 
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             // clang-format off
             return q.FromTable("That")
@@ -913,7 +913,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder: sub select with WhereIn", "[S
 
 TEST_CASE_METHOD(SqlTestFixture, "DropTable", "[SqlQueryBuilder][Migration]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             auto migration = q.Migration();
             migration.DropTable("Table");
@@ -927,7 +927,7 @@ TEST_CASE_METHOD(SqlTestFixture, "DropTable", "[SqlQueryBuilder][Migration]")
 TEST_CASE_METHOD(SqlTestFixture, "CreateTable with Column", "[SqlQueryBuilder][Migration]")
 {
     using namespace SqlColumnTypeDefinitions;
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             auto migration = q.Migration();
             migration.CreateTable("Test").Column("column", Varchar { 255 });
@@ -942,7 +942,7 @@ TEST_CASE_METHOD(SqlTestFixture, "CreateTable with Column", "[SqlQueryBuilder][M
 TEST_CASE_METHOD(SqlTestFixture, "CreateTable with RequiredColumn", "[SqlQueryBuilder][Migration]")
 {
     using namespace SqlColumnTypeDefinitions;
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             auto migration = q.Migration();
             migration.CreateTable("Test").RequiredColumn("column", Varchar { 255 });
@@ -957,7 +957,7 @@ TEST_CASE_METHOD(SqlTestFixture, "CreateTable with RequiredColumn", "[SqlQueryBu
 TEST_CASE_METHOD(SqlTestFixture, "CreateTable with Column: Guid", "[SqlQueryBuilder][Migration]")
 {
     using namespace SqlColumnTypeDefinitions;
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             auto migration = q.Migration();
             migration.CreateTable("Test").RequiredColumn("column", Guid {});
@@ -986,7 +986,7 @@ TEST_CASE_METHOD(SqlTestFixture, "CreateTable with Column: Guid", "[SqlQueryBuil
 TEST_CASE_METHOD(SqlTestFixture, "CreateTable with PrimaryKey", "[SqlQueryBuilder][Migration]")
 {
     using namespace SqlColumnTypeDefinitions;
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             auto migration = q.Migration();
             migration.CreateTable("Test").PrimaryKey("pk", Integer {});
@@ -1002,7 +1002,7 @@ TEST_CASE_METHOD(SqlTestFixture, "CreateTable with PrimaryKey", "[SqlQueryBuilde
 TEST_CASE_METHOD(SqlTestFixture, "CreateTable with PrimaryKeyWithAutoIncrement", "[SqlQueryBuilder][Migration]")
 {
     using namespace SqlColumnTypeDefinitions;
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             auto migration = q.Migration();
             migration.CreateTable("Test").PrimaryKeyWithAutoIncrement("pk");
@@ -1031,7 +1031,7 @@ TEST_CASE_METHOD(SqlTestFixture, "CreateTable with PrimaryKeyWithAutoIncrement",
 TEST_CASE_METHOD(SqlTestFixture, "CreateTable with Index", "[SqlQueryBuilder][Migration]")
 {
     using namespace SqlColumnTypeDefinitions;
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             auto migration = q.Migration();
             migration.CreateTable("Table").RequiredColumn("column", Integer {}).Index();
@@ -1047,7 +1047,7 @@ TEST_CASE_METHOD(SqlTestFixture, "CreateTable with Index", "[SqlQueryBuilder][Mi
 TEST_CASE_METHOD(SqlTestFixture, "CreateTable with foreign key", "[SqlQueryBuilder][Migration]")
 {
     using namespace SqlColumnTypeDefinitions;
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             auto migration = q.Migration();
             migration.CreateTable("Table").ForeignKey("other_id",
@@ -1081,7 +1081,7 @@ TEST_CASE_METHOD(SqlTestFixture, "CreateTable with foreign key", "[SqlQueryBuild
 TEST_CASE_METHOD(SqlTestFixture, "CreateTable complex demo", "[SqlQueryBuilder][Migration]")
 {
     using namespace SqlColumnTypeDefinitions;
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             // clang-format off
             auto migration = q.Migration();
@@ -1140,7 +1140,7 @@ TEST_CASE_METHOD(SqlTestFixture, "CreateTable complex demo", "[SqlQueryBuilder][
 TEST_CASE_METHOD(SqlTestFixture, "AlterTable AddColumn", "[SqlQueryBuilder][Migration]")
 {
     using namespace SqlColumnTypeDefinitions;
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             auto migration = q.Migration();
             migration.AlterTable("Table").AddColumn("column", Bigint {});
@@ -1163,7 +1163,7 @@ TEST_CASE_METHOD(SqlTestFixture, "AlterTable AlterColumn", "[SqlQueryBuilder][Mi
 
     SECTION("change type")
     {
-        runSqlQueryBuilder(QueryBuilderCheck {
+        RunSqlQueryBuilder(QueryBuilderCheck {
             .prepare = [](SqlMigrationQueryBuilder migration) -> SqlMigrationPlan {
                 migration.CreateTable("Table").Column("column", Char { 10 });
                 return migration.GetPlan();
@@ -1177,7 +1177,7 @@ TEST_CASE_METHOD(SqlTestFixture, "AlterTable AlterColumn", "[SqlQueryBuilder][Mi
 
     SECTION("change nullability")
     {
-        runSqlQueryBuilder(QueryBuilderCheck {
+        RunSqlQueryBuilder(QueryBuilderCheck {
             .prepare = [](SqlMigrationQueryBuilder migration) -> SqlMigrationPlan {
                 migration.CreateTable("Table").Column("column", Char { 10 });
                 return migration.GetPlan();
@@ -1194,7 +1194,7 @@ TEST_CASE_METHOD(SqlTestFixture, "AlterTable AlterColumn", "[SqlQueryBuilder][Mi
 TEST_CASE_METHOD(SqlTestFixture, "AlterTable multiple AddColumn calls", "[SqlQueryBuilder][Migration]")
 {
     using namespace SqlColumnTypeDefinitions;
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             auto migration = q.Migration();
             migration.AlterTable("Table").AddColumn("column", Bigint {}).AddColumn("column2", Varchar { 255 });
@@ -1218,7 +1218,7 @@ TEST_CASE_METHOD(SqlTestFixture, "AlterTable multiple AddColumn calls", "[SqlQue
 
 TEST_CASE_METHOD(SqlTestFixture, "AlterTable RenameColumn", "[SqlQueryBuilder][Migration]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             auto migration = q.Migration();
             migration.AlterTable("Table").RenameColumn("old", "new");
@@ -1230,7 +1230,7 @@ TEST_CASE_METHOD(SqlTestFixture, "AlterTable RenameColumn", "[SqlQueryBuilder][M
 
 TEST_CASE_METHOD(SqlTestFixture, "AlterTable RenameTo", "[SqlQueryBuilder][Migration]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             auto migration = q.Migration();
             migration.AlterTable("Table").RenameTo("NewTable");
@@ -1242,7 +1242,7 @@ TEST_CASE_METHOD(SqlTestFixture, "AlterTable RenameTo", "[SqlQueryBuilder][Migra
 
 TEST_CASE_METHOD(SqlTestFixture, "AlterTable AddIndex", "[SqlQueryBuilder][Migration]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             auto migration = q.Migration();
             migration.AlterTable("Table").AddIndex("column");
@@ -1254,7 +1254,7 @@ TEST_CASE_METHOD(SqlTestFixture, "AlterTable AddIndex", "[SqlQueryBuilder][Migra
 
 TEST_CASE_METHOD(SqlTestFixture, "AlterTable AddUniqueIndex", "[SqlQueryBuilder][Migration]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             auto migration = q.Migration();
             migration.AlterTable("Table").AddUniqueIndex("column");
@@ -1266,7 +1266,7 @@ TEST_CASE_METHOD(SqlTestFixture, "AlterTable AddUniqueIndex", "[SqlQueryBuilder]
 
 TEST_CASE_METHOD(SqlTestFixture, "AlterTable DropIndex", "[SqlQueryBuilder][Migration]")
 {
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             auto migration = q.Migration();
             migration.AlterTable("Table").DropIndex("column");
@@ -1278,7 +1278,7 @@ TEST_CASE_METHOD(SqlTestFixture, "AlterTable DropIndex", "[SqlQueryBuilder][Migr
 TEST_CASE_METHOD(SqlTestFixture, "AlterTable AddForeignKeyColumn", "[SqlQueryBuilder][Migration]")
 {
     using namespace SqlColumnTypeDefinitions;
-    checkSqlQueryBuilder(
+    CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) {
             auto migration = q.Migration();
             migration.AlterTable("Table").AddForeignKeyColumn("other_id",

--- a/src/tools/ddl2cpp.cpp
+++ b/src/tools/ddl2cpp.cpp
@@ -452,7 +452,7 @@ void GenerateExample(Configuration const& config,
     auto const sourceFileName = normalizedOutputDir + "example.cpp";
     auto file = std::ofstream(sourceFileName); // NOLINT(bugprone-suspicious-stringview-data-usage)
 
-    file << cxxModelPrinter.tableIncludes();
+    file << cxxModelPrinter.TableIncludes();
     file << "#include <cstdlib>\n";
     file << "\n";
     file << "int main()\n";
@@ -464,7 +464,7 @@ void GenerateExample(Configuration const& config,
     file << "\n";
     for (auto const& table: tables)
     {
-        file << cxxModelPrinter.example(table);
+        file << cxxModelPrinter.Example(table);
     }
     file << "\n";
     file << "return EXIT_SUCCESS;\n";
@@ -527,7 +527,7 @@ int main(int argc, char const* argv[])
         std::println("{}", cxxModelPrinter.ToString(config.modelNamespace));
     else
         TimedExecution(std::format("Writing to directory {}", config.outputDirectory),
-                       [&] { cxxModelPrinter.printToFiles(config.modelNamespace, config.outputDirectory); });
+                       [&] { cxxModelPrinter.PrintToFiles(config.modelNamespace, config.outputDirectory); });
 
     if (!config.cumulativeHeaderFile.empty())
     {


### PR DESCRIPTION
tried to fix *some* of the reports (mostly naming related) from clang-tidy, but explictly marked some as ignored, where we intentionally want to break, to mimmick C++ standard library API for container like classes, and similar.

The goal isto take clang-tidy reports serious again, and ideally also hard-fail CI on reports in the future.

### Actively ignored naming suggestions
those that are intentionally mimmicking standard C++ API

- `begin()` / `end()`
- `push_back()`
- `str()`
- `data()`
- `format(...)` (std::format specializations)