### PR TITLE
Fixes some test case random breakage.

### DIFF
--- a/src/tests/DataMapper/MiscTests.cpp
+++ b/src/tests/DataMapper/MiscTests.cpp
@@ -548,9 +548,9 @@ TEST_CASE_METHOD(SqlTestFixture, "ExecuteDirect", "[DataMapper]")
     auto stmt = SqlStatement(dm->Connection());
 
     auto const date =
-        stmt.ExecuteDirectScalar<SqlDateTime>(std::format("SELECT {};", stmt.Connection().QueryFormatter().DateFunction()));
+        stmt.ExecuteDirectScalar<SqlDate>(std::format("SELECT {};", stmt.Connection().QueryFormatter().DateFunction()));
     auto const dateFromDataMapper =
-        dm->Execute<SqlDateTime>(std::format("SELECT {};", stmt.Connection().QueryFormatter().DateFunction()));
+        dm->Execute<SqlDate>(std::format("SELECT {};", stmt.Connection().QueryFormatter().DateFunction()));
 
     REQUIRE(date.has_value());
     REQUIRE(dateFromDataMapper.has_value());


### PR DESCRIPTION
SQL query DATE() is being used to test 2 different ways of querying. However, we used SqlDateTime to read the data. That for some reason gives different results back - sometimes.
Requesting SqlDate instead, should be better.