### PR TITLE
Remove some noisy api from `BelongsTo`

### DIFF
--- a/src/Lightweight/DataMapper/BelongsTo.hpp
+++ b/src/Lightweight/DataMapper/BelongsTo.hpp
@@ -200,12 +200,6 @@ class BelongsTo
     /// Retrieves an immutable reference to the record from the relationship.
     [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord const& Record() const { RequireLoaded(); return *_record; }
 
-    /// Checks if the record is loaded into memory.
-    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr bool IsLoaded() const noexcept { return _loaded; }
-
-    /// Unloads the record from memory.
-    LIGHTWEIGHT_FORCE_INLINE void Unload() noexcept { _record = nullptr; _loaded = false; }
-
     /// Retrieves the record from the relationship.
     [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord& operator*() noexcept { RequireLoaded(); return *_record; }
 

--- a/src/tests/DataMapper/MiscTests.cpp
+++ b/src/tests/DataMapper/MiscTests.cpp
@@ -450,7 +450,6 @@ TEST_CASE_METHOD(SqlTestFixture, "TestMessageStructTo", "[DataMapper]")
         dm->Create(to);
         auto const queriedTo = dm->QuerySingle<MessageStructTo>(to.id).value();
         REQUIRE(queriedTo.id.Value() == to.id.Value());
-        REQUIRE(!queriedTo.log_message.IsLoaded());
         REQUIRE(!queriedTo.log_message.Value().has_value());
     }
 }

--- a/src/tests/DataMapper/RelationTests.cpp
+++ b/src/tests/DataMapper/RelationTests.cpp
@@ -65,13 +65,8 @@ TEST_CASE_METHOD(SqlTestFixture, "BelongsTo", "[DataMapper][relations]")
     CHECK(actualEmail1 == email1);
     dm->ConfigureRelationAutoLoading(actualEmail1);
 
-    REQUIRE(!actualEmail1.user.IsLoaded());
     CHECK(actualEmail1.user->id == user.id);
-    REQUIRE(actualEmail1.user.IsLoaded());
     CHECK(actualEmail1.user->name == user.name);
-
-    actualEmail1.user.Unload();
-    REQUIRE(!actualEmail1.user.IsLoaded());
 
     if (dm->Connection().ServerType() == SqlServerType::SQLITE)
     {
@@ -106,7 +101,6 @@ TEST_CASE_METHOD(SqlTestFixture, "BelongsTo do not load", "[DataMapper][relation
     auto actualEmail1 = dm->QuerySingleWithoutRelationAutoLoading<Email>(email1.id).value();
 
     CHECK(actualEmail1.address == email1.address);
-    REQUIRE(!actualEmail1.user.IsLoaded());
 
     // The following test works locally but seems to fail on GitHub Actions with SIGSEGV
     if (!IsGithubActions())
@@ -228,9 +222,7 @@ TEST_CASE_METHOD(SqlTestFixture, "HasOneThrough", "[DataMapper][relations]")
 
     SECTION("Explicit loading")
     {
-        REQUIRE(!supplier1.accountHistory.IsLoaded());
         dm->LoadRelations(supplier1);
-        REQUIRE(supplier1.accountHistory.IsLoaded());
 
         CHECK(supplier1.accountHistory.Record() == accountHistory1);
     }
@@ -239,9 +231,7 @@ TEST_CASE_METHOD(SqlTestFixture, "HasOneThrough", "[DataMapper][relations]")
     {
         dm->ConfigureRelationAutoLoading(supplier1);
 
-        REQUIRE(!supplier1.accountHistory.IsLoaded());
         CHECK(supplier1.accountHistory.Record() == accountHistory1);
-        REQUIRE(supplier1.accountHistory.IsLoaded());
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/LASTRADA-Software/Lightweight/issues/367

Removed two functions from the belongs to since they are likely can create confusion instead of providing something for the user