### PR TITLE
Do not use CPM if nlohmann_json already exist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ include(GNUInstallDirs)
 find_package(reflection-cpp 0.4.0 QUIET)
 find_package(Catch2 CONFIG REQUIRED)
 find_package(yaml-cpp CONFIG REQUIRED)
+find_package(nlohmann_json CONFIG QUIET)
 
 option(LIGHTWEIGHT_CXX26_REFLECTION "Enable experimental reflection support from C++26" OFF)
 

--- a/src/Lightweight/CMakeLists.txt
+++ b/src/Lightweight/CMakeLists.txt
@@ -28,11 +28,14 @@ if(WIN32)
 endif()
 # Note: libzip for non-Windows is handled in root CMakeLists.txt (system pkg-config or CPM fallback)
 
-CPMAddPackage(
+if(NOT nlohmann_json_FOUND)
+  message(STATUS "nlohmann_json not found, downloading via CPM")
+  CPMAddPackage(
     NAME nlohmann_json
     GITHUB_REPOSITORY nlohmann/json
     VERSION 3.11.3
-)
+  )
+endif()
 
 set(HEADER_FILES
     DataBinder/BasicStringBinder.hpp


### PR DESCRIPTION
A small fix for the CPM  usage, to ensure that if nlohmann_json already exist, do not load another one