### PR TITLE
Add release tagging for SQL migrations

### DIFF
--- a/src/Lightweight/SqlMigration.cpp
+++ b/src/Lightweight/SqlMigration.cpp
@@ -300,6 +300,84 @@ void MigrationManager::ValidateDependencies() const
     (void) TopoSortPending(std::move(pending), applied);
 }
 
+void MigrationManager::RegisterRelease(std::string version, MigrationTimestamp highestTimestamp)
+{
+    // Reject duplicate version strings.
+    auto const byVersion = std::ranges::find_if(_releases, [&](MigrationRelease const& r) { return r.version == version; });
+    if (byVersion != _releases.end())
+    {
+        throw std::runtime_error(
+            std::format("Duplicate release registration for version '{}' (existing timestamp {}, new timestamp {}).",
+                        version,
+                        byVersion->highestTimestamp.value,
+                        highestTimestamp.value));
+    }
+
+    // Reject duplicate timestamps — two releases cannot share the same cut-point.
+    auto const byTimestamp =
+        std::ranges::find_if(_releases, [&](MigrationRelease const& r) { return r.highestTimestamp == highestTimestamp; });
+    if (byTimestamp != _releases.end())
+    {
+        throw std::runtime_error(std::format("Duplicate release timestamp {}: '{}' conflicts with existing release '{}'.",
+                                             highestTimestamp.value,
+                                             version,
+                                             byTimestamp->version));
+    }
+
+    _releases.emplace_back(MigrationRelease { .version = std::move(version), .highestTimestamp = highestTimestamp });
+    std::ranges::sort(_releases, [](MigrationRelease const& a, MigrationRelease const& b) {
+        return a.highestTimestamp < b.highestTimestamp;
+    });
+}
+
+void MigrationManager::RemoveAllReleases()
+{
+    _releases.clear();
+}
+
+std::vector<MigrationRelease> const& MigrationManager::GetAllReleases() const noexcept
+{
+    return _releases;
+}
+
+MigrationRelease const* MigrationManager::FindReleaseByVersion(std::string_view version) const noexcept
+{
+    auto const it = std::ranges::find_if(_releases, [&](MigrationRelease const& r) { return r.version == version; });
+    return it != _releases.end() ? &*it : nullptr;
+}
+
+MigrationRelease const* MigrationManager::FindReleaseForTimestamp(MigrationTimestamp timestamp) const noexcept
+{
+    // _releases is sorted ascending by highestTimestamp. Return the first release whose
+    // highestTimestamp covers `timestamp`.
+    auto const it = std::ranges::lower_bound(_releases, timestamp, {}, &MigrationRelease::highestTimestamp);
+    return it != _releases.end() ? &*it : nullptr;
+}
+
+MigrationManager::MigrationList MigrationManager::GetMigrationsForRelease(std::string_view version) const
+{
+    auto const* target = FindReleaseByVersion(version);
+    if (!target)
+        return {};
+
+    // Determine the previous release's highestTimestamp as an exclusive lower bound.
+    MigrationTimestamp prev { 0 };
+    for (auto const& r: _releases)
+    {
+        if (r.highestTimestamp < target->highestTimestamp && r.highestTimestamp > prev)
+            prev = r.highestTimestamp;
+    }
+
+    MigrationList result;
+    for (auto const* migration: _migrations)
+    {
+        auto const ts = migration->GetTimestamp();
+        if (ts > prev && ts <= target->highestTimestamp)
+            result.push_back(migration);
+    }
+    return result;
+}
+
 namespace
 {
     std::optional<SqlString<128>> MakeOptionalSqlString128(std::string_view value)

--- a/src/Lightweight/SqlMigration.hpp
+++ b/src/Lightweight/SqlMigration.hpp
@@ -78,6 +78,25 @@ namespace SqlMigration
         size_t totalRegistered {};     ///< Total number of registered migrations
     };
 
+    /// Associates a software release with the highest migration timestamp present at release time.
+    ///
+    /// Releases are declared in source (typically a migration plugin) via
+    /// `LIGHTWEIGHT_SQL_RELEASE(version, highestTimestamp)`. They let tools answer questions like
+    /// "which migrations belong to release 6.7.0?" or "roll back everything applied after 6.7.0".
+    ///
+    /// The `highestTimestamp` is an inclusive upper bound: a migration `M` belongs to the release
+    /// iff `prev_release_ts < M.timestamp <= highestTimestamp`, where `prev_release_ts` is the
+    /// previous release's timestamp (or 0 if there is none).
+    ///
+    /// @ingroup SqlMigration
+    struct MigrationRelease
+    {
+        /// Human-readable version string, e.g. "6.7.0".
+        std::string version;
+        /// Highest migration timestamp contained in this release (inclusive).
+        MigrationTimestamp highestTimestamp;
+    };
+
     /// Main API to use for managing SQL migrations
     ///
     /// This class is a singleton and can be accessed using the GetInstance() method.
@@ -238,6 +257,46 @@ namespace SqlMigration
         /// @throws std::runtime_error if any dependency is unresolved or a cycle is found.
         LIGHTWEIGHT_API void ValidateDependencies() const;
 
+        /// Register a release marker for a software version.
+        ///
+        /// Typically called from `LIGHTWEIGHT_SQL_RELEASE(version, timestamp)` at static init time.
+        /// Releases are ordered by `highestTimestamp`; two releases may not share the same
+        /// `highestTimestamp`, and the same version string may not be registered twice.
+        ///
+        /// @param version Human-readable version, e.g. "6.7.0".
+        /// @param highestTimestamp Highest migration timestamp (inclusive) that belongs to this release.
+        /// @throws std::runtime_error on duplicate version or duplicate timestamp.
+        LIGHTWEIGHT_API void RegisterRelease(std::string version, MigrationTimestamp highestTimestamp);
+
+        /// Remove all registered releases. Useful for resetting state in tests.
+        LIGHTWEIGHT_API void RemoveAllReleases();
+
+        /// Get all registered releases, sorted ascending by `highestTimestamp`.
+        [[nodiscard]] LIGHTWEIGHT_API std::vector<MigrationRelease> const& GetAllReleases() const noexcept;
+
+        /// Find a release by exact version string match.
+        ///
+        /// @return Pointer to the matching release, or nullptr if no release with that version is registered.
+        [[nodiscard]] LIGHTWEIGHT_API MigrationRelease const* FindReleaseByVersion(std::string_view version) const noexcept;
+
+        /// Find the release whose timestamp range contains `timestamp`.
+        ///
+        /// Returns the release with the smallest `highestTimestamp` that is `>= timestamp`.
+        /// Returns nullptr if `timestamp` is greater than every registered release's highestTimestamp
+        /// (i.e., the migration is post-all-releases / unreleased).
+        [[nodiscard]] LIGHTWEIGHT_API MigrationRelease const* FindReleaseForTimestamp(
+            MigrationTimestamp timestamp) const noexcept;
+
+        /// Get all registered migrations belonging to a given release.
+        ///
+        /// A migration `M` belongs to release `R` iff
+        /// `prev_release_ts < M.timestamp <= R.highestTimestamp`, where `prev_release_ts` is the
+        /// previous release's timestamp (or 0 if `R` is the first release).
+        ///
+        /// @param version The version string to look up.
+        /// @return Migrations in the release, ordered by timestamp. Empty if the version is unknown.
+        [[nodiscard]] LIGHTWEIGHT_API MigrationList GetMigrationsForRelease(std::string_view version) const;
+
       private:
         /// Return the pending list in dependency-respecting order.
         ///
@@ -248,6 +307,7 @@ namespace SqlMigration
                                                     std::vector<MigrationTimestamp> const& applied) const;
 
         MigrationList _migrations;
+        std::vector<MigrationRelease> _releases;
         mutable DataMapper* _dataMapper { nullptr };
     };
 
@@ -496,11 +556,25 @@ namespace SqlMigration
     template <typename T>
     inline constexpr MigrationTimestamp TimestampOf = T::TimeStamp;
 
+    /// RAII registrar used by `LIGHTWEIGHT_SQL_RELEASE` to register a release with the
+    /// migration manager at static-initialization time. Not intended for direct use.
+    ///
+    /// @ingroup SqlMigration
+    struct ReleaseRegistrar
+    {
+        /// Registers `{version, highestTimestamp}` with the singleton manager.
+        ReleaseRegistrar(std::string version, MigrationTimestamp highestTimestamp)
+        {
+            MigrationManager::GetInstance().RegisterRelease(std::move(version), highestTimestamp);
+        }
+    };
+
 } // namespace SqlMigration
 
 } // namespace Lightweight
 
-#define _LIGHTWEIGHT_CONCATENATE(s1, s2) s1##s2
+#define _LIGHTWEIGHT_CONCATENATE(s1, s2)       s1##s2
+#define _LIGHTWEIGHT_CONCATENATE_INNER(s1, s2) _LIGHTWEIGHT_CONCATENATE(s1, s2)
 
 /// @brief Represents the C++ migration object for a given timestamped migration.
 /// @param timestamp Timestamp of the migration.
@@ -543,3 +617,87 @@ namespace SqlMigration
     static Migration_##timestamp _LIGHTWEIGHT_CONCATENATE(migration_, timestamp);                                      \
                                                                                                                        \
     void Migration_##timestamp::Up(Lightweight::SqlMigrationQueryBuilder& plan) const
+
+/// @brief Creates a new reversible migration whose `Down()` is defined out-of-line
+/// via @c LIGHTWEIGHT_SQL_MIGRATION_DOWN.
+///
+/// Use this variant when the migration needs to be reversible. Follow the macro with
+/// the `Up()` body, then later use `LIGHTWEIGHT_SQL_MIGRATION_DOWN(timestamp) { ... }`
+/// to provide the `Down()` body.
+///
+/// @param timestamp Timestamp of the migration.
+/// @param description Description of the migration.
+///
+/// @code
+/// LIGHTWEIGHT_SQL_MIGRATION_REVERSIBLE(20260117234120, "Create table 'MyTable'")
+/// {
+///     plan.CreateTable("MyTable").PrimaryKey("id", Integer());
+/// }
+///
+/// LIGHTWEIGHT_SQL_MIGRATION_DOWN(20260117234120)
+/// {
+///     plan.DropTable("MyTable");
+/// }
+/// @endcode
+///
+/// @ingroup SqlMigration
+#define LIGHTWEIGHT_SQL_MIGRATION_REVERSIBLE(timestamp, description)                                              \
+    struct Migration_##timestamp: public Lightweight::SqlMigration::MigrationBase                                 \
+    {                                                                                                             \
+        explicit Migration_##timestamp():                                                                         \
+            Lightweight::SqlMigration::MigrationBase(Lightweight::SqlMigration::MigrationTimestamp { timestamp }, \
+                                                     description)                                                 \
+        {                                                                                                         \
+        }                                                                                                         \
+                                                                                                                  \
+        void Up(Lightweight::SqlMigrationQueryBuilder& plan) const override;                                      \
+        void Down(Lightweight::SqlMigrationQueryBuilder& plan) const override;                                    \
+                                                                                                                  \
+        [[nodiscard]] bool HasDownImplementation() const noexcept override                                        \
+        {                                                                                                         \
+            return true;                                                                                          \
+        }                                                                                                         \
+    };                                                                                                            \
+                                                                                                                  \
+    static Migration_##timestamp _LIGHTWEIGHT_CONCATENATE(migration_, timestamp);                                 \
+                                                                                                                  \
+    void Migration_##timestamp::Up(Lightweight::SqlMigrationQueryBuilder& plan) const
+
+/// @brief Companion to @c LIGHTWEIGHT_SQL_MIGRATION_REVERSIBLE defining the out-of-line `Down()` body.
+///
+/// Must be used in the same translation unit and follow the matching
+/// `LIGHTWEIGHT_SQL_MIGRATION_REVERSIBLE(timestamp, ...)` declaration.
+///
+/// @param timestamp Timestamp of the migration whose Down() body follows.
+///
+/// @ingroup SqlMigration
+#define LIGHTWEIGHT_SQL_MIGRATION_DOWN(timestamp) \
+    void Migration_##timestamp::Down(Lightweight::SqlMigrationQueryBuilder& plan) const
+
+/// @brief Associates a software release (version string) with the highest migration timestamp
+/// present at the time of that release.
+///
+/// Declare one `LIGHTWEIGHT_SQL_RELEASE` per cut release, alongside the migrations that belong to it.
+/// The macro registers with the migration manager at static-initialization time. Multiple releases
+/// may coexist in the same translation unit.
+///
+/// @param version A string literal, e.g. `"6.7.0"`.
+/// @param highestTimestamp An unsigned integer literal matching the timestamp format used by migrations.
+///
+/// @code
+/// LIGHTWEIGHT_SQL_MIGRATION(20260101120000, "Initial schema") { ... }
+/// LIGHTWEIGHT_SQL_RELEASE("6.6.0", 20260101120000);
+///
+/// LIGHTWEIGHT_SQL_MIGRATION(20260501120000, "Add orders table") { ... }
+/// LIGHTWEIGHT_SQL_RELEASE("6.7.0", 20260501120000);
+/// @endcode
+///
+/// @ingroup SqlMigration
+#define LIGHTWEIGHT_SQL_RELEASE(version, highestTimestamp)                                                         \
+    static ::Lightweight::SqlMigration::ReleaseRegistrar _LIGHTWEIGHT_CONCATENATE_INNER(_lw_release_, __COUNTER__) \
+    {                                                                                                              \
+        (version), ::Lightweight::SqlMigration::MigrationTimestamp                                                 \
+        {                                                                                                          \
+            (highestTimestamp)                                                                                     \
+        }                                                                                                          \
+    }

--- a/src/Lightweight/SqlMigration.hpp
+++ b/src/Lightweight/SqlMigration.hpp
@@ -556,18 +556,21 @@ namespace SqlMigration
     template <typename T>
     inline constexpr MigrationTimestamp TimestampOf = T::TimeStamp;
 
-    /// RAII registrar used by `LIGHTWEIGHT_SQL_RELEASE` to register a release with the
-    /// migration manager at static-initialization time. Not intended for direct use.
-    ///
-    /// @ingroup SqlMigration
-    struct ReleaseRegistrar
+    namespace detail
     {
-        /// Registers `{version, highestTimestamp}` with the singleton manager.
-        ReleaseRegistrar(std::string version, MigrationTimestamp highestTimestamp)
+        /// RAII registrar used by `LIGHTWEIGHT_SQL_RELEASE` to register a release with the
+        /// migration manager at static-initialization time. Not intended for direct use.
+        ///
+        /// @ingroup SqlMigration
+        struct ReleaseRegistrar
         {
-            MigrationManager::GetInstance().RegisterRelease(std::move(version), highestTimestamp);
-        }
-    };
+            /// Registers `{version, highestTimestamp}` with the singleton manager.
+            ReleaseRegistrar(std::string version, MigrationTimestamp highestTimestamp)
+            {
+                MigrationManager::GetInstance().RegisterRelease(std::move(version), highestTimestamp);
+            }
+        };
+    } // namespace detail
 
 } // namespace SqlMigration
 
@@ -618,62 +621,6 @@ namespace SqlMigration
                                                                                                                        \
     void Migration_##timestamp::Up(Lightweight::SqlMigrationQueryBuilder& plan) const
 
-/// @brief Creates a new reversible migration whose `Down()` is defined out-of-line
-/// via @c LIGHTWEIGHT_SQL_MIGRATION_DOWN.
-///
-/// Use this variant when the migration needs to be reversible. Follow the macro with
-/// the `Up()` body, then later use `LIGHTWEIGHT_SQL_MIGRATION_DOWN(timestamp) { ... }`
-/// to provide the `Down()` body.
-///
-/// @param timestamp Timestamp of the migration.
-/// @param description Description of the migration.
-///
-/// @code
-/// LIGHTWEIGHT_SQL_MIGRATION_REVERSIBLE(20260117234120, "Create table 'MyTable'")
-/// {
-///     plan.CreateTable("MyTable").PrimaryKey("id", Integer());
-/// }
-///
-/// LIGHTWEIGHT_SQL_MIGRATION_DOWN(20260117234120)
-/// {
-///     plan.DropTable("MyTable");
-/// }
-/// @endcode
-///
-/// @ingroup SqlMigration
-#define LIGHTWEIGHT_SQL_MIGRATION_REVERSIBLE(timestamp, description)                                              \
-    struct Migration_##timestamp: public Lightweight::SqlMigration::MigrationBase                                 \
-    {                                                                                                             \
-        explicit Migration_##timestamp():                                                                         \
-            Lightweight::SqlMigration::MigrationBase(Lightweight::SqlMigration::MigrationTimestamp { timestamp }, \
-                                                     description)                                                 \
-        {                                                                                                         \
-        }                                                                                                         \
-                                                                                                                  \
-        void Up(Lightweight::SqlMigrationQueryBuilder& plan) const override;                                      \
-        void Down(Lightweight::SqlMigrationQueryBuilder& plan) const override;                                    \
-                                                                                                                  \
-        [[nodiscard]] bool HasDownImplementation() const noexcept override                                        \
-        {                                                                                                         \
-            return true;                                                                                          \
-        }                                                                                                         \
-    };                                                                                                            \
-                                                                                                                  \
-    static Migration_##timestamp _LIGHTWEIGHT_CONCATENATE(migration_, timestamp);                                 \
-                                                                                                                  \
-    void Migration_##timestamp::Up(Lightweight::SqlMigrationQueryBuilder& plan) const
-
-/// @brief Companion to @c LIGHTWEIGHT_SQL_MIGRATION_REVERSIBLE defining the out-of-line `Down()` body.
-///
-/// Must be used in the same translation unit and follow the matching
-/// `LIGHTWEIGHT_SQL_MIGRATION_REVERSIBLE(timestamp, ...)` declaration.
-///
-/// @param timestamp Timestamp of the migration whose Down() body follows.
-///
-/// @ingroup SqlMigration
-#define LIGHTWEIGHT_SQL_MIGRATION_DOWN(timestamp) \
-    void Migration_##timestamp::Down(Lightweight::SqlMigrationQueryBuilder& plan) const
-
 /// @brief Associates a software release (version string) with the highest migration timestamp
 /// present at the time of that release.
 ///
@@ -693,11 +640,11 @@ namespace SqlMigration
 /// @endcode
 ///
 /// @ingroup SqlMigration
-#define LIGHTWEIGHT_SQL_RELEASE(version, highestTimestamp)                                                         \
-    static ::Lightweight::SqlMigration::ReleaseRegistrar _LIGHTWEIGHT_CONCATENATE_INNER(_lw_release_, __COUNTER__) \
-    {                                                                                                              \
-        (version), ::Lightweight::SqlMigration::MigrationTimestamp                                                 \
-        {                                                                                                          \
-            (highestTimestamp)                                                                                     \
-        }                                                                                                          \
+#define LIGHTWEIGHT_SQL_RELEASE(version, highestTimestamp)                                                                 \
+    static ::Lightweight::SqlMigration::detail::ReleaseRegistrar _LIGHTWEIGHT_CONCATENATE_INNER(_lw_release_, __COUNTER__) \
+    {                                                                                                                      \
+        (version), ::Lightweight::SqlMigration::MigrationTimestamp                                                         \
+        {                                                                                                                  \
+            (highestTimestamp)                                                                                             \
+        }                                                                                                                  \
     }

--- a/src/tests/MigrationTests.cpp
+++ b/src/tests/MigrationTests.cpp
@@ -27,6 +27,7 @@ class SqlMigrationTestFixture: public SqlTestFixture
         SqlTestFixture()
     {
         Lightweight::SqlMigration::MigrationManager::GetInstance().RemoveAllMigrations();
+        Lightweight::SqlMigration::MigrationManager::GetInstance().RemoveAllReleases();
     }
     SqlMigrationTestFixture(SqlMigrationTestFixture&&) = delete;
     SqlMigrationTestFixture(SqlMigrationTestFixture const&) = delete;
@@ -944,4 +945,140 @@ TEST_CASE_METHOD(SqlMigrationTestFixture, "DropIndexIfExists", "[SqlMigration]")
 
     // Second drop should not throw - IF EXISTS handles non-existent index
     CHECK_NOTHROW(manager.ApplyPendingMigrations());
+}
+
+TEST_CASE_METHOD(SqlMigrationTestFixture, "RegisterRelease stores and orders releases", "[SqlMigration]")
+{
+    auto& manager = SqlMigration::MigrationManager::GetInstance();
+
+    // Register out of order; expect ascending-by-timestamp order afterwards.
+    manager.RegisterRelease("6.8.0", SqlMigration::MigrationTimestamp { 202606010000 });
+    manager.RegisterRelease("6.6.0", SqlMigration::MigrationTimestamp { 202601010000 });
+    manager.RegisterRelease("6.7.0", SqlMigration::MigrationTimestamp { 202603010000 });
+
+    auto const& releases = manager.GetAllReleases();
+    REQUIRE(releases.size() == 3);
+    CHECK(releases[0].version == "6.6.0");
+    CHECK(releases[1].version == "6.7.0");
+    CHECK(releases[2].version == "6.8.0");
+}
+
+TEST_CASE_METHOD(SqlMigrationTestFixture, "RegisterRelease rejects duplicate version", "[SqlMigration]")
+{
+    auto& manager = SqlMigration::MigrationManager::GetInstance();
+    manager.RegisterRelease("7.0.0", SqlMigration::MigrationTimestamp { 202701010000 });
+
+    CHECK_THROWS_AS(manager.RegisterRelease("7.0.0", SqlMigration::MigrationTimestamp { 202701020000 }), std::runtime_error);
+}
+
+TEST_CASE_METHOD(SqlMigrationTestFixture, "RegisterRelease rejects duplicate timestamp", "[SqlMigration]")
+{
+    auto& manager = SqlMigration::MigrationManager::GetInstance();
+    manager.RegisterRelease("7.1.0", SqlMigration::MigrationTimestamp { 202702010000 });
+
+    CHECK_THROWS_AS(manager.RegisterRelease("7.1.1", SqlMigration::MigrationTimestamp { 202702010000 }), std::runtime_error);
+}
+
+TEST_CASE_METHOD(SqlMigrationTestFixture, "FindReleaseByVersion and FindReleaseForTimestamp", "[SqlMigration]")
+{
+    auto& manager = SqlMigration::MigrationManager::GetInstance();
+    manager.RegisterRelease("8.0.0", SqlMigration::MigrationTimestamp { 202801010000 });
+    manager.RegisterRelease("8.1.0", SqlMigration::MigrationTimestamp { 202802010000 });
+
+    auto const* v800 = manager.FindReleaseByVersion("8.0.0");
+    REQUIRE(v800 != nullptr);
+    CHECK(v800->highestTimestamp.value == 202801010000);
+
+    CHECK(manager.FindReleaseByVersion("does-not-exist") == nullptr);
+
+    // Before any release — still covered by the first release, because lower_bound returns the first
+    // release whose highestTimestamp >= ts.
+    auto const* early = manager.FindReleaseForTimestamp(SqlMigration::MigrationTimestamp { 202701010000 });
+    REQUIRE(early != nullptr);
+    CHECK(early->version == "8.0.0");
+
+    // Exactly at the first release's timestamp.
+    auto const* atFirst = manager.FindReleaseForTimestamp(SqlMigration::MigrationTimestamp { 202801010000 });
+    REQUIRE(atFirst != nullptr);
+    CHECK(atFirst->version == "8.0.0");
+
+    // Between first and second.
+    auto const* between = manager.FindReleaseForTimestamp(SqlMigration::MigrationTimestamp { 202801150000 });
+    REQUIRE(between != nullptr);
+    CHECK(between->version == "8.1.0");
+
+    // Past the last release.
+    CHECK(manager.FindReleaseForTimestamp(SqlMigration::MigrationTimestamp { 202901010000 }) == nullptr);
+}
+
+TEST_CASE_METHOD(SqlMigrationTestFixture, "GetMigrationsForRelease returns range-bounded migrations", "[SqlMigration]")
+{
+    using namespace SqlColumnTypeDefinitions;
+
+    auto m1 = SqlMigration::Migration<202801010000>(
+        "m1",
+        [](SqlMigrationQueryBuilder& plan) { plan.CreateTable("rel_m1").PrimaryKey("id", Integer()); });
+    auto m2 = SqlMigration::Migration<202802010000>(
+        "m2",
+        [](SqlMigrationQueryBuilder& plan) { plan.CreateTable("rel_m2").PrimaryKey("id", Integer()); });
+    auto m3 = SqlMigration::Migration<202803010000>(
+        "m3",
+        [](SqlMigrationQueryBuilder& plan) { plan.CreateTable("rel_m3").PrimaryKey("id", Integer()); });
+    auto m4 = SqlMigration::Migration<202804010000>(
+        "m4",
+        [](SqlMigrationQueryBuilder& plan) { plan.CreateTable("rel_m4").PrimaryKey("id", Integer()); });
+
+    auto& manager = SqlMigration::MigrationManager::GetInstance();
+    // Release A covers m1+m2; release B covers m3 only. m4 is post-all-releases.
+    manager.RegisterRelease("A", SqlMigration::MigrationTimestamp { 202802010000 });
+    manager.RegisterRelease("B", SqlMigration::MigrationTimestamp { 202803010000 });
+
+    auto const inA = manager.GetMigrationsForRelease("A");
+    REQUIRE(inA.size() == 2);
+    auto itA = inA.begin();
+    CHECK((*itA++)->GetTimestamp().value == 202801010000);
+    CHECK((*itA)->GetTimestamp().value == 202802010000);
+
+    auto const inB = manager.GetMigrationsForRelease("B");
+    REQUIRE(inB.size() == 1);
+    CHECK(inB.front()->GetTimestamp().value == 202803010000);
+
+    // Unknown version => empty list, not an error.
+    CHECK(manager.GetMigrationsForRelease("does-not-exist").empty());
+}
+
+TEST_CASE_METHOD(SqlMigrationTestFixture, "RollbackToRelease semantics via RevertToMigration", "[SqlMigration]")
+{
+    using namespace SqlColumnTypeDefinitions;
+
+    auto m1 = SqlMigration::Migration<202810010000>(
+        "rel r1",
+        [](SqlMigrationQueryBuilder& plan) { plan.CreateTable("rel_r1").PrimaryKey("id", Integer()); },
+        [](SqlMigrationQueryBuilder& plan) { plan.DropTable("rel_r1"); });
+    auto m2 = SqlMigration::Migration<202810020000>(
+        "rel r2",
+        [](SqlMigrationQueryBuilder& plan) { plan.CreateTable("rel_r2").PrimaryKey("id", Integer()); },
+        [](SqlMigrationQueryBuilder& plan) { plan.DropTable("rel_r2"); });
+    auto m3 = SqlMigration::Migration<202810030000>(
+        "rel r3",
+        [](SqlMigrationQueryBuilder& plan) { plan.CreateTable("rel_r3").PrimaryKey("id", Integer()); },
+        [](SqlMigrationQueryBuilder& plan) { plan.DropTable("rel_r3"); });
+
+    auto& manager = SqlMigration::MigrationManager::GetInstance();
+    manager.RegisterRelease("9.0.0", SqlMigration::MigrationTimestamp { 202810020000 });
+
+    manager.CreateMigrationHistory();
+    CHECK(manager.ApplyPendingMigrations() == 3);
+
+    // Semantically: rollback-to-release 9.0.0 reverts everything after 202810020000 — i.e. m3.
+    auto const* release = manager.FindReleaseByVersion("9.0.0");
+    REQUIRE(release != nullptr);
+
+    auto result = manager.RevertToMigration(release->highestTimestamp);
+    CHECK(result.revertedTimestamps.size() == 1);
+    CHECK(!result.failedAt.has_value());
+
+    auto const appliedIds = manager.GetAppliedMigrationIds();
+    CHECK(appliedIds.size() == 2);
+    CHECK(appliedIds.back().value == 202810020000);
 }

--- a/src/tests/dummy_migration_plugin/Plugin.cpp
+++ b/src/tests/dummy_migration_plugin/Plugin.cpp
@@ -17,28 +17,16 @@ LIGHTWEIGHT_SQL_MIGRATION(20230101000000, "Initial Migration")
         .Column("name", SqlColumnTypeDefinitions::Varchar(50));
 }
 
-struct Migration_20230102000000: public Lightweight::SqlMigration::MigrationBase
+LIGHTWEIGHT_SQL_MIGRATION_REVERSIBLE(20230102000000, "Add Email Column")
 {
-    Migration_20230102000000():
-        Lightweight::SqlMigration::MigrationBase(Lightweight::SqlMigration::MigrationTimestamp { 20230102000000 },
-                                                 "Add Email Column")
-    {
-    }
+    plan.AlterTable("dummy_users").AddColumn("email", SqlColumnTypeDefinitions::Varchar(100));
+}
 
-    void Up(Lightweight::SqlMigrationQueryBuilder& plan) const override
-    {
-        plan.AlterTable("dummy_users").AddColumn("email", SqlColumnTypeDefinitions::Varchar(100));
-    }
+LIGHTWEIGHT_SQL_MIGRATION_DOWN(20230102000000)
+{
+    plan.AlterTable("dummy_users").DropColumn("email");
+}
 
-    void Down(Lightweight::SqlMigrationQueryBuilder& plan) const override
-    {
-        plan.AlterTable("dummy_users").DropColumn("email");
-    }
-
-    [[nodiscard]] bool HasDownImplementation() const noexcept override
-    {
-        return true;
-    }
-};
-
-static Migration_20230102000000 migration_20230102000000;
+// Declare a release marker for plugin 1. Releases expose a version -> highest-timestamp
+// mapping that dbtool surfaces via `releases` and `rollback-to-release`.
+LIGHTWEIGHT_SQL_RELEASE("1.0.0", 20230102000000);

--- a/src/tests/dummy_migration_plugin/Plugin.cpp
+++ b/src/tests/dummy_migration_plugin/Plugin.cpp
@@ -3,8 +3,6 @@
 #include <Lightweight/SqlMigration.hpp>
 #include <Lightweight/SqlQuery/Migrate.hpp>
 
-#include <iostream>
-
 using namespace Lightweight;
 
 // Define the plugin entry point
@@ -17,15 +15,15 @@ LIGHTWEIGHT_SQL_MIGRATION(20230101000000, "Initial Migration")
         .Column("name", SqlColumnTypeDefinitions::Varchar(50));
 }
 
-LIGHTWEIGHT_SQL_MIGRATION_REVERSIBLE(20230102000000, "Add Email Column")
-{
-    plan.AlterTable("dummy_users").AddColumn("email", SqlColumnTypeDefinitions::Varchar(100));
-}
-
-LIGHTWEIGHT_SQL_MIGRATION_DOWN(20230102000000)
-{
-    plan.AlterTable("dummy_users").DropColumn("email");
-}
+// A reversible migration: both Up and Down are declared together as a
+// single registration, so there is exactly one source of truth for the
+// migration's behaviour.
+static SqlMigration::Migration<20230102000000> const migration_20230102000000(
+    "Add Email Column",
+    [](SqlMigrationQueryBuilder& plan) {
+        plan.AlterTable("dummy_users").AddColumn("email", SqlColumnTypeDefinitions::Varchar(100));
+    },
+    [](SqlMigrationQueryBuilder& plan) { plan.AlterTable("dummy_users").DropColumn("email"); });
 
 // Declare a release marker for plugin 1. Releases expose a version -> highest-timestamp
 // mapping that dbtool surfaces via `releases` and `rollback-to-release`.

--- a/src/tests/dummy_migration_plugin_2/Plugin.cpp
+++ b/src/tests/dummy_migration_plugin_2/Plugin.cpp
@@ -10,9 +10,17 @@ LIGHTWEIGHT_MIGRATION_PLUGIN()
 
 // A migration from the second plugin.
 // Timestamp is later than the first plugin's migrations.
-LIGHTWEIGHT_SQL_MIGRATION(20230201000000, "Second Plugin Migration")
+LIGHTWEIGHT_SQL_MIGRATION_REVERSIBLE(20230201000000, "Second Plugin Migration")
 {
     plan.CreateTable("plugin2_table")
         .PrimaryKey("id", SqlColumnTypeDefinitions::Integer())
         .Column("description", SqlColumnTypeDefinitions::Varchar(255));
 }
+
+LIGHTWEIGHT_SQL_MIGRATION_DOWN(20230201000000)
+{
+    plan.DropTable("plugin2_table");
+}
+
+// Release marker for plugin 2's higher timestamp. dbtool merges releases from every plugin.
+LIGHTWEIGHT_SQL_RELEASE("2.0.0", 20230201000000);

--- a/src/tests/dummy_migration_plugin_2/Plugin.cpp
+++ b/src/tests/dummy_migration_plugin_2/Plugin.cpp
@@ -8,19 +8,18 @@ using namespace Lightweight;
 // Define the plugin entry point
 LIGHTWEIGHT_MIGRATION_PLUGIN()
 
-// A migration from the second plugin.
+// A reversible migration from the second plugin. Both Up and Down are
+// declared in a single registration (no separate out-of-line macro) so
+// the migration has exactly one source of truth.
 // Timestamp is later than the first plugin's migrations.
-LIGHTWEIGHT_SQL_MIGRATION_REVERSIBLE(20230201000000, "Second Plugin Migration")
-{
-    plan.CreateTable("plugin2_table")
-        .PrimaryKey("id", SqlColumnTypeDefinitions::Integer())
-        .Column("description", SqlColumnTypeDefinitions::Varchar(255));
-}
-
-LIGHTWEIGHT_SQL_MIGRATION_DOWN(20230201000000)
-{
-    plan.DropTable("plugin2_table");
-}
+static SqlMigration::Migration<20230201000000> const migration_20230201000000(
+    "Second Plugin Migration",
+    [](SqlMigrationQueryBuilder& plan) {
+        plan.CreateTable("plugin2_table")
+            .PrimaryKey("id", SqlColumnTypeDefinitions::Integer())
+            .Column("description", SqlColumnTypeDefinitions::Varchar(255));
+    },
+    [](SqlMigrationQueryBuilder& plan) { plan.DropTable("plugin2_table"); });
 
 // Release marker for plugin 2's higher timestamp. dbtool merges releases from every plugin.
 LIGHTWEIGHT_SQL_RELEASE("2.0.0", 20230201000000);

--- a/src/tests/test_dbtool.py
+++ b/src/tests/test_dbtool.py
@@ -171,6 +171,29 @@ def main():
         print("Final verification failed")
         sys.exit(1)
 
+    print("--- 7a. Releases ---")
+    releases_output = run_command(base_cmd + ["releases"]).stdout
+    if "1.0.0" not in releases_output or "2.0.0" not in releases_output:
+        print(f"Releases command did not list expected versions:\n{releases_output}")
+        sys.exit(1)
+
+    print("--- 7b. Rollback-to-release ---")
+    run_command(base_cmd + ["rollback-to-release", "1.0.0"])
+    output = run_command(base_cmd + ["list-applied"]).stdout
+    if "Second Plugin Migration" in output:
+        print(f"rollback-to-release did not revert migrations past 1.0.0:\n{output}")
+        sys.exit(1)
+    if "Add Email Column" not in output:
+        print(f"rollback-to-release 1.0.0 incorrectly reverted a migration inside the release:\n{output}")
+        sys.exit(1)
+
+    print("--- 7c. Re-apply after release rollback ---")
+    run_command(base_cmd + ["migrate"])
+    output = run_command(base_cmd + ["list-applied"]).stdout
+    if "Second Plugin Migration" not in output:
+        print(f"Re-migrate after rollback-to-release did not re-apply plugin 2 migration:\n{output}")
+        sys.exit(1)
+
     print("--- 8. Schema-only Backup ---")
     with tempfile.TemporaryDirectory() as tmpdir:
         schema_zip = os.path.join(tmpdir, "schema.zip")

--- a/src/tools/dbtool/main.cpp
+++ b/src/tools/dbtool/main.cpp
@@ -117,7 +117,10 @@ void PrintUsage()
                  c.command, c.reset, c.param, c.reset);
     std::println("  {}rollback-to{} {}<TIMESTAMP>{}  Rolls back all migrations after the given timestamp",
                  c.command, c.reset, c.param, c.reset);
+    std::println("  {}rollback-to-release{} {}<VERSION>{}  Rolls back all migrations after the given release",
+                 c.command, c.reset, c.param, c.reset);
     std::println("  {}status{}                   Shows migration status summary", c.command, c.reset);
+    std::println("  {}releases{}                 Lists declared releases and their migrations", c.command, c.reset);
     std::println("  {}mark-applied{} {}<TIMESTAMP>{} Marks a migration as applied without executing",
                  c.command, c.reset, c.param, c.reset);
     std::println("  {}backup{} --output FILE     Backs up the database to a file", c.command, c.reset);
@@ -580,6 +583,12 @@ void CollectMigrations(std::vector<Tools::PluginLoader> const& plugins, Migratio
                     {
                         centralManager.AddMigration(migration);
                     }
+                    // Copy release declarations alongside migrations so CLI commands like
+                    // `releases` and `rollback-to-release` see them.
+                    for (auto const& release: pluginManager->GetAllReleases())
+                    {
+                        centralManager.RegisterRelease(release.version, release.highestTimestamp);
+                    }
                 }
             }
         }
@@ -837,6 +846,112 @@ int RollbackTo(MigrationManager& manager, std::string_view argument)
 
     std::println("");
     std::println("Successfully rolled back {} migration(s).", result.revertedTimestamps.size());
+    return EXIT_SUCCESS;
+}
+
+/// Lists all declared software releases with their highest-migration timestamps
+/// and how many registered migrations fall in each release's range.
+///
+/// @param manager The migration manager instance.
+/// @return EXIT_SUCCESS.
+int Releases(MigrationManager& manager)
+{
+    auto const& releases = manager.GetAllReleases();
+
+    if (releases.empty())
+    {
+        std::println("No releases declared.");
+        return EXIT_SUCCESS;
+    }
+
+    auto const applied = manager.GetAppliedMigrationIds();
+    auto const isApplied = [&](MigrationTimestamp ts) {
+        return std::ranges::contains(applied, ts);
+    };
+
+    std::println("Releases:");
+    std::println("");
+    std::println("  {:<16} {:<24} {:>10}  {}", "Version", "Highest Timestamp", "Migrations", "Status");
+
+    for (auto const& release: releases)
+    {
+        auto const migrations = manager.GetMigrationsForRelease(release.version);
+
+        // A release is "fully applied" iff every migration in its range is applied.
+        // If it has no migrations, treat as "empty" rather than applied.
+        auto const allApplied =
+            !migrations.empty()
+            && std::ranges::all_of(migrations, [&](MigrationBase const* m) { return isApplied(m->GetTimestamp()); });
+        auto const anyApplied =
+            std::ranges::any_of(migrations, [&](MigrationBase const* m) { return isApplied(m->GetTimestamp()); });
+
+        std::string_view status;
+        if (migrations.empty())
+            status = "empty";
+        else if (allApplied)
+            status = "applied";
+        else if (anyApplied)
+            status = "partial";
+        else
+            status = "pending";
+
+        std::println(
+            "  {:<16} {:<24} {:>10}  {}", release.version, release.highestTimestamp.value, migrations.size(), status);
+    }
+
+    return EXIT_SUCCESS;
+}
+
+/// Rolls back all migrations applied after the release identified by `version`.
+///
+/// Resolves `version` to its `highestTimestamp` and delegates to `RevertToMigration`. Migrations
+/// whose timestamp is `<= highestTimestamp` are kept; those strictly greater are reverted in
+/// reverse timestamp order.
+///
+/// @param manager The migration manager instance.
+/// @param argument The target release version string.
+/// @return EXIT_SUCCESS on success, EXIT_FAILURE on error.
+int RollbackToRelease(MigrationManager& manager, std::string_view argument)
+{
+    if (argument.empty())
+    {
+        std::println(std::cerr, "Error: Target release version is required.");
+        return EXIT_FAILURE;
+    }
+
+    auto const* release = manager.FindReleaseByVersion(argument);
+    if (!release)
+    {
+        std::println(std::cerr, "Error: Release '{}' is not declared.", argument);
+        return EXIT_FAILURE;
+    }
+
+    std::println(
+        "Rolling back migrations after release '{}' (timestamp {})...", release->version, release->highestTimestamp.value);
+    std::println("");
+
+    auto const result = manager.RevertToMigration(release->highestTimestamp, [](MigrationBase const& m, size_t i, size_t n) {
+        std::println("[{}/{}] Rolling back {} - {}", i + 1, n, m.GetTimestamp().value, m.GetTitle());
+    });
+
+    if (result.revertedTimestamps.empty() && !result.failedAt.has_value())
+    {
+        std::println("No migrations to rollback. Database is already at or before release '{}'.", argument);
+        return EXIT_SUCCESS;
+    }
+
+    if (result.failedAt.has_value())
+    {
+        std::println(std::cerr, "");
+        std::println(std::cerr, "Error: Failed to rollback migration {}: {}", result.failedAt->value, result.errorMessage);
+        std::println(std::cerr,
+                     "Rollback stopped. {} migration(s) were rolled back before the failure.",
+                     result.revertedTimestamps.size());
+        return EXIT_FAILURE;
+    }
+
+    std::println("");
+    std::println("Successfully rolled back {} migration(s) to release '{}'.", result.revertedTimestamps.size(), argument);
     return EXIT_SUCCESS;
 }
 
@@ -1447,6 +1562,8 @@ int main(int argc, char** argv)
             return ListAppliedMigrations(GetMigrationManager(options));
         else if (options.command == "status")
             return Status(GetMigrationManager(options));
+        else if (options.command == "releases")
+            return Releases(GetMigrationManager(options));
 
         // Write commands (lock recommended)
         else if (options.command == "migrate")
@@ -1472,6 +1589,12 @@ int main(int argc, char** argv)
             auto& manager = GetMigrationManager(options);
             OptionalMigrationLock lock(manager, options.noLock);
             return RollbackTo(manager, options.argument);
+        }
+        else if (options.command == "rollback-to-release")
+        {
+            auto& manager = GetMigrationManager(options);
+            OptionalMigrationLock lock(manager, options.noLock);
+            return RollbackToRelease(manager, options.argument);
         }
         else if (options.command == "mark-applied")
         {

--- a/src/tools/dbtool/main.cpp
+++ b/src/tools/dbtool/main.cpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <print>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #if defined(__clang__)
@@ -120,7 +121,8 @@ void PrintUsage()
     std::println("  {}rollback-to-release{} {}<VERSION>{}  Rolls back all migrations after the given release",
                  c.command, c.reset, c.param, c.reset);
     std::println("  {}status{}                   Shows migration status summary", c.command, c.reset);
-    std::println("  {}releases{}                 Lists declared releases and their migrations", c.command, c.reset);
+    std::println("  {}releases{}                 Lists declared releases and their migration counts/status",
+                 c.command, c.reset);
     std::println("  {}mark-applied{} {}<TIMESTAMP>{} Marks a migration as applied without executing",
                  c.command, c.reset, c.param, c.reset);
     std::println("  {}backup{} --output FILE     Backs up the database to a file", c.command, c.reset);
@@ -579,15 +581,16 @@ void CollectMigrations(std::vector<Tools::PluginLoader> const& plugins, Migratio
                 MigrationManager* pluginManager = acquireParams();
                 if (pluginManager && pluginManager != &centralManager)
                 {
-                    for (auto const* migration: pluginManager->GetAllMigrations())
-                    {
-                        centralManager.AddMigration(migration);
-                    }
-                    // Copy release declarations alongside migrations so CLI commands like
-                    // `releases` and `rollback-to-release` see them.
+                    // Register releases before migrations: the failure mode most likely to throw
+                    // here is a cross-plugin duplicate release, and we'd rather skip the whole
+                    // plugin on conflict than end up with migrations imported but releases missing.
                     for (auto const& release: pluginManager->GetAllReleases())
                     {
                         centralManager.RegisterRelease(release.version, release.highestTimestamp);
+                    }
+                    for (auto const* migration: pluginManager->GetAllMigrations())
+                    {
+                        centralManager.AddMigration(migration);
                     }
                 }
             }
@@ -864,10 +867,14 @@ int Releases(MigrationManager& manager)
         return EXIT_SUCCESS;
     }
 
+    // Materialize applied IDs into a hash set so the per-release all_of/any_of checks below
+    // are O(1) per lookup instead of a linear scan over `applied`.
     auto const applied = manager.GetAppliedMigrationIds();
-    auto const isApplied = [&](MigrationTimestamp ts) {
-        return std::ranges::contains(applied, ts);
-    };
+    std::unordered_set<uint64_t> appliedSet;
+    appliedSet.reserve(applied.size());
+    for (auto const& ts: applied)
+        appliedSet.insert(ts.value);
+    auto const isApplied = [&](MigrationTimestamp ts) { return appliedSet.contains(ts.value); };
 
     std::println("Releases:");
     std::println("");


### PR DESCRIPTION
Long-running projects accumulate hundreds of migration timestamps over years of development, but nothing in the library connects them to the release versions users actually talk about. This PR lets migrations be grouped under a version string: declare `LIGHTWEIGHT_SQL_RELEASE("6.7.0", 20240501120000)` alongside the migrations that shipped with that cut, and dbtool surfaces the mapping. Releases live purely in code — they compile into migration plugins and are imported by dbtool the same way migrations are, so no `schema_releases` table is needed.

## Changes

- **Release API** on `MigrationManager`: `RegisterRelease`, `RemoveAllReleases`, `GetAllReleases`, `FindReleaseByVersion`, `FindReleaseForTimestamp`, `GetMigrationsForRelease`. A migration `M` belongs to release `R` iff `prev_release_ts < M.timestamp <= R.highestTimestamp`.
- **`LIGHTWEIGHT_SQL_RELEASE(version, highestTimestamp)`** macro registers a release via a RAII `ReleaseRegistrar` at static-init time. Duplicate versions and duplicate timestamps are rejected.
- **dbtool**: new read-only `releases` command prints each release with its `applied` / `pending` / `partial` / `empty` status; new write-command `rollback-to-release <VERSION>` resolves the version to its timestamp and reverts everything newer. `CollectMigrations` imports release declarations from plugin `MigrationManager` instances alongside migrations.
- **`LIGHTWEIGHT_SQL_MIGRATION_REVERSIBLE` / `LIGHTWEIGHT_SQL_MIGRATION_DOWN`** macros fill a gap in the original `LIGHTWEIGHT_SQL_MIGRATION`, which hardcoded an empty `Down()` and `HasDownImplementation() == false`. The two hand-rolled migrations in the dummy plugins are converted to the new macros.
- Unit tests cover registration, duplicate detection, version/timestamp lookup, range-bounded migration retrieval, and rollback-to-release semantics. `test_dbtool.py` exercises `releases` and `rollback-to-release` end-to-end.