### PR TITLE
Rename FullFieldNameOf to QuotedFieldNameOf

### DIFF
--- a/src/Lightweight/DataMapper/QueryBuilders.hpp
+++ b/src/Lightweight/DataMapper/QueryBuilders.hpp
@@ -376,7 +376,7 @@ class [[nodiscard]] SqlCoreDataMapperQueryBuilder: public SqlBasicSelectQueryBui
     {
         auto constexpr count = 1;
         _stmt.ExecuteDirect(_formatter.SelectFirst(this->_query.distinct,
-                                                   FullFieldNameOf<Field>.string_view(),
+                                                   QuotedFieldNameOf<Field>.string_view(),
                                                    RecordTableName<Record>,
                                                    this->_query.searchCondition.tableAlias,
                                                    this->_query.searchCondition.tableJoins,

--- a/src/tests/DataMapper/NamingTests.cpp
+++ b/src/tests/DataMapper/NamingTests.cpp
@@ -47,10 +47,10 @@ TEST_CASE_METHOD(SqlTestFixture, "SQL entity naming", "[DataMapper]")
     static_assert(FieldNameOf<&NamingTest2::pk1> == "First_PK"sv);
     static_assert(FieldNameOf<&NamingTest2::pk2> == "Second_PK"sv);
 
-    static_assert(FullFieldNameOf<&NamingTest1::normal> == R"("NamingTest1"."normal")");
-    static_assert(FullFieldNameOf<&NamingTest1::name> == R"("NamingTest1"."c1")");
-    static_assert(FullFieldNameOf<&NamingTest2::pk1> == R"("NamingTest2_aliased"."First_PK")");
-    static_assert(FullFieldNameOf<&NamingTest2::pk2> == R"("NamingTest2_aliased"."Second_PK")");
+    static_assert(QuotedFieldNameOf<&NamingTest1::normal> == R"("NamingTest1"."normal")");
+    static_assert(QuotedFieldNameOf<&NamingTest1::name> == R"("NamingTest1"."c1")");
+    static_assert(QuotedFieldNameOf<&NamingTest2::pk1> == R"("NamingTest2_aliased"."First_PK")");
+    static_assert(QuotedFieldNameOf<&NamingTest2::pk2> == R"("NamingTest2_aliased"."Second_PK")");
 }
 
 namespace Models

--- a/src/tests/DataMapper/ReadTests.cpp
+++ b/src/tests/DataMapper/ReadTests.cpp
@@ -125,14 +125,14 @@ TEST_CASE_METHOD(SqlTestFixture, "Query into First()", "[DataMapper]")
 
     SECTION("Get()")
     {
-        auto const record = dm.Query<Person>().Where(FullFieldNameOf<&Person::age>, "=", 36).First();
+        auto const record = dm.Query<Person>().Where(FieldNameOf<&Person::age>, "=", 36).First();
         CHECK(record.has_value());
         CHECK(record.value() == expectedPersons[2]);
     }
 
     SECTION("Get() with non-existing record")
     {
-        auto const record = dm.Query<Person>().Where(FullFieldNameOf<&Person::age>, "=", -5).First();
+        auto const record = dm.Query<Person>().Where(FieldNameOf<&Person::age>, "=", -5).First();
         CHECK(record.has_value() == false);
     }
 


### PR DESCRIPTION
closes #343.

@Yaraslaut this streamlines its plural sibling `QuotedFieldNamesOf<F...>` that was already calling `FullFieldNameOf<F>` to generate the full list. This reduces the naming convention diversion, hopefully.