### PR TITLE
Fixes directory that is used when trying to figure out version

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -25,7 +25,7 @@ function(GetVersionInformation VersionTripleVar VersionStringVar)
         # --match "v*": only consider tags starting with 'v'
         execute_process(
             COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0 --match "v*"
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
             OUTPUT_VARIABLE GIT_TAG
             OUTPUT_STRIP_TRAILING_WHITESPACE
             ERROR_QUIET


### PR DESCRIPTION
This is needed, when you include Lightweight as a package using CPM for instance