### PR TITLE
[SqlBackup] Add tests for --schema-only backup/restore

### DIFF
--- a/src/tests/SqlBackup/Tests.cpp
+++ b/src/tests/SqlBackup/Tests.cpp
@@ -1633,4 +1633,123 @@ TEST_CASE("SqlBackup: Restore rejects unsupported format version", "[SqlBackup]"
     }
 }
 
+// =============================================================================
+// Schema-only Backup / Restore Tests
+// =============================================================================
+
+TEST_CASE("SqlBackup: Schema-only Backup and Restore", "[SqlBackup]")
+{
+    ScopedFileRemoved const backupFileCleaner { BackupFile };
+
+    SetupDatabase(); // creates test_table and inserts 3 rows
+
+    LambdaProgressManager pm { [](SqlBackup::Progress const& p) {
+        if (p.state == SqlBackup::Progress::State::Error)
+            FAIL_CHECK("Backup Error: " << p.message);
+    } };
+
+    SqlBackup::BackupSettings const backupSettings { .schemaOnly = true };
+    REQUIRE_NOTHROW(
+        SqlBackup::Backup(BackupFile, GetConnectionString(), 1, pm, "", "*", SqlBackup::RetrySettings {}, backupSettings));
+    REQUIRE(std::filesystem::exists(BackupFile));
+
+    // Inspect the archive: schema-only backup must contain metadata.json,
+    // must NOT contain any data/*.msgpack entries, and must NOT contain checksums.json.
+    // NOLINTBEGIN(clang-analyzer-nullability.*)
+    {
+        int err = 0;
+        zip_t* zip = zip_open(BackupFile.string().c_str(), ZIP_RDONLY, &err);
+        REQUIRE(zip != nullptr);
+
+        bool hasMetadata = false;
+        bool hasChecksums = false;
+        int dataEntryCount = 0;
+
+        zip_int64_t const numEntries = zip_get_num_entries(zip, 0);
+        for (zip_int64_t i = 0; i < numEntries; ++i)
+        {
+            char const* name = zip_get_name(zip, static_cast<zip_uint64_t>(i), 0);
+            if (name == nullptr)
+                continue;
+            std::string_view const sv { name };
+            if (sv == "metadata.json")
+                hasMetadata = true;
+            else if (sv == "checksums.json")
+                hasChecksums = true;
+            else if (sv.starts_with("data/"))
+                ++dataEntryCount;
+        }
+
+        zip_close(zip);
+
+        CHECK(hasMetadata);
+        CHECK_FALSE(hasChecksums);
+        CHECK(dataEntryCount == 0);
+    }
+    // NOLINTEND(clang-analyzer-nullability.*)
+
+    // Drop the table to simulate a clean target, then restore schema-only.
+    {
+        SqlConnection conn;
+        conn.Connect(GetConnectionString());
+        SqlStatement stmt { conn };
+        stmt.MigrateDirect([](SqlMigrationQueryBuilder& migration) { migration.DropTable("test_table"); });
+    }
+
+    LambdaProgressManager restorePm { [](SqlBackup::Progress const& p) {
+        if (p.state == SqlBackup::Progress::State::Error)
+            FAIL_CHECK("Restore Error: " << p.message);
+    } };
+
+    SqlBackup::RestoreSettings const restoreSettings { .schemaOnly = true };
+    REQUIRE_NOTHROW(SqlBackup::Restore(
+        BackupFile, GetConnectionString(), 1, restorePm, "", "*", SqlBackup::RetrySettings {}, restoreSettings));
+
+    // Table must exist but contain no rows.
+    SqlConnection conn;
+    conn.Connect(GetConnectionString());
+    SqlStatement stmt { conn };
+    auto const count = stmt.ExecuteDirectScalar<long long>("SELECT COUNT(*) FROM test_table");
+    REQUIRE(count == 0);
+}
+
+TEST_CASE("SqlBackup: Schema-only restore from full backup", "[SqlBackup]")
+{
+    ScopedFileRemoved const backupFileCleaner { BackupFile };
+
+    SetupDatabase(); // creates test_table and inserts 3 rows
+
+    // Produce a full backup (data included).
+    LambdaProgressManager pm { [](SqlBackup::Progress const& p) {
+        if (p.state == SqlBackup::Progress::State::Error)
+            FAIL_CHECK("Backup Error: " << p.message);
+    } };
+    REQUIRE_NOTHROW(SqlBackup::Backup(BackupFile, GetConnectionString(), 1, pm));
+    REQUIRE(std::filesystem::exists(BackupFile));
+
+    // Drop the table, then schema-only restore from the full archive.
+    {
+        SqlConnection conn;
+        conn.Connect(GetConnectionString());
+        SqlStatement stmt { conn };
+        stmt.MigrateDirect([](SqlMigrationQueryBuilder& migration) { migration.DropTable("test_table"); });
+    }
+
+    LambdaProgressManager restorePm { [](SqlBackup::Progress const& p) {
+        if (p.state == SqlBackup::Progress::State::Error)
+            FAIL_CHECK("Restore Error: " << p.message);
+    } };
+
+    SqlBackup::RestoreSettings const restoreSettings { .schemaOnly = true };
+    REQUIRE_NOTHROW(SqlBackup::Restore(
+        BackupFile, GetConnectionString(), 1, restorePm, "", "*", SqlBackup::RetrySettings {}, restoreSettings));
+
+    // The data chunks present in the archive must have been ignored.
+    SqlConnection conn;
+    conn.Connect(GetConnectionString());
+    SqlStatement stmt { conn };
+    auto const count = stmt.ExecuteDirectScalar<long long>("SELECT COUNT(*) FROM test_table");
+    REQUIRE(count == 0);
+}
+
 // NOLINTEND(bugprone-unchecked-optional-access)

--- a/src/tests/test_dbtool.py
+++ b/src/tests/test_dbtool.py
@@ -3,6 +3,8 @@ import argparse
 import subprocess
 import sys
 import os
+import tempfile
+import zipfile
 from pathlib import Path
 
 try:
@@ -168,6 +170,35 @@ def main():
     if "Add Email Column" not in output:
         print("Final verification failed")
         sys.exit(1)
+
+    print("--- 8. Schema-only Backup ---")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        schema_zip = os.path.join(tmpdir, "schema.zip")
+        run_command(base_cmd + ["backup", "--schema-only", "--output", schema_zip])
+        if not os.path.exists(schema_zip):
+            print("Schema-only backup did not produce an output file")
+            sys.exit(1)
+
+        with zipfile.ZipFile(schema_zip) as zf:
+            names = zf.namelist()
+
+        if "metadata.json" not in names:
+            print(f"Schema-only backup missing metadata.json (entries: {names})")
+            sys.exit(1)
+        if "checksums.json" in names:
+            print(f"Schema-only backup unexpectedly contains checksums.json (entries: {names})")
+            sys.exit(1)
+        data_entries = [n for n in names if n.startswith("data/")]
+        if data_entries:
+            print(f"Schema-only backup unexpectedly contains data entries: {data_entries}")
+            sys.exit(1)
+
+        print("--- 9. Schema-only Dry-run Backup ---")
+        dry_output = run_command(base_cmd + ["backup", "--schema-only", "--dry-run",
+                                             "--output", os.path.join(tmpdir, "discard.zip")]).stdout
+        if "schema only" not in dry_output.lower():
+            print(f"Dry-run output did not mention schema-only backup:\n{dry_output}")
+            sys.exit(1)
 
     print("SUCCESS")
 


### PR DESCRIPTION
The `--schema-only` flag for `dbtool backup` / `dbtool restore` is fully wired on master (CLI → `BackupSettings::schemaOnly` / `RestoreSettings::schemaOnly` → library short-circuits), but there was no test coverage for either branch. This PR adds tests at the library and CLI levels so the behaviour is guarded against regressions.

## Changes

- `src/tests/SqlBackup/Tests.cpp`: add `SqlBackup: Schema-only Backup and Restore` — performs a schema-only backup, opens the resulting ZIP with libzip, and asserts that `metadata.json` is present, no `data/*` entries exist, and `checksums.json` is absent; then schema-only-restores and asserts the table exists with 0 rows.
- `src/tests/SqlBackup/Tests.cpp`: add `SqlBackup: Schema-only restore from full backup` — produces a normal (data-bearing) backup and then restores it with `schemaOnly = true`, confirming the data chunks in the archive are ignored.
- `src/tests/test_dbtool.py`: extend the CLI integration script with two new steps — (1) `dbtool backup --schema-only` followed by a Python-side `zipfile` inspection of the archive layout, and (2) a `--dry-run --schema-only` invocation whose stdout must mention schema-only mode.

Verified across all three DBMS backends (`--test-env=sqlite3`, `postgres`, `mssql2022`) — all 115 `[SqlBackup]` cases pass on each, and the Python integration script completes end-to-end on SQLite.