### PR TITLE
Add compile-time helper `QualifiedColumnName<"TableName.ColumnName">` for constructing  qualified column name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,11 +101,9 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
       - name: "vcpkg: Install dependencies"
-        uses: lukka/run-vcpkg@v11.1
-        id: runvcpkg
-        with:
-          vcpkgDirectory: ${{ runner.workspace }}/vcpkg
-          vcpkgGitCommitId: 80403036a665cb8fcc1a1b3e17593d20b03b2489
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git ${{ runner.workspace }}\vcpkg
+          ${{ runner.workspace }}\vcpkg\bootstrap-vcpkg.bat
       - name: "Install SQLite3 for Win32"
         run: |
           choco install sqliteodbc

--- a/docs/sqlquery.md
+++ b/docs/sqlquery.md
@@ -80,6 +80,7 @@ interface. Here we present a compressed list of functions that can be used to cr
   - `Field()`
     - Simple usage `Field("field")` 
     - With table name specification as `Field(SqlQualifiedTableColumnName { "Table", "field" })`
+    - Helper function to construct `SqlQualifiedTableColumnName` from a string `QualifiedColumnName<"Table.field">`
   - `Fields()`
     - Simple usage `Fields({"a", "b", "c"})`
     - Fields from another table `Fields({"a", "b", "c"}, "Table_B")`

--- a/src/Lightweight/SqlQuery/Core.hpp
+++ b/src/Lightweight/SqlQuery/Core.hpp
@@ -5,9 +5,9 @@
 #include "../Api.hpp"
 #include "../SqlQueryFormatter.hpp"
 
+#include <algorithm>
 #include <concepts>
 #include <ranges>
-#include <algorithm>
 
 namespace Lightweight
 {
@@ -66,10 +66,13 @@ struct SqlQualifiedTableColumnName
 /// tableName = "Table" and columnName = "Column".
 template <Reflection::StringLiteral columnLiteral>
 constexpr SqlQualifiedTableColumnName QualifiedColumnName = []() consteval {
+#if !defined(_MSC_VER)
     // enforce that we do not have symbols \ [ ] " '
-    static_assert(!std::ranges::any_of(columnLiteral,
-                                       [](char c) { return c == '\\' || c == '[' || c == ']' || c == '"' || c == '\''; }),
-                  "QualifiedColumnName should not contain symbols \\ [ ] \" '");
+    static_assert(
+        !std::ranges::any_of(columnLiteral,
+                             [](char c) consteval { return c == '\\' || c == '[' || c == ']' || c == '"' || c == '\''; }),
+        "QualifiedColumnName should not contain symbols \\ [ ] \" '");
+#endif
 
     static_assert(std::ranges::count(columnLiteral, '.') == 1,
                   "QualifiedColumnName requires a column name with a single '.' to separate table and column name");

--- a/src/tests/DataMapper/ReadTests.cpp
+++ b/src/tests/DataMapper/ReadTests.cpp
@@ -4,6 +4,7 @@
 #include "Entities.hpp"
 
 #include <Lightweight/Lightweight.hpp>
+#include <Lightweight/SqlQuery/Core.hpp>
 
 #include <reflection-cpp/reflection.hpp>
 
@@ -313,7 +314,7 @@ TEST_CASE_METHOD(SqlTestFixture, "Query: SELECT into simple struct", "[DataMappe
     auto records =
         dm.Query<SimpleStruct>(dm.FromTable("TableA")
                                    .Select()
-                                   .Field(SqlQualifiedTableColumnName { .tableName = "TableA", .columnName = "pk" })
+                                   .Field(QualifiedColumnName<"TableA.pk">)
                                    .Field(SqlQualifiedTableColumnName { .tableName = "TableB", .columnName = "pk" })
                                    .Fields({ "c1"sv, "c2"sv }, "TableA"sv)
                                    .Fields({ "c1"sv, "c2"sv }, "TableB"sv)

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -534,10 +534,10 @@ TEST_CASE_METHOD(SqlTestFixture, "Join with table aliasing", "[SqlQueryBuilder]"
                                    SqlQualifiedTableColumnName { .tableName ="A", .columnName = "bar" })
                         .InnerJoin(AliasedTableName { .tableName = "That", .alias = "C" },
                                    "bar",
-                                   SqlQualifiedTableColumnName { .tableName = "B", .columnName = "com" })
+                                   QualifiedColumnName<"B.com">)
                         .InnerJoin(AliasedTableName { .tableName = "That", .alias = "D" },
                                    "com",
-                                   SqlQualifiedTableColumnName { .tableName = "C", .columnName = "tar" })
+                                   QualifiedColumnName<"C.tar">)
                         .All();
             },
             QueryExpectations::All(


### PR DESCRIPTION
Closes https://github.com/LASTRADA-Software/Lightweight/issues/339

Implements a helper function `QualifiedColumnName` that construct `SqlQualifiedTableColumnName` given one string