### PR TITLE
Drop belongs to name implementation

### DIFF
--- a/src/Lightweight/Utils.hpp
+++ b/src/Lightweight/Utils.hpp
@@ -101,22 +101,6 @@ namespace detail
         }();
     };
 
-    template <std::size_t I, typename Record>
-    struct BelongsToNameImpl
-    {
-        static constexpr auto baseName = Reflection::MemberNameOf<I, Record>;
-        static constexpr auto storage = []() -> std::array<char, baseName.size() + 4>
-        {
-            std::array<char, baseName.size() + 4> storage {};
-            std::copy_n(baseName.begin(), baseName.size(), storage.begin());
-            std::copy_n("_id", 3, storage.begin() + baseName.size());
-            storage.back() = '\0';
-            return storage;
-        }
-        ();
-        static constexpr auto name = std::string_view(storage.data(), storage.size() - 1);
-    };
-
     template <typename FieldType>
     constexpr auto ColumnNameOverride = []() consteval {
         if constexpr (requires { FieldType::ColumnNameOverride; })
@@ -150,12 +134,7 @@ namespace detail
         {
             return FieldType::ColumnNameOverride;
         }
-        else if constexpr (requires { FieldType::ReferencedField; }) // check isBelongsTo
-        {
-            return detail::BelongsToNameImpl<I, Record>::name;
-        }
-        else
-            return Reflection::MemberNameOf<I, Record>;
+        return Reflection::MemberNameOf<I, Record>;
     }
 } // namespace detail
 

--- a/src/tests/DataMapper/Entities.hpp
+++ b/src/tests/DataMapper/Entities.hpp
@@ -48,7 +48,7 @@ struct Email
 {
     Light::Field<Light::SqlGuid, Light::PrimaryKey::AutoAssign> id {};
     Light::Field<Light::SqlAnsiString<30>> address {};
-    Light::BelongsTo<&User::id> user {};
+    Light::BelongsTo<&User::id, Light::SqlRealName { "user_id" }> user {};
 
     constexpr std::weak_ordering operator<=>(Email const& other) const = default;
 };
@@ -104,8 +104,8 @@ struct Appointment
     Light::Field<Light::SqlGuid, Light::PrimaryKey::AutoAssign> id;
     Light::Field<Light::SqlDateTime> date;
     Light::Field<Light::SqlAnsiString<80>> comment;
-    Light::BelongsTo<&Physician::id> physician;
-    Light::BelongsTo<&Patient::id> patient;
+    Light::BelongsTo<&Physician::id, Light::SqlRealName { "physician_id" }> physician;
+    Light::BelongsTo<&Patient::id, Light::SqlRealName { "patient_id" }> patient;
 
     constexpr std::weak_ordering operator<=>(Appointment const& other) const
     {

--- a/src/tests/DataMapper/RelationTests.cpp
+++ b/src/tests/DataMapper/RelationTests.cpp
@@ -417,7 +417,7 @@ struct AliasedRecord
 struct BelongsToAliasedRecord
 {
     Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id {};
-    BelongsTo<&AliasedRecord::id> record;
+    BelongsTo<&AliasedRecord::id, SqlRealName { "record_id" }> record;
 };
 
 static_assert(std::same_as<typename BelongsTo<&AliasedRecord::id>::ReferencedRecord, AliasedRecord>);

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -261,7 +261,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.FieldsForFieldMembers", "[SqlQ
 struct QueryBuilderTestEmail
 {
     Field<std::string> email;
-    BelongsTo<&UsersFields::name> user;
+    BelongsTo<&UsersFields::name, SqlRealName{"user_id"} > user;
 };
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.FieldsWithBelongsTo", "[SqlQueryBuilder]")


### PR DESCRIPTION
This PR removes belongs to name implementation function since this can be something not expected by the user and does not bring any benefits in my opinion 