### PR TITLE
QueryBuilder: Add support for WhereIn() with empty ranges not generating an `X IN ()` sub expression

### DIFF
--- a/src/Lightweight/SqlQuery/Core.hpp
+++ b/src/Lightweight/SqlQuery/Core.hpp
@@ -631,6 +631,8 @@ template <typename ColumnName, std::ranges::input_range InputRange>
 inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlWhereClauseBuilder<Derived>::WhereIn(ColumnName const& columnName,
                                                                                  InputRange const& values)
 {
+    if (values.empty())
+        return static_cast<Derived&>(*this);
     return Where(columnName, "IN", PopulateSqlSetExpression(values));
 }
 
@@ -639,6 +641,8 @@ template <typename ColumnName, typename T>
 inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlWhereClauseBuilder<Derived>::WhereIn(ColumnName const& columnName,
                                                                                  std::initializer_list<T> const& values)
 {
+    if (values.begin() == values.end())
+        return static_cast<Derived&>(*this);
     return Where(columnName, "IN", PopulateSqlSetExpression(values));
 }
 

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -395,6 +395,16 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn", "[SqlQueryBuilder]")
                                                    WHERE "foo" IN (1, 2, 3))"));
 }
 
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn with empty list", "[SqlQueryBuilder]")
+{
+    CheckSqlQueryBuilder([](SqlQueryBuilder& q) { return q.FromTable("That").Delete().WhereIn("foo", std::vector<int> {}); },
+                         QueryExpectations::All(R"(DELETE FROM "That")"));
+
+    CheckSqlQueryBuilder(
+        [](SqlQueryBuilder& q) { return q.FromTable("That").Delete().WhereIn("foo", std::initializer_list<int> {}); },
+        QueryExpectations::All(R"(DELETE FROM "That")"));
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn with strings", "[SqlQueryBuilder]")
 {
     using namespace std::string_view_literals;


### PR DESCRIPTION
no AI, just me, @Yaraslaut :-D

closes #422.