### PR TITLE
Fix PostgreSQL Unicode round-trip on Windows by switching ODBC to W variants

### DIFF
--- a/.agent/README.md
+++ b/.agent/README.md
@@ -1,0 +1,12 @@
+# `.agent/` — Agent deep-dives
+
+Supporting material for AI agents (Claude Code, Codex, etc.) working on Lightweight. The primary entry point is `../AGENT.md`; this directory keeps the longer deep-dives out of the top-level guide so it stays scannable.
+
+| File | Topic |
+|------|-------|
+| [`architecture.md`](architecture.md) | Component map deep-dive, canonical examples for formatter dispatch, `SqlDataBinder<T>` specialization, `DataMapper` field/relationship mechanics, connection pool, migration model |
+| [`databases.md`](databases.md) | Per-DBMS specifics: features, connection-string formats, Docker harness, known footguns (Unicode round-trips, `NULL` semantics, identifier quoting) |
+| [`testing.md`](testing.md) | Catch2 conventions, `.test-env.yml` schema, `--test-env=<name>` flag, the `dbtool` Python integration suite, sanitizer/valgrind presets |
+| [`cpp-guidelines.md`](cpp-guidelines.md) | Self-contained C++23 ruleset (general + Lightweight-specific). No external `cpp.md` required |
+
+These files are loaded into agent context via the top-level `CLAUDE.md` (`@.agent/`).

--- a/.agent/architecture.md
+++ b/.agent/architecture.md
@@ -1,0 +1,94 @@
+# Architecture deep-dive
+
+## Layers
+
+```
+                ┌─────────────────────────────────────────────┐
+ user code ──▶  │  DataMapper (Field, BelongsTo, HasMany,…)   │  high-level
+                ├─────────────────────────────────────────────┤
+                │  SqlQuery DSL (Select/Insert/Update/Delete) │
+                │  SqlMigration / SqlMigrationLock            │
+                ├─────────────────────────────────────────────┤
+                │  SqlStatement / SqlConnection               │  low-level
+                │  SqlDataBinder<T> (per-type bind/fetch)     │
+                ├─────────────────────────────────────────────┤
+                │  SqlQueryFormatter — per-DBMS dispatch      │
+                │   ├── SqlServerFormatter                    │
+                │   ├── PostgreSqlFormatter                   │
+                │   └── SQLiteFormatter                       │
+                ├─────────────────────────────────────────────┤
+                │  ODBC (unixODBC / Windows ODBC)             │  driver
+                └─────────────────────────────────────────────┘
+```
+
+Anything that varies between DBMSes belongs in `SqlQueryFormatter`. Business logic above must be database-agnostic.
+
+## Canonical examples
+
+### Per-DBMS formatter override
+File: `src/Lightweight/QueryFormatter/PostgreSqlFormatter.hpp`
+
+```cpp
+class PostgreSqlFormatter final: public SQLiteQueryFormatter
+{
+  public:
+    [[nodiscard]] std::string QueryLastInsertId(std::string_view) const override
+    {
+        return "SELECT lastval();";
+    }
+
+    [[nodiscard]] std::string_view DateFunction() const noexcept override
+    {
+        return "CURRENT_DATE";
+    }
+    // … BinaryLiteral, BuildColumnDefinition, DropTable (CASCADE) overrides …
+};
+```
+
+To add a new dialect-sensitive primitive:
+1. Add a `[[nodiscard]] virtual` method in `SqlQueryFormatter.hpp` with the most reasonable default.
+2. Override it in any formatter where the default is wrong.
+3. Have the caller request the SQL fragment from the formatter — never inline a `switch` on `SqlServerType`.
+
+### `SqlDataBinder<T>` specialization shape
+Files: `src/Lightweight/SqlDataBinder.hpp` (primary template), `src/Lightweight/DataBinder/*.hpp` (specializations).
+
+Each specialization typically provides:
+- `static SQLRETURN InputParameter(SQLHSTMT, SQLUSMALLINT, T const&, SqlDataBinderCallback&)`
+- `static SQLRETURN OutputColumn(SQLHSTMT, SQLUSMALLINT, T*, SQLLEN*, SqlDataBinderCallback&)`
+- `static SQLRETURN GetColumn(SQLHSTMT, SQLUSMALLINT, T*, SQLLEN*, SqlDataBinderCallback const&)`
+- `static std::string Inspect(T const&)` (optional — used by tracing and `DataMapper::Inspect`)
+
+For Unicode-bearing strings, reuse `BasicStringBinder.hpp` helpers (`GetRawColumnArrayData`, `GetColumnUtf16`, `BindOutputColumnNonUtf16Unicode`) and `UnicodeConverter.hpp` rather than re-implementing buffer growth, NULL handling, or transcoding.
+
+### `DataMapper` field & relationship primitives
+- `Field<T, …Modifiers>` — one column with optional `PrimaryKey`, `SqlRealName`, default value.
+- `BelongsTo<&Other::id, SqlRealName{"fk_col"}>` — many-to-one (lazy-loads via dereference).
+- `HasMany<&Child::parent_id>` — one-to-many.
+- `HasManyThrough<&Through::a_id, &Through::b_id>` — many-to-many via join table.
+- `HasOneThrough<…>` — one-to-one via intermediate.
+
+Records are plain aggregates of these field/relation types — there is no required base class. Reflection (C++20 member pointers, or C++26 reflection when `LIGHTWEIGHT_CXX26_REFLECTION`) drives column enumeration.
+
+### Connection pool
+File: `src/Lightweight/DataMapper/Pool.{hpp,cpp}`. The pool is the canonical way to share connections across threads — never store a `SqlConnection` as a long-lived bare member.
+
+### Migrations
+- DSL: `src/Lightweight/SqlQuery/Migrate.{hpp,cpp}`, `MigrationPlan.{hpp,cpp}`.
+- Runner: `src/Lightweight/SqlMigration.{hpp,cpp}`.
+- Cross-process lock: `src/Lightweight/SqlMigrationLock.{hpp,cpp}`.
+- The `dbtool` subcommand and the `lup2dbtool` adapter live in `src/tools/`.
+
+## Where reflection lives
+
+`Lightweight.cppm` exports the public surface as a C++20 module when `LIGHTWEIGHT_BUILD_MODULES=ON`. The `Member(x)` macro in `src/tests/Utils.hpp` (and similar in production headers) selects between C++20 member pointers (`&x`) and C++26 reflection (`^^x`) depending on `LIGHTWEIGHT_CXX26_REFLECTION`.
+
+## Key types to recognise
+
+| Type | Role |
+|------|------|
+| `SqlServerType` | Enum: `MICROSOFT_SQL`, `POSTGRESQL`, `SQLITE`, `MYSQL`, `UNKNOWN`. Derived from the connected driver |
+| `SqlConnectInfo` | Parsed connection-string descriptor |
+| `SqlError` / `SqlErrorDetection` | Error reporting; pair with `std::expected<T, SqlError>` in new APIs |
+| `SqlScopedTraceLogger` / `SqlLogger` | Tracing hooks (driven by `--trace-sql --trace-odbc`) |
+| `ThreadSafeQueue` | Internal MPMC queue used by the pool |

--- a/.agent/cpp-guidelines.md
+++ b/.agent/cpp-guidelines.md
@@ -1,0 +1,105 @@
+# C++ guidelines (self-contained)
+
+This file is the canonical, project-internal C++ ruleset. Contributors and agents do **not** need any external file (no `~/.claude/rules/cpp.md`, no global notes) — every rule that applies to Lightweight is here.
+
+## 1. General C++23 baseline
+
+### Design
+- **Data-driven design** — avoid hard-coded magic values. Prefer descriptor tables, configuration, or polymorphic dispatch over scattered conditionals.
+- **Dependency injection** — pass collaborators through constructors / parameters so tests can substitute fakes. Anything touching I/O, time, randomness, or the database must be injectable.
+
+### Documentation
+- **Doxygen** on every new public function, parameter, return, class, struct, and member:
+  ```cpp
+  /// Short description.
+  /// @param name Description.
+  /// @return Description.
+  ```
+- Be factual — no marketing prose.
+
+### Type & const correctness
+- **`const`-correctness** throughout: refs, pointers, member functions, parameters that don't mutate.
+- **`auto` type deduction** for readability; **structured bindings** for tuple-like returns.
+- Mark return values **`[[nodiscard]]`** where ignoring the result would be a bug — this includes builders, query objects, and anything returning `std::expected`.
+
+### Modern C++ surface
+- Prefer **C++23**: `constexpr`, `std::ranges`, `std::format`, `std::expected`, `std::span`.
+- **`std::expected<T, E>`** with monadic chaining (`and_then`, `or_else`, `transform`, `transform_error`) for fallible operations. Avoid nested `if`s when a chain reads better.
+- **`std::span`** for arrays / contiguous sequences in API surfaces.
+- **Range views** for generation/transformation: `std::views::iota`, `std::views::filter`, `std::views::transform`, etc.
+
+### Forbidden constructs
+- **C-style loops are forbidden.** Use range-based `for` and the views above.
+- **No raw owning pointers.** `std::unique_ptr` / `std::shared_ptr` for ownership, RAII for resources.
+- **No `NOLINT` suppressions** — fix the underlying issue clang-tidy reports. The `linux-clang-debug` preset enables `clang-tidy` automatically.
+- **No new third-party dependencies** without strong justification — vcpkg manifest at `vcpkg.json` lists what we already accept.
+
+### Tooling
+- Run **`clang-format`** on every changed file (project `.clang-format` is authoritative).
+- Build with the matching preset (`linux-clang-debug` / `windows-clangcl-debug`); resolve every warning — `PEDANTIC_COMPILER_WERROR=ON`.
+- All changes must be covered by unit tests; aim to **increase** code coverage with every PR.
+
+## 2. Lightweight-specific patterns
+
+### Namespace & symbol visibility
+- All public symbols live in the `Lightweight` namespace; the alias `Light` is provided for brevity in user code.
+- Public headers must be **self-contained** — they must compile with no PCH and only their own includes.
+- Keep ABI-affecting changes deliberate; the library is consumed as a vcpkg port.
+
+### Error handling on the public API
+Prefer `std::expected<T, SqlError>` for fallible public APIs. Reserve exceptions for programmer errors (precondition violation, contract misuse). Internally, ODBC `SQLRETURN` codes are wrapped via the helpers in `src/Lightweight/SqlError.{hpp,cpp}` and `SqlErrorDetection.hpp`.
+
+```cpp
+return statement.Prepare(sql)
+    .and_then([&] { return statement.Execute(args...); })
+    .transform([&](auto&&) { return …; })
+    .transform_error([](SqlError const& e) { return wrapWithContext(e); });
+```
+
+### ODBC `SQLHANDLE` lifetime
+ODBC handles (env, dbc, stmt) are owned by `SqlConnection` / `SqlStatement` (and the small RAII wrappers near them). They are released in the destructor. Never:
+- allocate a raw `SQLHANDLE` at call sites,
+- store one beyond the lifetime of its wrapper,
+- pass `SQLHANDLE` across abstraction boundaries (pass the wrapper instead).
+
+### Per-DBMS dispatch
+Per-DBMS branching belongs only inside `SqlQueryFormatter` and its subclasses. Business logic must call a virtual method on the formatter and let the override decide. **Do not** write `if (server == SqlServerType::POSTGRESQL)` outside `QueryFormatter/`.
+
+If a new feature behaves differently on each DBMS:
+1. Add a `[[nodiscard]] virtual` method to `SqlQueryFormatter` with a sensible default.
+2. Override per DBMS in `PostgreSqlFormatter`, `SQLiteFormatter`, `SqlServerFormatter`.
+3. Cover all three in tests.
+
+### `SqlDataBinder<T>` contract for Unicode strings
+Unicode-bearing string types must round-trip identically across MSSQL, PostgreSQL, and SQLite. This is non-trivial because each driver has different opinions about UTF-16 vs UTF-8.
+
+The repo's hard-won rules (codified in commits `894c67c7`, `89885982`, `f311cb9f`):
+
+- Bind Unicode payloads via **`SQL_C_WCHAR`** (UTF-16) uniformly across the `BasicStringBinder` surface — `BasicStringBinder.hpp` does this.
+- For non-`u16string` Unicode types, transcode through a temporary `std::u16string` using `UnicodeConverter.hpp`, bind that, and copy back in the post-process callback (`SqlDataBinderCallback::PlanPostProcessOutputColumn`).
+- Use `SQL_C_WCHAR` even where the driver "would also accept" `SQL_C_CHAR` — the latter is unreliable for non-ASCII on `psqlODBC`.
+- For PostgreSQL connection strings, **disable LF↔CRLF translation** (`LFConversion=0`); without this, embedded newlines in character data silently mutate.
+
+### `[[nodiscard]]` policy on builders
+Query builders (`SqlQuery::Select`, `Insert`, `Update`, `Delete`, `Migrate`) and `DataMapper::Query<…>` return objects that *must* be terminated (`.All()`, `.First()`, `.Execute()`, etc.). Mark every step `[[nodiscard]]` so accidental discard is a build error.
+
+### Catch2 + DI in tests
+Tests must obtain a connection through the test fixture wired to `--test-env=<name>`, never by constructing one with hard-coded strings. New connection strings go in `.test-env.yml`. See `.agent/testing.md`.
+
+### Reflection
+The library uses C++20 member pointers by default and supports a C++26 reflection mode (`LIGHTWEIGHT_CXX26_REFLECTION`). New code that enumerates record fields should use the abstraction (e.g., the `Member(x)` macro pattern in `src/tests/Utils.hpp`) rather than committing to one mode.
+
+### Modules
+`Lightweight.cppm` is the C++20 module aggregator (`LIGHTWEIGHT_BUILD_MODULES=ON`, requires CMake ≥ 3.28). New public headers must be addable to the module export list without breaking the build.
+
+## 3. Quick checklist before pushing
+
+- `clang-format` clean
+- `clang-tidy` clean (no `NOLINT`s added)
+- `linux-clang-debug` builds with no warnings
+- Tests run green against `sqlite3`, `mssql2022`, `postgres`
+- New public APIs have doxygen + `[[nodiscard]]` where relevant
+- No new `if (server == …)` outside `QueryFormatter/`
+- New SQL primitives go through `SqlQueryFormatter` virtuals
+- Unicode-bearing types round-trip via `SQL_C_WCHAR` / `BasicStringBinder.hpp`
+- `/simplify` was run; out-of-scope findings were either addressed or surfaced to the user

--- a/.agent/databases.md
+++ b/.agent/databases.md
@@ -1,0 +1,70 @@
+# Per-DBMS notes
+
+Lightweight is exercised against three databases in CI (`.github/workflows/build.yml` → `dbms_test_matrix`). Every change must be verified against all three before being marked done — driver semantics differ in non-obvious ways.
+
+## SQLite3
+
+- **`SqlServerType::SQLITE`**, test-env name `sqlite3`.
+- **Driver**: `sqliteodbc` (`libsqliteodbc` on Linux, `sqliteodbc` MSI on Windows).
+- **Connection string**: `DRIVER=SQLite3;Database=test.db` (Linux) or `DRIVER={SQLite3 ODBC Driver};Database=file::memory:` (Windows).
+- **Strengths**: fast local tests, no daemon needed.
+- **Footguns**:
+  - Type affinity instead of strict types — column types are advisory.
+  - No real `BOOLEAN` (stored as INTEGER).
+  - Limited migration support (no native `ALTER COLUMN` semantics; the migration layer emulates).
+  - Valgrind is run *only* against SQLite3 in CI to catch driver-leaked allocations (`build.yml` adds `valgrind --leak-check=full ... --error-exitcode=1` for the sqlite3 matrix entry).
+
+## Microsoft SQL Server
+
+- **`SqlServerType::MICROSOFT_SQL`**, test-env names `mssql2017`, `mssql2019`, `mssql2022`, `mssql` (Windows LocalDB).
+- **Driver**: `ODBC Driver 17/18 for SQL Server` (`mssql-tools18` on Linux installs ODBC Driver 18; the Windows CI uses LocalDB + Driver 17).
+- **Connection strings**:
+  - Linux Docker: `Driver={ODBC Driver 18 for SQL Server};SERVER=localhost;PORT=1433;UID=SA;PWD=Lightweight!Test42;TrustServerCertificate=yes;DATABASE=LightweightTest`
+  - Windows LocalDB: `Driver={ODBC Driver 17 for SQL Server};Server=(LocalDB)\MSSQLLocalDB;Database=TestDB;Trusted_Connection=Yes;`
+- **Footguns**:
+  - `wchar_t` is 16-bit on Windows; on Linux the driver still expects UTF-16 even though `wchar_t` is 32-bit. Use the `WideChar` typedef from `src/tests/Utils.hpp` (or `char16_t` directly) for portable UTF-16 in tests.
+  - `IDENTITY` columns are queried via `SELECT @@IDENTITY` (note the formatter override).
+  - Schema-qualified identifiers use `[schema].[name]` quoting.
+  - 2017 `mssql-tools` (no `-C` flag); 2018+ `mssql-tools18` (requires `-C` for self-signed cert).
+  - 2025 image is currently disabled in CI (image broken).
+
+## PostgreSQL
+
+- **`SqlServerType::POSTGRESQL`**, test-env name `postgres`.
+- **Driver**: `psqlODBC` — pick `PostgreSQL Unicode` (NOT `PostgreSQL ANSI`) for any Unicode-bearing workload.
+- **Connection string**: `Driver={PostgreSQL Unicode};Server=localhost;Port=5432;Uid=postgres;Pwd=Lightweight!Test42;Database=test`
+- **Footguns**:
+  - **Newline translation**: `psqlODBC` defaults to LF↔CRLF translation. The project's test connection strings disable it explicitly (commit `f311cb9f`); preserve that in any new test-env entry, or character-data round-trips with embedded newlines will silently mutate.
+  - **Unicode round-trip**: `SQL_C_WCHAR` (UTF-16) is the binding type that round-trips reliably across all DataBinder paths (commit `894c67c7`); avoid `SQL_C_CHAR` for non-ASCII strings unless you've validated the driver actually transcodes.
+  - `SERIAL` columns: detect via `nextval(` in the captured default value (see `PostgreSqlFormatter::BuildColumnDefinition`); restored backups carry the sequence default rather than `AUTO_INCREMENT`.
+  - Identifier quoting uses `"`. Folding to lowercase happens for unquoted identifiers — the formatter quotes everything to keep behaviour consistent.
+  - `SELECT lastval();` retrieves the last inserted id (formatter override). Race-prone if multiple clients insert into different sequences simultaneously — call it inside the same session right after the insert.
+
+## Docker harness
+
+`scripts/tests/docker-databases.py` is the supported way to spin up MSSQL/Postgres locally:
+
+```sh
+python3 scripts/tests/docker-databases.py --start --wait                # all
+python3 scripts/tests/docker-databases.py --start --wait mssql2022 postgres
+python3 scripts/tests/docker-databases.py --status
+python3 scripts/tests/docker-databases.py --stop
+python3 scripts/tests/docker-databases.py --remove
+python3 scripts/tests/docker-databases.py --load-sql Chinook.sql mssql2022
+```
+
+The script is **idempotent** and waits through four phases (internal health → external port → stability → post-ready stabilisation) before reporting ready. Container ports: MSSQL 2017 → 1432, 2019 → 1434, 2022 → 1433, 2025 → 1435, Postgres → 5432. The shared password is `Lightweight!Test42`.
+
+## When can you legitimately skip a DB?
+
+Only when the test exercises a feature that the database *intrinsically* does not support — e.g., a SQL Server-only construct on SQLite. Use the `UNSUPPORTED_DATABASE(stmt, dbType)` macro from `src/tests/Utils.hpp`:
+
+```cpp
+TEST_CASE("merge upsert", "[migration]") {
+    auto stmt = ConnectTestEnv();
+    UNSUPPORTED_DATABASE(stmt, SqlServerType::SQLITE);
+    // … MSSQL/Postgres-only path …
+}
+```
+
+Do **not** use it to dodge a flaky failure or a Unicode bug — that's a real bug, fix it.

--- a/.agent/testing.md
+++ b/.agent/testing.md
@@ -1,0 +1,100 @@
+# Testing deep-dive
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `src/tests/CoreTests.cpp` | Core SQL API |
+| `src/tests/DataBinderTests.cpp` | `SqlDataBinder<T>` specializations (start here for new types) |
+| `src/tests/DataMapper/` | High-level mapper, relations, query builders |
+| `src/tests/QueryBuilderTests.cpp` | DSL surface |
+| `src/tests/MigrationTests.cpp`, `MigrationReflectionTests.cpp` | Migrations & reflection |
+| `src/tests/CxxModelPrinterTests.cpp` | `ddl2cpp` output shape |
+| `src/tests/Lup2DbtoolTests.cpp` | `lup2dbtool` |
+| `src/tests/UnicodeConverterTests.cpp` | u8/u16/wchar_t conversion |
+| `src/tests/UtilsTests.cpp` | Internal utilities |
+| `src/tests/SqlBackup/` | Backup framework |
+| `src/tests/Zip/` | libzip wrapper |
+| `src/tests/dbtool/` + `test_dbtool.py` | `dbtool` integration (Python driver) |
+| `src/tests/Utils.{hpp,cpp}` | Shared fixture, `UNSUPPORTED_DATABASE` macro, `WideChar` typedef |
+| `src/tests/LargeTestDatabase/` | Generators for large-DB perf tests |
+| `src/tests/dummy_migration_plugin*` | Plugin integration fixtures |
+
+The test binary is `LightweightTest` (Catch2 single-binary). Filter with Catch2 tags / patterns:
+
+```sh
+LightweightTest "[model]"                    # all model tests
+LightweightTest "SqlVariant: SqlGuid"        # one test
+LightweightTest --reporter compact           # condensed output
+LightweightTest --trace-sql --trace-odbc     # diagnose driver behaviour
+```
+
+## `.test-env.yml`
+
+The connection-string registry consumed by `--test-env=<name>`:
+
+```yaml
+ODBC_CONNECTION_STRING:
+  sqlite3:    "DRIVER=SQLite3;Database=test.db"
+  mssql2017:  "Driver={ODBC Driver 17 for SQL Server};SERVER=localhost;PORT=1432;UID=SA;PWD=Lightweight!Test42;TrustServerCertificate=yes;DATABASE=LightweightTest"
+  mssql2019:  "Driver={ODBC Driver 18 for SQL Server};SERVER=localhost;PORT=1434;UID=SA;PWD=Lightweight!Test42;TrustServerCertificate=yes;DATABASE=LightweightTest"
+  mssql2022:  "Driver={ODBC Driver 18 for SQL Server};SERVER=localhost;PORT=1433;UID=SA;PWD=Lightweight!Test42;TrustServerCertificate=yes;DATABASE=LightweightTest"
+  postgres:   "Driver={PostgreSQL Unicode};Server=localhost;Port=5432;Uid=postgres;Pwd=Lightweight!Test42;Database=test"
+```
+
+Add new test-env entries here — never hard-code connection strings inside test sources.
+
+## Required local flow
+
+```sh
+# 1. Start non-SQLite DBs
+python3 scripts/tests/docker-databases.py --start --wait mssql2022 postgres
+
+# 2. Run Catch2 tests against each
+LightweightTest --test-env=sqlite3
+LightweightTest --test-env=mssql2022
+LightweightTest --test-env=postgres
+
+# 3. Run dbtool integration tests against each
+python3 src/tests/test_dbtool.py --dbtool ./out/build/<preset>/target/dbtool \
+    --plugins-dir ./out/build/<preset>/target/plugins \
+    --test-env sqlite3
+python3 src/tests/test_dbtool.py --dbtool … --test-env mssql2022
+python3 src/tests/test_dbtool.py --dbtool … --test-env postgres
+```
+
+## Sanitizers & valgrind
+
+| Preset | What it gives you |
+|--------|-------------------|
+| `linux-clang-debug` | ASan + UBSan + clang-tidy + pedantic warnings |
+| `linux-clang-asan-ubsan` | ASan + UBSan, no tidy (faster build for repro) |
+| `linux-clang-tsan` | ThreadSanitizer (use for pool/migration-lock changes) |
+| `linux-clang-coverage` / `linux-gcc-coverage` | LCOV / gcov |
+
+CI runs valgrind on the SQLite3 matrix entry only:
+
+```sh
+valgrind --error-exitcode=1 --leak-check=full --leak-resolution=high --num-callers=64 \
+    LightweightTest --test-env=sqlite3
+```
+
+ASan/UBSan environment used in CI:
+
+```sh
+ASAN_OPTIONS="detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
+UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:suppressions=.github/ubsan.suppressions"
+TSAN_OPTIONS="second_deadlock_stack=1"
+```
+
+## Catch2 conventions
+
+- Test files end in `*Tests.cpp` (note the trailing `s`). New test files must be added to `src/tests/CMakeLists.txt`.
+- Tag conventions used in this repo: `[model]`, `[TableFilter]`, `[migration]`, `[binder]`, `[unicode]`. Reuse existing tags before inventing new ones.
+- The `WideChar` typedef in `src/tests/Utils.hpp` selects the platform-appropriate UTF-16 code unit (`wchar_t` on Windows, `char16_t` on Linux). Use it (and the `WTEXT(x)` literal macro) for any portable UTF-16 test data.
+- The `Member(x)` macro abstracts over C++20 member pointers vs. C++26 reflection (`^^x`). Use it in test code that should compile under both reflection modes.
+- The `UNSUPPORTED_DATABASE(stmt, dbType)` macro is the only sanctioned way to skip a test for a specific DBMS. Use it sparingly and only for genuinely unsupported features.
+
+## When tests fail on Windows
+
+The harness suppresses Windows blocking error dialogs (commit `bd5cd8ae`). If a test crash brings up a Watson dialog, set `MSVC_DISABLE_WATSON=1 _NO_DEBUG_HEAP=1` in the env. The `test_dbtool.py` runner decodes stdout as UTF-8 and disables Python output buffering (commit `6d8c360f`) so `dbtool` log output remains intact across the bridge.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -370,7 +370,13 @@ jobs:
         run: sudo apt install -y unixodbc odbcinst libuuid1 valgrind libyaml-cpp-dev libzip4
       - name: "Install SQLite3 ODBC driver"
         if: matrix.database == 'SQLite3'
-        run: sudo apt install -y libsqlite3-dev libsqliteodbc sqlite3
+        # On Ubuntu, libsqliteodbc registers itself in /etc/odbcinst.ini under
+        # `[SQLite3]`; on Windows, the choco-installed driver is `SQLite3 ODBC
+        # Driver`. We rename the Linux entry so the same .test-env.yml string
+        # works on both platforms.
+        run: |
+          sudo apt install -y libsqlite3-dev libsqliteodbc sqlite3
+          sudo sed -i 's/^\[SQLite3\]$/[SQLite3 ODBC Driver]/' /etc/odbcinst.ini
       - name: "Install MS SQL ODBC driver"
         if: startsWith(matrix.database, 'MS SQL')
         run: |
@@ -427,7 +433,11 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 19
       - name: "install dependencies"
-        run: sudo apt install -y cmake ninja-build catch2 unixodbc-dev sqlite3 libsqlite3-dev libsqliteodbc uuid-dev libyaml-cpp-dev libzip-dev
+        # Rename the libsqliteodbc driver section to match the Windows driver
+        # name so the shared .test-env.yml works on both platforms.
+        run: |
+          sudo apt install -y cmake ninja-build catch2 unixodbc-dev sqlite3 libsqlite3-dev libsqliteodbc uuid-dev libyaml-cpp-dev libzip-dev
+          sudo sed -i 's/^\[SQLite3\]$/[SQLite3 ODBC Driver]/' /etc/odbcinst.ini
       - name: "cmake"
         run: |
           cmake --preset linux-clang-${{ matrix.sanitizer }} \

--- a/AGENT.md
+++ b/AGENT.md
@@ -160,10 +160,15 @@ LightweightTest --test-env=sqlite3
 LightweightTest --test-env=mssql2022
 LightweightTest --test-env=postgres
 
-# 4. Run the dbtool integration suite per DB
-python3 src/tests/test_dbtool.py --test-env sqlite3
-python3 src/tests/test_dbtool.py --test-env mssql2022
-python3 src/tests/test_dbtool.py --test-env postgres
+# 4. Run the dbtool integration suite per DB. The script needs the dbtool
+#    binary and the directory holding the dummy_migration_plugin DLLs that
+#    its test fixtures dlopen. Adjust paths to your build dir (the example
+#    below is for the windows-clangcl-debug preset).
+DBTOOL=$PWD/out/build/windows-clangcl-debug/target/dbtool.exe
+PLUGINS=$PWD/out/build/windows-clangcl-debug/tests/plugins
+python3 src/tests/test_dbtool.py --dbtool "$DBTOOL" --plugins-dir "$PLUGINS" --test-env sqlite3
+python3 src/tests/test_dbtool.py --dbtool "$DBTOOL" --plugins-dir "$PLUGINS" --test-env mssql2022
+python3 src/tests/test_dbtool.py --dbtool "$DBTOOL" --plugins-dir "$PLUGINS" --test-env postgres
 ```
 
 If a database is **deliberately** skipped (e.g., feature genuinely doesn't apply, container can't be started in the environment), call it out in the PR summary with the reason. The `UNSUPPORTED_DATABASE(stmt, dbType)` macro in `src/tests/Utils.hpp` is the in-test escape hatch for genuinely unsupported features per DBMS — use it only when the limitation is intrinsic, not as a way to dodge a failure.

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,211 @@
+# Lightweight — Agent Guidelines
+
+## Project Architecture
+
+Lightweight is a thin, modern **C++23 ODBC SQL API** for raw and high-level database access. It exposes a low-level layer (`SqlConnection`, `SqlStatement`, `SqlDataBinder<T>`) and a high-level `DataMapper` (record/relationship mapping). All public symbols live in the `Lightweight` namespace (alias `Light`).
+
+Per-DBMS differences are funneled through a single dispatch point: `SqlQueryFormatter`. Business logic must be database-agnostic and let the formatter shape the SQL. Currently supported databases:
+
+| Database | `SqlServerType` | Test env name (`.test-env.yml`) |
+|----------|-----------------|---------------------------------|
+| Microsoft SQL Server  | `MICROSOFT_SQL` | `mssql2017`, `mssql2019`, `mssql2022`, `mssql` |
+| PostgreSQL            | `POSTGRESQL`    | `postgres`                       |
+| SQLite3               | `SQLITE`        | `sqlite3`                        |
+
+Bundled tools (in `src/tools/`): `dbtool` (general DB CLI), `ddl2cpp` (schema → C++ records generator), `lup2dbtool` (Lightweight migration plugin → dbtool migration), `large-db-generator` (test data).
+
+## Component Map
+
+| Path | Purpose |
+|------|---------|
+| `src/Lightweight/SqlConnection.{hpp,cpp}` | ODBC connection (driver, attrs, transaction, server-type detection) |
+| `src/Lightweight/SqlStatement.{hpp,cpp}`  | Prepared statement, bind/execute/fetch, batched execute |
+| `src/Lightweight/SqlDataBinder.hpp`       | Generic `SqlDataBinder<T>` traits — specialize per type |
+| `src/Lightweight/DataBinder/`             | Binder specializations: strings, GUID, date/time, binary, numeric, variant, optional |
+| `src/Lightweight/DataMapper/`             | High-level mapper: `Field`, `BelongsTo`, `HasMany`, `HasManyThrough`, `HasOneThrough`, connection pool, query builders |
+| `src/Lightweight/QueryFormatter/`         | Per-DBMS formatters: `SqlServerFormatter.hpp`, `PostgreSqlFormatter.hpp`, `SQLiteFormatter.hpp` |
+| `src/Lightweight/SqlQuery/`               | DSL: `Select`, `Insert`, `Update`, `Delete`, `Migrate`, `MigrationPlan`, `Core` |
+| `src/Lightweight/SqlMigration.{hpp,cpp}`  | Migration runner; `SqlMigrationLock` for cross-process safety |
+| `src/Lightweight/SqlBackup/` (+ `.hpp`)   | Schema/data backup framework |
+| `src/Lightweight/Tools/`                  | Shared internal tools/utilities used by `src/tools/` binaries |
+| `src/Lightweight/Zip/`                    | libzip wrapper used by backup |
+| `src/Lightweight/Lightweight.cppm`        | C++20 module export aggregator (when `LIGHTWEIGHT_BUILD_MODULES=ON`) |
+| `src/tests/`                              | Catch2 test suite (built as `LightweightTest`); `.test-env.yml` consumed via `--test-env=<name>` |
+| `src/tools/`                              | `dbtool/`, `ddl2cpp.cpp`, `lup2dbtool/`, `large-db-generator/`, `LupMigrationsPlugin/`, `test_chinook.sh` |
+| `src/examples/`                           | Compilable usage samples + Chinook integration |
+| `src/benchmark/`                          | Performance benchmarks |
+| `cmake/`                                  | `ClangTidy.cmake`, `Coverage.cmake`, `PedanticCompiler.cmake`, `Sanitizers.cmake`, `Version.cmake`, `Lightweight-config.cmake.in` |
+| `docs/`                                   | User-facing documentation (`data-binder.md`, `dbtool.md`, `how-to.md`, `sql-migrations.md`, `sqlquery.md`, `usage.md`, `best-practices.md`, `lup-migration-plugin.md`, `sql-backup-format.md`) |
+| `scripts/tests/docker-databases.py`       | Docker harness for MSSQL/Postgres test containers |
+| `.github/workflows/build.yml`             | Authoritative CI matrix (presets × databases × sanitizers) |
+| `.agent/`                                 | Agent deep-dives (architecture, databases, testing, C++ patterns) |
+
+See `.agent/architecture.md` for a deeper structural walkthrough with canonical examples.
+
+## Design Patterns & Principles
+
+### Per-DBMS dispatch via `SqlQueryFormatter`
+Never branch on `SqlServerType` in business logic. Instead, add a virtual method to `SqlQueryFormatter` and override it per DBMS in `QueryFormatter/{SqlServerFormatter,PostgreSqlFormatter,SQLiteFormatter}.hpp`. Canonical example: `PostgreSqlFormatter::QueryLastInsertId()` returns `"SELECT lastval();"` while the SQL Server override returns `"SELECT @@IDENTITY;"`.
+
+### `SqlDataBinder<T>` specialization for new types
+Bind/fetch/inspect for a new C++ type lives in a `SqlDataBinder<T>` specialization under `src/Lightweight/DataBinder/`. Reuse the shared helpers in `BasicStringBinder.hpp` (Unicode), `Core.hpp` (length indicators), and `UnicodeConverter.hpp` (u8/u16/wchar_t conversion) rather than re-implementing buffer growth or NULL handling.
+
+### Error handling: `std::expected<T, SqlError>`
+Prefer `std::expected<T, SqlError>` for fallible API surface. Chain monadically with `and_then`, `or_else`, `transform`, `transform_error` rather than nested `if`s. Reserve exceptions for programmer errors (precondition violation, misuse).
+
+### Dependency injection
+Tests must obtain a connection via the Catch2 fixture wired to `--test-env`, not by constructing one with hard-coded strings. Internally, anything that touches I/O, time, or randomness should be injectable so the unit tests in `src/tests/` can drive it.
+
+### Data-driven design
+Drive behaviour with descriptor tables, not scattered `switch (server)` ladders. The formatter dispatch is the canonical example; new dialect knobs should follow it.
+
+### RAII for ODBC handles
+`SQLHANDLE` resources (env, dbc, stmt) are owned by the Lightweight wrapper types and released via destructor. Do not allocate raw `SQLHANDLE` outside of those wrappers.
+
+## C++ Coding Guidelines (self-contained — no external `cpp.md` required)
+
+### Baseline (general C++23)
+- **Data-driven design** — avoid hard-coded magic values; prefer tables/descriptors.
+- **Dependency injection** — decouple components and improve testability.
+- **Doxygen** on every new public function (params, return), class, struct, and member:
+  ```cpp
+  /// Short description.
+  /// @param name Description.
+  /// @return Description.
+  ```
+- **`const` correctness** throughout (refs, pointers, member functions).
+- **C++23 features** — `constexpr`, `std::ranges`, `std::format`, `std::expected` and its monadic methods (`and_then`, `or_else`, `transform`, `transform_error`).
+- **C-style loops are forbidden.** Use range-based `for`, `std::views::iota`, and other range views for generation/transformation.
+- **`std::span`** for arrays and contiguous sequences.
+- **`auto` type deduction** for readability; **structured bindings** for tuple-like returns.
+- **`clang-format` after every change** — use the project `.clang-format`.
+- **`clang-tidy` reports must be fixed at the source.** Never silence with `NOLINT` — address the underlying issue. The `linux-clang-debug` preset enables `clang-tidy` automatically.
+- **All changes covered by unit tests.** Aim to **increase** coverage with every PR.
+- **No raw owning pointers.** Use `std::unique_ptr` / `std::shared_ptr` for ownership; RAII for resources.
+- **No new third-party dependencies** without strong justification.
+
+### Lightweight-specific additions
+- Public headers must be **self-contained** (compile standalone, no PCH dependency).
+- Public symbols live in the `Lightweight` namespace (alias `Light`).
+- Mark builders, queries, and `std::expected`-returning APIs `[[nodiscard]]`.
+- Prefer `std::expected<T, SqlError>` over throwing on the public API surface.
+- Per-DBMS branching belongs only inside `SqlQueryFormatter` overrides — never in business logic.
+- For Unicode-bearing data binders, follow the `BasicStringBinder.hpp` contract (u8/u16/wchar_t round-trip via `UnicodeConverter`); see `.agent/cpp-guidelines.md` for the contract.
+- ODBC `SQLHANDLE` lifetimes are bound to the wrapper types; never leak them across abstraction boundaries.
+
+## Building
+
+CMake presets live in `CMakePresets.json`. Common entry points:
+
+```sh
+# Linux — Clang Debug with PEDANTIC + ASan + UBSan + clang-tidy (the default agent preset)
+cmake --preset linux-clang-debug
+cmake --build --preset linux-clang-debug
+ctest --preset linux-clang-debug
+
+# Linux — GCC Debug
+cmake --preset linux-gcc-debug && cmake --build --preset linux-gcc-debug
+
+# Linux — Coverage (HTML in out/build/linux-clang-coverage/)
+cmake --preset linux-clang-coverage
+cmake --build --preset linux-clang-coverage
+
+# Linux — sanitizer-only presets
+cmake --preset linux-clang-asan-ubsan
+cmake --preset linux-clang-tsan
+
+# Windows — MSVC CL Debug (requires VCPKG_ROOT in env)
+cmake --preset windows-cl-debug
+cmake --build --preset windows-cl-debug
+
+# Windows — clang-cl Debug
+cmake --preset windows-clangcl-debug
+cmake --build --preset windows-clangcl-debug
+```
+
+`PEDANTIC_COMPILER_WERROR=ON` is the default for Windows presets — warnings break the build, fix them at the source.
+
+## Testing
+
+Catch2 tests live in `src/tests/` and produce a single `LightweightTest` binary. Database selection is parameterised:
+
+```sh
+LightweightTest --test-env=<name>     # picks ODBC_CONNECTION_STRING.<name> from .test-env.yml
+LightweightTest --trace-sql --trace-odbc   # for diagnosing dialect/driver issues
+```
+
+`.test-env.yml` schema:
+```yaml
+ODBC_CONNECTION_STRING:
+  sqlite3:    "DRIVER=SQLite3;Database=test.db"
+  mssql2022:  "Driver={ODBC Driver 18 for SQL Server};SERVER=localhost;PORT=1433;UID=SA;PWD=...;TrustServerCertificate=yes;DATABASE=LightweightTest"
+  postgres:   "Driver={PostgreSQL Unicode};Server=localhost;Port=5432;Uid=...;Pwd=...;Database=test"
+```
+
+### Always test against every supported database before claiming done
+
+This project's CI matrix runs the full suite against **SQLite3**, **MS SQL Server 2017/2019/2022**, and **PostgreSQL** (`.github/workflows/build.yml` → `dbms_test_matrix`). An agent that runs only `sqlite3` locally and reports green has **not** finished the work — Unicode, type, NULL, and migration semantics differ in non-obvious ways across drivers.
+
+Required local flow (use the Docker harness for the non-SQLite DBs):
+
+```sh
+# 1. Start MSSQL 2022 + Postgres (idempotent)
+python3 scripts/tests/docker-databases.py --start --wait mssql2022 postgres
+
+# 2. Make sure .test-env.yml has entries for sqlite3, mssql2022, postgres
+#    (see schema above; the docker harness uses these connection strings)
+
+# 3. Run the full suite three times
+LightweightTest --test-env=sqlite3
+LightweightTest --test-env=mssql2022
+LightweightTest --test-env=postgres
+
+# 4. Run the dbtool integration suite per DB
+python3 src/tests/test_dbtool.py --test-env sqlite3
+python3 src/tests/test_dbtool.py --test-env mssql2022
+python3 src/tests/test_dbtool.py --test-env postgres
+```
+
+If a database is **deliberately** skipped (e.g., feature genuinely doesn't apply, container can't be started in the environment), call it out in the PR summary with the reason. The `UNSUPPORTED_DATABASE(stmt, dbType)` macro in `src/tests/Utils.hpp` is the in-test escape hatch for genuinely unsupported features per DBMS — use it only when the limitation is intrinsic, not as a way to dodge a failure.
+
+When touching anything in `DataBinder/`, also exercise both `u8`/`u16`/`wchar_t` paths (the `WideChar` typedef in `Utils.hpp` selects the platform-appropriate UTF-16 code unit). See `.agent/testing.md` and `.agent/databases.md` for deeper guidance.
+
+## Adding Features
+
+### New `SqlDataBinder<T>` specialization
+1. Create `src/Lightweight/DataBinder/<Type>.hpp` with `template <> struct SqlDataBinder<T> { … }`.
+2. Implement `InputParameter`, `OutputColumn`, `GetColumn`, and (if needed) `Inspect`.
+3. Reuse helpers from `BasicStringBinder.hpp` / `Core.hpp` / `UnicodeConverter.hpp`.
+4. Add tests in `src/tests/DataBinderTests.cpp` covering bind, fetch, NULL, and (for strings) Unicode round-trip.
+5. **Run the suite against all three databases.**
+
+### New SQL surface (DSL / migration / query primitive)
+1. Extend the relevant header in `src/Lightweight/SqlQuery/` (`Select`, `Insert`, `Update`, `Delete`, `Migrate`, `MigrationPlan`, `Core`).
+2. If the SQL text differs by DBMS, add a virtual hook to `SqlQueryFormatter` and override per-DBMS in `QueryFormatter/`.
+3. Update or add tests in `src/tests/QueryBuilderTests.cpp` / `MigrationTests.cpp`.
+4. If user-visible: update the matching `docs/*.md` page.
+5. **Run the suite against all three databases.**
+
+### New tool or `dbtool` subcommand
+1. Add the source under `src/tools/<tool>/` and register in `src/tools/CMakeLists.txt`.
+2. Drive it by descriptors / config tables, not hard-coded option ladders.
+3. Add coverage in `src/tests/test_dbtool.py` (or its peers).
+4. Document in `docs/dbtool.md` (or a new file).
+
+### New per-DBMS feature gate
+Add the capability check to `SqlQueryFormatter` (e.g., `bool SupportsX() const`); use it in callers. Do **not** use `if (server == SqlServerType::X)` in non-formatter code.
+
+## Workflow (post-implementation checklist)
+
+1. Run `clang-format` on every changed `.hpp` / `.cpp` (project `.clang-format`).
+2. Build the relevant preset (`linux-clang-debug` for full coverage of warnings + clang-tidy + ASan/UBSan; `windows-clangcl-debug` if Windows-side changes). Resolve all warnings — `PEDANTIC_COMPILER_WERROR` is on.
+3. **Run the full test suite against every supported database.** At minimum: `sqlite3`, `mssql2022`, `postgres`. Use `scripts/tests/docker-databases.py --start --wait mssql2022 postgres` to spin up the non-SQLite containers. Document any DB skipped with the reason.
+4. Run `clang-tidy` (it runs automatically under `linux-clang-debug`); fix every finding at the source — never `NOLINT`.
+5. If touching public headers or user-visible behaviour, update `docs/` (`data-binder.md`, `sql-migrations.md`, `dbtool.md`, `usage.md`, `how-to.md`, `best-practices.md`, etc.).
+6. Run the sanitizer presets when relevant (`linux-clang-asan-ubsan`, `linux-clang-tsan`) — required for changes touching pools, threading, or raw buffer arithmetic.
+7. Execute `/simplify` to reduce duplication and code-quality issues. If the simplify pass surfaces issues out of scope, **ask** the user whether to address them in this PR; if yes, include them; if no, ignore and move on.
+8. In the PR / commit summary include:
+   - **Performance impact** — with measurements where possible (use `src/benchmark/` if applicable).
+   - **Risk assessment** — what could break per DBMS, threading, ABI, ODBC version compatibility.
+   - **Code coverage** — results from `linux-clang-coverage` if coverage was a goal.
+   - **Databases tested** — explicit list with versions (`sqlite3`, `mssql2022 (Docker)`, `postgres (Docker 16.4)`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENT.md

--- a/scripts/tests/.test-env.yml
+++ b/scripts/tests/.test-env.yml
@@ -9,4 +9,4 @@ ODBC_CONNECTION_STRING:
   # don't silently turn into `\r\n` on insert.
   postgres: Driver={PostgreSQL Unicode};Server=localhost;Port=5432;Uid=postgres;Pwd=Lightweight!Test42;Database=test;LFConversion=0
   postgres_unicode: Driver={PostgreSQL Unicode};Server=localhost;Port=5432;Uid=postgres;Pwd=Lightweight!Test42;Database=test;LFConversion=0
-  sqlite3: Driver=SQLite3;Database=test.db
+  sqlite3: Driver={SQLite3 ODBC Driver};Database=test.db

--- a/scripts/tests/.test-env.yml
+++ b/scripts/tests/.test-env.yml
@@ -3,6 +3,10 @@ ODBC_CONNECTION_STRING:
   mssql2022: Driver={ODBC Driver 18 for SQL Server};SERVER=localhost,1433;UID=SA;PWD=Lightweight!Test42;TrustServerCertificate=yes;DATABASE=LightweightTest
   mssql2019: Driver={ODBC Driver 18 for SQL Server};SERVER=localhost,1434;UID=SA;PWD=Lightweight!Test42;TrustServerCertificate=yes;DATABASE=LightweightTest
   mssql2017: Driver={ODBC Driver 18 for SQL Server};SERVER=localhost,1432;UID=SA;PWD=Lightweight!Test42;TrustServerCertificate=yes;DATABASE=LightweightTest
-  postgres: Driver={PostgreSQL Unicode};Server=localhost;Port=5432;Uid=postgres;Pwd=Lightweight!Test42;Database=test
-  postgres_unicode: Driver={PostgreSQL Unicode};Server=localhost;Port=5432;Uid=postgres;Pwd=Lightweight!Test42;Database=test
+  # LFConversion=0 disables the psqlODBC driver's LF<->CRLF translation that is on
+  # by default on Windows. We want byte-exact round-trips of TEXT/VARCHAR data so
+  # test fixtures with embedded `\n` (corner-case strings, batch-manager smoke tests)
+  # don't silently turn into `\r\n` on insert.
+  postgres: Driver={PostgreSQL Unicode};Server=localhost;Port=5432;Uid=postgres;Pwd=Lightweight!Test42;Database=test;LFConversion=0
+  postgres_unicode: Driver={PostgreSQL Unicode};Server=localhost;Port=5432;Uid=postgres;Pwd=Lightweight!Test42;Database=test;LFConversion=0
   sqlite3: Driver=SQLite3;Database=test.db

--- a/src/Lightweight/CMakeLists.txt
+++ b/src/Lightweight/CMakeLists.txt
@@ -90,6 +90,7 @@ set(HEADER_FILES
     SqlLogger.hpp
     SqlMigration.hpp
     SqlMigrationLock.hpp
+    SqlOdbcWide.hpp
     SqlQueryFormatter.hpp
     SqlSchema.hpp
     SqlScopedTraceLogger.hpp

--- a/src/Lightweight/DataBinder/BasicStringBinder.hpp
+++ b/src/Lightweight/DataBinder/BasicStringBinder.hpp
@@ -83,7 +83,8 @@ namespace detail
             result->resize(result->size() * 2);
             auto* const bufferStart = result->data() + writeIndex;
             size_t const bufferCharsAvailable = result->size() - writeIndex;
-            sqlResult = SQLGetData(stmt, column, CType, bufferStart, static_cast<SQLLEN>(bufferCharsAvailable), indicator);
+            sqlResult = SQLGetData(
+                stmt, column, CType, bufferStart, static_cast<SQLLEN>(bufferCharsAvailable * sizeof(CharType)), indicator);
         }
         return sqlResult;
     }

--- a/src/Lightweight/DataBinder/BasicStringBinder.hpp
+++ b/src/Lightweight/DataBinder/BasicStringBinder.hpp
@@ -145,6 +145,23 @@ namespace detail
                     (CharType const*) u32String.data() + u32String.size(),
                 };
             }
+
+            // The UTF-16 binder applies StringTraits::PostProcessOutputColumn (if present) so that
+            // FIXED_SIZE_RIGHT_TRIMMED strings strip the trailing CHAR(N)/NCHAR(N) padding the server
+            // returned. The UTF-32 / UTF-8 path constructs *result above, which preserves the padding,
+            // so we have to invoke the same post-process here. The synthetic indicator is the
+            // result's own byte count: PostProcessOutputColumn divides by sizeof(CharType) to get
+            // the char count, and TrimRight then walks back over trailing whitespace/null.
+            using StringTraits = SqlBasicStringOperations<StringType>;
+            if constexpr (requires { StringTraits::PostProcessOutputColumn(result, *indicator); })
+            {
+                if (*indicator != SQL_NULL_DATA && *indicator != SQL_NO_TOTAL)
+                {
+                    auto const syntheticIndicator =
+                        static_cast<SQLLEN>(StringTraits::Size(result) * sizeof(CharType));
+                    StringTraits::PostProcessOutputColumn(result, syntheticIndicator);
+                }
+            }
         });
 
         return SQLBindCol(stmt,
@@ -416,15 +433,9 @@ struct SqlDataBinder<Utf16StringType>
                                     Utf16StringType const& value,
                                     SqlDataBinderCallback& cb) noexcept
     {
-        // Bind UTF-16 input directly via SQL_C_WCHAR for every backend, including
-        // PostgreSQL. The previous PG-specific hatch — pre-converting to UTF-8 and
-        // binding as SQL_C_CHAR / SQL_VARCHAR — was a workaround for psqlODBC running
-        // in ANSI mode on Windows, where SQL_C_CHAR is treated as the system codepage
-        // (cp1252) and re-encoded as UTF-8. With SqlConnection now opening every handle
-        // via SQLDriverConnectW the driver is in Unicode app mode, where SQL_C_WCHAR
-        // input is converted to the server's encoding by the driver itself — including
-        // correct handling of UTF-16 surrogate pairs for supplementary-plane code points
-        // (emoji, CJK extension, etc.).
+        // Bind UTF-16 input directly via SQL_C_WCHAR for every backend; the driver
+        // converts to the server's encoding, including correct handling of UTF-16
+        // surrogate pairs for supplementary-plane code points (emoji, CJK extension B+).
         using CharType = StringTraits::CharType;
         auto const* data = StringTraits::Data(&value);
         auto const sizeInBytes = StringTraits::Size(&value) * sizeof(CharType);
@@ -526,10 +537,7 @@ struct SqlDataBinder<Utf32StringType>
                                     SqlDataBinderCallback& cb) noexcept
     {
         // Always go via UTF-16 + SQL_C_WCHAR; the driver handles encoding conversion
-        // for the target server. See the matching comment on the std::u16string binder
-        // above — same rationale, the previous PostgreSQL-specific UTF-8 hatch was
-        // a workaround for ANSI-mode psqlODBC and is no longer needed now that the
-        // connection is opened via SQLDriverConnectW.
+        // for the target server.
         auto u16String =
             std::make_shared<std::u16string>(ToUtf16(detail::SqlViewHelper<Utf32StringType>::View(value)));
         cb.PlanPostExecuteCallback([u16String = u16String]() {}); // Keep the string alive
@@ -603,12 +611,7 @@ struct SqlDataBinder<Utf8StringType>
                                     SqlDataBinderCallback& cb) noexcept
     {
         // Always go via UTF-16 + SQL_C_WCHAR; the driver handles encoding conversion
-        // for the target server. Same rationale as the std::u16string / std::u32string
-        // binders above: the previous PostgreSQL-specific UTF-8 hatch (bind UTF-8 bytes
-        // as SQL_C_CHAR / SQL_VARCHAR) only worked when the connection happened to be in
-        // ANSI mode on a UTF-8 system locale (Linux). On Windows it ran the bytes through
-        // cp1252 → UTF-8 a second time, doubling each byte ≥ 0x80 — emoji and `ö`
-        // round-tripped wrong, and 200-byte UTF-8 payloads tripped VARCHAR-length checks.
+        // for the target server.
         auto u16String =
             std::make_shared<std::u16string>(ToUtf16(detail::SqlViewHelper<Utf8StringType>::View(value)));
         cb.PlanPostExecuteCallback([u16String = u16String]() {}); // Keep the string alive

--- a/src/Lightweight/DataBinder/BasicStringBinder.hpp
+++ b/src/Lightweight/DataBinder/BasicStringBinder.hpp
@@ -172,6 +172,41 @@ struct SqlDataBinder<AnsiStringType>
                                                              AnsiStringType const& value,
                                                              SqlDataBinderCallback& cb) noexcept
     {
+        // PostgreSQL: route narrow strings through UTF-16 + SQL_C_WCHAR. Even with the
+        // DBC handle in Unicode-app mode (SQLDriverConnectW), psqlODBC on Windows still
+        // interprets SQL_C_CHAR data as the system codepage (cp1252), not UTF-8 — so a
+        // 200-byte UTF-8 payload representing 100 supplementary-plane characters gets
+        // re-encoded into 400 bytes and trips VARCHAR(100)'s character-count check.
+        // Going via SQL_C_WCHAR makes the driver itself do the encoding conversion to
+        // the server's encoding (UTF-8) using proper Unicode rules. We treat the
+        // incoming `std::string` as UTF-8 by convention — that is what every other
+        // call path in the library produces (file readers, query formatters, etc.).
+        if (cb.ServerType() == SqlServerType::POSTGRESQL)
+        {
+            auto u16String = std::make_shared<std::u16string>(
+                ToUtf16(std::u8string_view { reinterpret_cast<char8_t const*>(StringTraits::Data(&value)),
+                                             StringTraits::Size(&value) }));
+            cb.PlanPostExecuteCallback([u16String = u16String]() {}); // keep buffer alive
+            auto const charCount = u16String->size();
+            auto const byteCount = charCount * sizeof(char16_t);
+            auto const sqlType =
+                static_cast<SQLSMALLINT>(charCount > SqlOptimalMaxColumnSize ? SQL_WLONGVARCHAR : SQL_WVARCHAR);
+
+            SQLLEN* indicator = cb.ProvideInputIndicator();
+            *indicator = static_cast<SQLLEN>(byteCount);
+
+            return SQLBindParameter(stmt,
+                                    column,
+                                    SQL_PARAM_INPUT,
+                                    SQL_C_WCHAR,
+                                    sqlType,
+                                    charCount,
+                                    0,
+                                    (SQLPOINTER) u16String->data(),
+                                    static_cast<SQLLEN>(byteCount),
+                                    indicator);
+        }
+
         auto const charCount = StringTraits::Size(&value);
         auto const sqlType = static_cast<SQLSMALLINT>(charCount > SqlOptimalMaxColumnSize ? SQL_LONGVARCHAR : SQL_VARCHAR);
 
@@ -380,54 +415,35 @@ struct SqlDataBinder<Utf16StringType>
                                     Utf16StringType const& value,
                                     SqlDataBinderCallback& cb) noexcept
     {
-        switch (cb.ServerType())
-        {
-            case SqlServerType::POSTGRESQL: {
-                // PostgreSQL only supports UTF-8 as Unicode encoding
-                auto u8String = std::make_shared<std::u8string>(ToUtf8(detail::SqlViewHelper<Utf16StringType>::View(value)));
-                cb.PlanPostExecuteCallback([u8String = u8String]() {}); // Keep the string alive
+        // Bind UTF-16 input directly via SQL_C_WCHAR for every backend, including
+        // PostgreSQL. The previous PG-specific hatch — pre-converting to UTF-8 and
+        // binding as SQL_C_CHAR / SQL_VARCHAR — was a workaround for psqlODBC running
+        // in ANSI mode on Windows, where SQL_C_CHAR is treated as the system codepage
+        // (cp1252) and re-encoded as UTF-8. With SqlConnection now opening every handle
+        // via SQLDriverConnectW the driver is in Unicode app mode, where SQL_C_WCHAR
+        // input is converted to the server's encoding by the driver itself — including
+        // correct handling of UTF-16 surrogate pairs for supplementary-plane code points
+        // (emoji, CJK extension, etc.).
+        using CharType = StringTraits::CharType;
+        auto const* data = StringTraits::Data(&value);
+        auto const sizeInBytes = StringTraits::Size(&value) * sizeof(CharType);
+        auto const charCount = StringTraits::Size(&value);
+        auto const sqlType =
+            static_cast<SQLSMALLINT>(charCount > SqlOptimalMaxColumnSize ? SQL_WLONGVARCHAR : SQL_WVARCHAR);
 
-                SQLLEN* indicator = cb.ProvideInputIndicator();
-                *indicator = static_cast<SQLLEN>(u8String->size());
+        SQLLEN* indicator = cb.ProvideInputIndicator();
+        *indicator = static_cast<SQLLEN>(sizeInBytes);
 
-                return SQLBindParameter(stmt,
-                                        column,
-                                        SQL_PARAM_INPUT,
-                                        SQL_C_CHAR,
-                                        SQL_VARCHAR,
-                                        u8String->size(),
-                                        0,
-                                        (SQLPOINTER) u8String->data(),
-                                        0,
-                                        indicator);
-            }
-            case SqlServerType::MYSQL:
-            case SqlServerType::SQLITE: // We assume UTF-16 for SQLite
-            case SqlServerType::MICROSOFT_SQL:
-            case SqlServerType::UNKNOWN: {
-                using CharType = StringTraits::CharType;
-                auto const* data = StringTraits::Data(&value);
-                auto const sizeInBytes = StringTraits::Size(&value) * sizeof(CharType);
-                auto const charCount = StringTraits::Size(&value);
-                auto const sqlType =
-                    static_cast<SQLSMALLINT>(charCount > SqlOptimalMaxColumnSize ? SQL_WLONGVARCHAR : SQL_WVARCHAR);
-
-                SQLLEN* indicator = cb.ProvideInputIndicator();
-                *indicator = static_cast<SQLLEN>(sizeInBytes);
-
-                return SQLBindParameter(stmt,
-                                        column,
-                                        SQL_PARAM_INPUT,
-                                        CType,
-                                        sqlType,
-                                        charCount,
-                                        0,
-                                        (SQLPOINTER) data,
-                                        static_cast<SQLLEN>(sizeInBytes),
-                                        indicator);
-            }
-        }
-        std::unreachable();
+        return SQLBindParameter(stmt,
+                                column,
+                                SQL_PARAM_INPUT,
+                                CType,
+                                sqlType,
+                                charCount,
+                                0,
+                                (SQLPOINTER) data,
+                                static_cast<SQLLEN>(sizeInBytes),
+                                indicator);
     }
 
     static SQLRETURN OutputColumn(
@@ -508,57 +524,34 @@ struct SqlDataBinder<Utf32StringType>
                                     Utf32StringType const& value,
                                     SqlDataBinderCallback& cb) noexcept
     {
-        switch (cb.ServerType())
-        {
-            case SqlServerType::POSTGRESQL: {
-                // PostgreSQL only supports UTF-8 as Unicode encoding
-                auto u8String = std::make_shared<std::u8string>(ToUtf8(detail::SqlViewHelper<Utf32StringType>::View(value)));
-                cb.PlanPostExecuteCallback([u8String = u8String]() {}); // Keep the string alive
+        // Always go via UTF-16 + SQL_C_WCHAR; the driver handles encoding conversion
+        // for the target server. See the matching comment on the std::u16string binder
+        // above — same rationale, the previous PostgreSQL-specific UTF-8 hatch was
+        // a workaround for ANSI-mode psqlODBC and is no longer needed now that the
+        // connection is opened via SQLDriverConnectW.
+        auto u16String =
+            std::make_shared<std::u16string>(ToUtf16(detail::SqlViewHelper<Utf32StringType>::View(value)));
+        cb.PlanPostExecuteCallback([u16String = u16String]() {}); // Keep the string alive
+        auto const* data = u16String->data();
+        auto const charCount = u16String->size();
+        auto const sizeInBytes = u16String->size() * sizeof(char16_t);
+        auto const CType = SQLSMALLINT { SQL_C_WCHAR };
+        auto const sqlType =
+            static_cast<SQLSMALLINT>(charCount > SqlOptimalMaxColumnSize ? SQL_WLONGVARCHAR : SQL_WVARCHAR);
 
-                SQLLEN* indicator = cb.ProvideInputIndicator();
-                *indicator = static_cast<SQLLEN>(u8String->size());
+        SQLLEN* indicator = cb.ProvideInputIndicator();
+        *indicator = static_cast<SQLLEN>(sizeInBytes);
 
-                return SQLBindParameter(stmt,
-                                        column,
-                                        SQL_PARAM_INPUT,
-                                        SQL_C_CHAR,
-                                        SQL_VARCHAR,
-                                        u8String->size(),
-                                        0,
-                                        (SQLPOINTER) u8String->data(),
-                                        0,
-                                        indicator);
-            }
-            case SqlServerType::MYSQL:
-            case SqlServerType::SQLITE: // We assume UTF-16 for SQLite
-            case SqlServerType::MICROSOFT_SQL:
-            case SqlServerType::UNKNOWN: {
-                auto u16String =
-                    std::make_shared<std::u16string>(ToUtf16(detail::SqlViewHelper<Utf32StringType>::View(value)));
-                cb.PlanPostExecuteCallback([u8String = u16String]() {}); // Keep the string alive
-                auto const* data = u16String->data();
-                auto const charCount = u16String->size();
-                auto const sizeInBytes = u16String->size() * sizeof(char16_t);
-                auto const CType = SQLSMALLINT { SQL_C_WCHAR };
-                auto const sqlType =
-                    static_cast<SQLSMALLINT>(charCount > SqlOptimalMaxColumnSize ? SQL_WLONGVARCHAR : SQL_WVARCHAR);
-
-                SQLLEN* indicator = cb.ProvideInputIndicator();
-                *indicator = static_cast<SQLLEN>(sizeInBytes);
-
-                return SQLBindParameter(stmt,
-                                        column,
-                                        SQL_PARAM_INPUT,
-                                        CType,
-                                        sqlType,
-                                        charCount,
-                                        0,
-                                        (SQLPOINTER) data,
-                                        static_cast<SQLLEN>(sizeInBytes),
-                                        indicator);
-            }
-        }
-        std::unreachable();
+        return SQLBindParameter(stmt,
+                                column,
+                                SQL_PARAM_INPUT,
+                                CType,
+                                sqlType,
+                                charCount,
+                                0,
+                                (SQLPOINTER) data,
+                                static_cast<SQLLEN>(sizeInBytes),
+                                indicator);
     }
 
     static SQLRETURN OutputColumn(
@@ -608,47 +601,36 @@ struct SqlDataBinder<Utf8StringType>
                                     Utf8StringType const& value,
                                     SqlDataBinderCallback& cb) noexcept
     {
-        switch (cb.ServerType())
-        {
-            case SqlServerType::POSTGRESQL: {
-                // PostgreSQL only supports UTF-8 as Unicode encoding
-                auto const len = value.size();
-                SQLLEN* indicator = cb.ProvideInputIndicator();
-                *indicator = static_cast<SQLLEN>(len);
+        // Always go via UTF-16 + SQL_C_WCHAR; the driver handles encoding conversion
+        // for the target server. Same rationale as the std::u16string / std::u32string
+        // binders above: the previous PostgreSQL-specific UTF-8 hatch (bind UTF-8 bytes
+        // as SQL_C_CHAR / SQL_VARCHAR) only worked when the connection happened to be in
+        // ANSI mode on a UTF-8 system locale (Linux). On Windows it ran the bytes through
+        // cp1252 → UTF-8 a second time, doubling each byte ≥ 0x80 — emoji and `ö`
+        // round-tripped wrong, and 200-byte UTF-8 payloads tripped VARCHAR-length checks.
+        auto u16String =
+            std::make_shared<std::u16string>(ToUtf16(detail::SqlViewHelper<Utf8StringType>::View(value)));
+        cb.PlanPostExecuteCallback([u16String = u16String]() {}); // Keep the string alive
 
-                return SQLBindParameter(
-                    stmt, column, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, len, 0, (SQLPOINTER) value.data(), 0, indicator);
-            }
-            case SqlServerType::MYSQL:
-            case SqlServerType::SQLITE: // We assume UTF-16 for SQLite
-            case SqlServerType::MICROSOFT_SQL:
-            case SqlServerType::UNKNOWN: {
-                auto u16String =
-                    std::make_shared<std::u16string>(ToUtf16(detail::SqlViewHelper<Utf8StringType>::View(value)));
-                cb.PlanPostExecuteCallback([u16String = u16String]() {}); // Keep the string alive
+        auto const CType = SQL_C_WCHAR;
+        auto const charCount = u16String->size();
+        auto const byteCount = u16String->size() * sizeof(char16_t);
+        auto const sqlType =
+            static_cast<SQLSMALLINT>(charCount > SqlOptimalMaxColumnSize ? SQL_WLONGVARCHAR : SQL_WVARCHAR);
 
-                auto const CType = SQL_C_WCHAR;
-                auto const charCount = u16String->size();
-                auto const byteCount = u16String->size() * sizeof(char16_t);
-                auto const sqlType =
-                    static_cast<SQLSMALLINT>(charCount > SqlOptimalMaxColumnSize ? SQL_WLONGVARCHAR : SQL_WVARCHAR);
+        SQLLEN* indicator = cb.ProvideInputIndicator();
+        *indicator = static_cast<SQLLEN>(byteCount);
 
-                SQLLEN* indicator = cb.ProvideInputIndicator();
-                *indicator = static_cast<SQLLEN>(byteCount);
-
-                return SQLBindParameter(stmt,
-                                        column,
-                                        SQL_PARAM_INPUT,
-                                        CType,
-                                        sqlType,
-                                        charCount,
-                                        0,
-                                        (SQLPOINTER) u16String->data(),
-                                        static_cast<SQLLEN>(byteCount),
-                                        indicator);
-            }
-        }
-        std::unreachable();
+        return SQLBindParameter(stmt,
+                                column,
+                                SQL_PARAM_INPUT,
+                                CType,
+                                sqlType,
+                                charCount,
+                                0,
+                                (SQLPOINTER) u16String->data(),
+                                static_cast<SQLLEN>(byteCount),
+                                indicator);
     }
 
     static SQLRETURN OutputColumn(

--- a/src/Lightweight/DataBinder/SqlVariant.cpp
+++ b/src/Lightweight/DataBinder/SqlVariant.cpp
@@ -22,8 +22,15 @@ SQLRETURN SqlDataBinder<SqlVariant>::GetColumn(
     SQLHSTMT stmt, SQLUSMALLINT column, SqlVariant* result, SQLLEN* indicator, SqlDataBinderCallback const& cb) noexcept
 {
     SQLLEN columnType {};
+    // Use the W variant — the call passes nullptr for the string buffer (we only fetch
+    // the numeric SQL_DESC_TYPE), so it's a near-pure rename, but it keeps the entire
+    // ODBC call surface on the Unicode-app path the rest of the library now uses.
+    // Note: SQLColAttributeA takes a *signed* `SQLSMALLINT ColumnNumber` (legacy ODBC 2.0
+    // signature), while SQLColAttributeW takes the modern *unsigned* `SQLUSMALLINT`. The
+    // pre-existing `static_cast<SQLSMALLINT>(column)` is therefore wrong (and a
+    // clang-tidy sign-conversion error) when paired with the W variant — drop it.
     SQLRETURN returnCode =
-        SQLColAttributeA(stmt, static_cast<SQLSMALLINT>(column), SQL_DESC_TYPE, nullptr, 0, nullptr, &columnType);
+        SQLColAttributeW(stmt, column, SQL_DESC_TYPE, nullptr, 0, nullptr, &columnType);
     if (!SQL_SUCCEEDED(returnCode))
         return returnCode;
 

--- a/src/Lightweight/DataBinder/SqlVariant.cpp
+++ b/src/Lightweight/DataBinder/SqlVariant.cpp
@@ -24,11 +24,7 @@ SQLRETURN SqlDataBinder<SqlVariant>::GetColumn(
     SQLLEN columnType {};
     // Use the W variant — the call passes nullptr for the string buffer (we only fetch
     // the numeric SQL_DESC_TYPE), so it's a near-pure rename, but it keeps the entire
-    // ODBC call surface on the Unicode-app path the rest of the library now uses.
-    // Note: SQLColAttributeA takes a *signed* `SQLSMALLINT ColumnNumber` (legacy ODBC 2.0
-    // signature), while SQLColAttributeW takes the modern *unsigned* `SQLUSMALLINT`. The
-    // pre-existing `static_cast<SQLSMALLINT>(column)` is therefore wrong (and a
-    // clang-tidy sign-conversion error) when paired with the W variant — drop it.
+    // ODBC call surface on the Unicode-app path the rest of the library is using.
     SQLRETURN returnCode =
         SQLColAttributeW(stmt, column, SQL_DESC_TYPE, nullptr, 0, nullptr, &columnType);
     if (!SQL_SUCCEEDED(returnCode))

--- a/src/Lightweight/DataBinder/UnicodeConverter.hpp
+++ b/src/Lightweight/DataBinder/UnicodeConverter.hpp
@@ -279,13 +279,27 @@ template <typename T = std::u32string>
 T ToUtf32(std::u16string_view u16InputString)
 {
     auto result = T {};
+    result.reserve(u16InputString.size());
 
-    for (char16_t const c16: u16InputString)
+    for (size_t i = 0; i < u16InputString.size(); ++i)
     {
-        if (c16 < 0xD800 || c16 >= 0xDC00)
-            result.push_back(static_cast<char32_t>(c16));
+        auto const c16 = u16InputString[i];
+        if (c16 >= 0xD800 && c16 <= 0xDBFF && i + 1 < u16InputString.size() && u16InputString[i + 1] >= 0xDC00
+            && u16InputString[i + 1] <= 0xDFFF)
+        {
+            auto const high = static_cast<char32_t>(c16 - 0xD800);
+            auto const low = static_cast<char32_t>(u16InputString[++i] - 0xDC00);
+            result.push_back(static_cast<char32_t>(0x10000 + (high << 10) + low));
+        }
+        else if (c16 >= 0xD800 && c16 <= 0xDFFF)
+        {
+            // Orphan surrogate (high without low, or stray low) — emit replacement.
+            result.push_back(detail::Utf32Converter::InvalidCodePoint);
+        }
         else
-            result.push_back(static_cast<char32_t>(0x10000 + ((c16 & 0x3FF) | ((c16 & 0x3FF) << 10))));
+        {
+            result.push_back(static_cast<char32_t>(c16));
+        }
     }
 
     return result;

--- a/src/Lightweight/SqlConnection.cpp
+++ b/src/Lightweight/SqlConnection.cpp
@@ -7,6 +7,7 @@
 #include "SqlQueryFormatter.hpp"
 #include "SqlStatement.hpp"
 
+#include <algorithm>
 #include <array>
 #include <mutex>
 
@@ -175,10 +176,22 @@ bool SqlConnection::Connect(SqlConnectionDataSource const& info) noexcept
     // Convert the three input strings to UTF-16 once, *outside* the scoped lock,
     // so the W-variant `SQLConnectW` call below sees properly-decoded Unicode and
     // marks this DBC handle as a Unicode application — which in turn flips the
-    // psqlODBC driver out of its ANSI / cp1252 mode.
-    auto wDataSource = detail::OdbcWideArg { info.datasource };
-    auto wUsername = detail::OdbcWideArg { info.username };
-    auto wPassword = detail::OdbcWideArg { info.password };
+    // psqlODBC driver out of its ANSI / cp1252 mode. The try/catch defends the
+    // noexcept contract: OdbcWideArg allocates a std::u16string and can throw
+    // std::bad_alloc, which would otherwise call std::terminate.
+    detail::OdbcWideArg wDataSource { std::string_view {} };
+    detail::OdbcWideArg wUsername { std::string_view {} };
+    detail::OdbcWideArg wPassword { std::string_view {} };
+    try
+    {
+        wDataSource = detail::OdbcWideArg { info.datasource };
+        wUsername = detail::OdbcWideArg { info.username };
+        wPassword = detail::OdbcWideArg { info.password };
+    }
+    catch (...)
+    {
+        return false;
+    }
 
     SQLRETURN sqlReturn {};
     {
@@ -239,8 +252,18 @@ bool SqlConnection::Connect(SqlConnectionString sqlConnectionString) noexcept
     // the W-variant `SQLDriverConnectW` call below puts this DBC handle into Unicode-app
     // mode for the rest of its lifetime. Without this, psqlODBC on Windows drops into
     // ANSI mode and runs every SQL_C_CHAR / SQL_C_WCHAR payload through the system
-    // codepage, which mangles UTF-8 bytes ≥ 0x80 and UTF-16 surrogate pairs.
-    auto wConnectionString = detail::OdbcWideArg { m_data->connectionString.value };
+    // codepage, which mangles UTF-8 bytes ≥ 0x80 and UTF-16 surrogate pairs. The
+    // try/catch defends the noexcept contract against std::bad_alloc from the UTF-16
+    // allocation.
+    detail::OdbcWideArg wConnectionString { std::string_view {} };
+    try
+    {
+        wConnectionString = detail::OdbcWideArg { m_data->connectionString.value };
+    }
+    catch (...)
+    {
+        return false;
+    }
 
     SQLRETURN sqlResult {};
     {

--- a/src/Lightweight/SqlConnection.cpp
+++ b/src/Lightweight/SqlConnection.cpp
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include "DataBinder/UnicodeConverter.hpp"
 #include "SqlConnection.hpp"
+#include "SqlOdbcWide.hpp"
 #include "SqlQuery.hpp"
 #include "SqlQueryFormatter.hpp"
 #include "SqlStatement.hpp"
 
+#include <array>
 #include <mutex>
 
 #include <sql.h>
@@ -19,6 +22,28 @@ static SqlConnectionString gDefaultConnectionString {};
 static std::atomic<uint64_t> gNextConnectionId { 1 };
 static std::function<void(SqlConnection&)> gPostConnectedHook {};
 static std::mutex gConnectionMutex {};
+
+namespace
+{
+
+/// @brief Reads a string-typed `SQLGetInfoW` value into a UTF-8 `std::string`. The
+/// W variant returns the buffer length in **bytes** (not characters) per the ODBC
+/// spec — divide by `sizeof(SQLWCHAR)` to recover the character count.
+std::string GetInfoStringW(SQLHDBC hDbc, SQLUSMALLINT infoType)
+{
+    std::array<SQLWCHAR, 256> buffer {};
+    SQLSMALLINT byteLen {};
+    auto const sqlResult = SQLGetInfoW(hDbc, infoType, buffer.data(), sizeof(buffer), &byteLen);
+    if (!SQL_SUCCEEDED(sqlResult) || byteLen <= 0)
+        return {};
+    auto const charCount =
+        std::min(static_cast<size_t>(byteLen) / sizeof(SQLWCHAR), buffer.size() - 1);
+    auto const utf8 =
+        ToUtf8(std::u16string_view { reinterpret_cast<char16_t const*>(buffer.data()), charCount });
+    return std::string { reinterpret_cast<char const*>(utf8.data()), utf8.size() };
+}
+
+} // namespace
 
 // =====================================================================================================================
 
@@ -147,6 +172,14 @@ bool SqlConnection::Connect(SqlConnectionDataSource const& info) noexcept
     if (m_hDbc)
         SQLDisconnect(m_hDbc);
 
+    // Convert the three input strings to UTF-16 once, *outside* the scoped lock,
+    // so the W-variant `SQLConnectW` call below sees properly-decoded Unicode and
+    // marks this DBC handle as a Unicode application — which in turn flips the
+    // psqlODBC driver out of its ANSI / cp1252 mode.
+    auto wDataSource = detail::OdbcWideArg { info.datasource };
+    auto wUsername = detail::OdbcWideArg { info.username };
+    auto wPassword = detail::OdbcWideArg { info.password };
+
     SQLRETURN sqlReturn {};
     {
         // Serialize ODBC connection establishment to prevent data races in the ODBC driver
@@ -154,20 +187,20 @@ bool SqlConnection::Connect(SqlConnectionDataSource const& info) noexcept
         std::scoped_lock const lock(gConnectionMutex);
 
         // NOLINTNEXTLINE(performance-no-int-to-ptr)
-        sqlReturn = SQLSetConnectAttrA(m_hDbc, SQL_LOGIN_TIMEOUT, (SQLPOINTER) info.timeout.count(), 0);
+        sqlReturn = SQLSetConnectAttrW(m_hDbc, SQL_LOGIN_TIMEOUT, (SQLPOINTER) info.timeout.count(), 0);
         if (!SQL_SUCCEEDED(sqlReturn))
         {
             SqlLogger::GetLogger().OnError(LastError());
             return false;
         }
 
-        sqlReturn = SQLConnectA(m_hDbc,
-                                (SQLCHAR*) info.datasource.data(),
-                                (SQLSMALLINT) info.datasource.size(),
-                                (SQLCHAR*) info.username.data(),
-                                (SQLSMALLINT) info.username.size(),
-                                (SQLCHAR*) info.password.data(),
-                                (SQLSMALLINT) info.password.size());
+        sqlReturn = SQLConnectW(m_hDbc,
+                                wDataSource.data(),
+                                wDataSource.length(),
+                                wUsername.data(),
+                                wUsername.length(),
+                                wPassword.data(),
+                                wPassword.length());
     }
     if (!SQL_SUCCEEDED(sqlReturn))
     {
@@ -175,7 +208,7 @@ bool SqlConnection::Connect(SqlConnectionDataSource const& info) noexcept
         return false;
     }
 
-    sqlReturn = SQLSetConnectAttrA(m_hDbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER) SQL_AUTOCOMMIT_ON, SQL_IS_UINTEGER);
+    sqlReturn = SQLSetConnectAttrW(m_hDbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER) SQL_AUTOCOMMIT_ON, SQL_IS_UINTEGER);
     if (!SQL_SUCCEEDED(sqlReturn))
     {
         SqlLogger::GetLogger().OnError(LastError());
@@ -202,17 +235,22 @@ bool SqlConnection::Connect(SqlConnectionString sqlConnectionString) noexcept
 
     m_data->connectionString = std::move(sqlConnectionString);
 
-    auto const& connectionString = m_data->connectionString.value;
+    // Convert the connection string from UTF-8 to UTF-16 *before* the scoped lock so
+    // the W-variant `SQLDriverConnectW` call below puts this DBC handle into Unicode-app
+    // mode for the rest of its lifetime. Without this, psqlODBC on Windows drops into
+    // ANSI mode and runs every SQL_C_CHAR / SQL_C_WCHAR payload through the system
+    // codepage, which mangles UTF-8 bytes ≥ 0x80 and UTF-16 surrogate pairs.
+    auto wConnectionString = detail::OdbcWideArg { m_data->connectionString.value };
 
     SQLRETURN sqlResult {};
     {
         // Serialize ODBC connection establishment to prevent data races in the ODBC driver
         // and OpenSSL during concurrent TLS handshakes (detected by ThreadSanitizer).
         std::scoped_lock const lock(gConnectionMutex);
-        sqlResult = SQLDriverConnectA(m_hDbc,
+        sqlResult = SQLDriverConnectW(m_hDbc,
                                       (SQLHWND) nullptr,
-                                      (SQLCHAR*) connectionString.data(),
-                                      (SQLSMALLINT) connectionString.size(),
+                                      wConnectionString.data(),
+                                      wConnectionString.length(),
                                       nullptr,
                                       0,
                                       nullptr,
@@ -221,7 +259,7 @@ bool SqlConnection::Connect(SqlConnectionString sqlConnectionString) noexcept
     if (!SQL_SUCCEEDED(sqlResult))
         return false;
 
-    sqlResult = SQLSetConnectAttrA(m_hDbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER) SQL_AUTOCOMMIT_ON, SQL_IS_UINTEGER);
+    sqlResult = SQLSetConnectAttrW(m_hDbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER) SQL_AUTOCOMMIT_ON, SQL_IS_UINTEGER);
     if (!SQL_SUCCEEDED(sqlResult))
         return false;
 
@@ -256,14 +294,7 @@ void SqlConnection::PostConnect()
     m_queryFormatter = SqlQueryFormatter::Get(m_serverType);
 
     // Get the driver name from the connection handle.
-    {
-        SQLCHAR driverName[128] {};
-        SQLSMALLINT driverNameLen = 0;
-
-        if (auto ret = SQLGetInfo(m_hDbc, SQL_DRIVER_NAME, driverName, sizeof(driverName), &driverNameLen);
-            SQL_SUCCEEDED(ret))
-            m_driverName = std::string(reinterpret_cast<char const*>(driverName), static_cast<size_t>(driverNameLen));
-    }
+    m_driverName = GetInfoStringW(m_hDbc, SQL_DRIVER_NAME);
 
     if (m_serverType == SqlServerType::SQLITE)
     {
@@ -310,44 +341,28 @@ void SqlConnection::Close() noexcept
 
 std::string SqlConnection::DatabaseName() const
 {
-    std::string name(128, '\0');
-    SQLSMALLINT nameLen {};
-    RequireSuccess(SQLGetInfoA(m_hDbc, SQL_DATABASE_NAME, name.data(), (SQLSMALLINT) name.size(), &nameLen));
-    name.resize(static_cast<size_t>(nameLen));
-    return name;
+    return GetInfoStringW(m_hDbc, SQL_DATABASE_NAME);
 }
 
 std::string SqlConnection::UserName() const
 {
-    std::string name(128, '\0');
-    SQLSMALLINT nameLen {};
-    RequireSuccess(SQLGetInfoA(m_hDbc, SQL_USER_NAME, name.data(), (SQLSMALLINT) name.size(), &nameLen));
-    name.resize(static_cast<size_t>(nameLen));
-    return name;
+    return GetInfoStringW(m_hDbc, SQL_USER_NAME);
 }
 
 std::string SqlConnection::ServerName() const
 {
-    std::string name(128, '\0');
-    SQLSMALLINT nameLen {};
-    RequireSuccess(SQLGetInfoA(m_hDbc, SQL_DBMS_NAME, (SQLPOINTER) name.data(), (SQLSMALLINT) name.size(), &nameLen));
-    name.resize(static_cast<size_t>(nameLen));
-    return name;
+    return GetInfoStringW(m_hDbc, SQL_DBMS_NAME);
 }
 
 std::string SqlConnection::ServerVersion() const
 {
-    std::string text(128, '\0');
-    SQLSMALLINT textLen {};
-    RequireSuccess(SQLGetInfoA(m_hDbc, SQL_DBMS_VER, (SQLPOINTER) text.data(), (SQLSMALLINT) text.size(), &textLen));
-    text.resize(static_cast<size_t>(textLen));
-    return text;
+    return GetInfoStringW(m_hDbc, SQL_DBMS_VER);
 }
 
 bool SqlConnection::TransactionActive() const noexcept
 {
     SQLUINTEGER state {};
-    SQLRETURN const sqlResult = SQLGetConnectAttrA(m_hDbc, SQL_ATTR_AUTOCOMMIT, &state, 0, nullptr);
+    SQLRETURN const sqlResult = SQLGetConnectAttrW(m_hDbc, SQL_ATTR_AUTOCOMMIT, &state, 0, nullptr);
     return sqlResult == SQL_SUCCESS && state == SQL_AUTOCOMMIT_OFF;
 }
 
@@ -355,14 +370,14 @@ bool SqlConnection::TransactionsAllowed() const noexcept
 {
     SQLUSMALLINT txn {};
     SQLSMALLINT t {};
-    SQLRETURN const rv = SQLGetInfo(m_hDbc, (SQLUSMALLINT) SQL_TXN_CAPABLE, &txn, sizeof(txn), &t);
+    SQLRETURN const rv = SQLGetInfoW(m_hDbc, (SQLUSMALLINT) SQL_TXN_CAPABLE, &txn, sizeof(txn), &t);
     return rv == SQL_SUCCESS && txn != SQL_TC_NONE;
 }
 
 bool SqlConnection::IsAlive() const noexcept
 {
     SQLUINTEGER state {};
-    SQLRETURN const sqlResult = SQLGetConnectAttrA(m_hDbc, SQL_ATTR_CONNECTION_DEAD, &state, 0, nullptr);
+    SQLRETURN const sqlResult = SQLGetConnectAttrW(m_hDbc, SQL_ATTR_CONNECTION_DEAD, &state, 0, nullptr);
     return SQL_SUCCEEDED(sqlResult) && state == SQL_CD_FALSE;
 }
 

--- a/src/Lightweight/SqlError.cpp
+++ b/src/Lightweight/SqlError.cpp
@@ -5,6 +5,7 @@
 #include "SqlLogger.hpp"
 #include "SqlOdbcWide.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cstring>
 

--- a/src/Lightweight/SqlError.cpp
+++ b/src/Lightweight/SqlError.cpp
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include "DataBinder/UnicodeConverter.hpp"
 #include "SqlError.hpp"
 #include "SqlLogger.hpp"
+#include "SqlOdbcWide.hpp"
+
+#include <array>
+#include <cstring>
 
 namespace Lightweight
 {
@@ -20,6 +25,48 @@ void SqlErrorInfo::RequireStatementSuccess(SQLRETURN result, SQLHSTMT hStmt, std
         return;
 
     throw std::runtime_error { std::format("{}: {}", message, FromStatementHandle(hStmt)) };
+}
+
+// Collect ODBC diagnostics via the wide-character variant. Calling SQLGetDiagRecW (rather
+// than the A variant) keeps us on the Unicode path the rest of the library uses, so
+// driver-side diagnostic text containing non-ASCII characters round-trips without going
+// through the system ANSI codepage. This function is on the failure path itself and must
+// never throw — encoding errors degrade to a best-effort lossy conversion.
+SqlErrorInfo SqlErrorInfo::FromHandle(SQLSMALLINT handleType, SQLHANDLE handle)
+{
+    SqlErrorInfo info {};
+
+    constexpr SQLSMALLINT SqlStateLen = 6;       // 5 SQLSTATE chars + NUL
+    constexpr SQLSMALLINT MessageBufferLen = 1024;
+    std::array<SQLWCHAR, SqlStateLen> sqlStateBuffer {};
+    std::array<SQLWCHAR, MessageBufferLen> messageBuffer {};
+    SQLSMALLINT msgLen {};
+
+    auto const rc = SQLGetDiagRecW(handleType,
+                                   handle,
+                                   1,
+                                   sqlStateBuffer.data(),
+                                   &info.nativeErrorCode,
+                                   messageBuffer.data(),
+                                   MessageBufferLen,
+                                   &msgLen);
+    if (!SQL_SUCCEEDED(rc))
+        return info;
+
+    // The SQLWCHAR ↔ char16_t layout invariant lives in SqlOdbcWide.hpp; the buffers
+    // we just filled are reinterpretable as char16_t under that same assumption.
+    auto const sqlStateChars = static_cast<size_t>(SqlStateLen - 1); // SQLSTATE is exactly 5 chars
+    auto const sqlStateUtf8 = ToUtf8(std::u16string_view {
+        reinterpret_cast<char16_t const*>(sqlStateBuffer.data()), sqlStateChars });
+    info.sqlState.assign(reinterpret_cast<char const*>(sqlStateUtf8.data()), sqlStateUtf8.size());
+
+    auto const messageChars =
+        msgLen > 0 ? std::min(static_cast<SQLSMALLINT>(MessageBufferLen - 1), msgLen) : SQLSMALLINT { 0 };
+    auto const messageUtf8 = ToUtf8(std::u16string_view {
+        reinterpret_cast<char16_t const*>(messageBuffer.data()), static_cast<size_t>(messageChars) });
+    info.message.assign(reinterpret_cast<char const*>(messageUtf8.data()), messageUtf8.size());
+
+    return info;
 }
 
 } // namespace Lightweight

--- a/src/Lightweight/SqlError.hpp
+++ b/src/Lightweight/SqlError.hpp
@@ -60,23 +60,7 @@ struct SqlErrorInfo
     static void RequireStatementSuccess(SQLRETURN result, SQLHSTMT hStmt, std::string_view message);
 
   private:
-    static SqlErrorInfo FromHandle(SQLSMALLINT handleType, SQLHANDLE handle)
-    {
-        SqlErrorInfo info {};
-        info.message = std::string(1024, '\0');
-
-        SQLSMALLINT msgLen {};
-        SQLGetDiagRecA(handleType,
-                       handle,
-                       1,
-                       (SQLCHAR*) info.sqlState.data(),
-                       &info.nativeErrorCode,
-                       (SQLCHAR*) info.message.data(),
-                       (SQLSMALLINT) info.message.capacity(),
-                       &msgLen);
-        info.message.resize(static_cast<size_t>(msgLen));
-        return info;
-    }
+    LIGHTWEIGHT_API static SqlErrorInfo FromHandle(SQLSMALLINT handleType, SQLHANDLE handle);
 };
 
 class SqlException: public std::runtime_error

--- a/src/Lightweight/SqlOdbcWide.hpp
+++ b/src/Lightweight/SqlOdbcWide.hpp
@@ -20,9 +20,9 @@ static_assert(sizeof(SQLWCHAR) == sizeof(char16_t),
               "ODBC W variants require a 16-bit code unit; SQLWCHAR shape mismatch");
 
 /// @brief Converts a UTF-8 string view into a `std::u16string` for ODBC W variants.
-/// Distinct from `ToUtf16(std::string const&)` in `UnicodeConverter.hpp`, which on
-/// Windows interprets its input as the system ANSI codepage (CP_ACP) — the very
-/// trap this whole switch to W variants exists to side-step.
+/// Use this rather than `ToUtf16(std::string const&)` from `UnicodeConverter.hpp`:
+/// that overload treats its input as the platform narrow encoding (CP_ACP on
+/// Windows), which silently corrupts UTF-8 bytes >= 0x80.
 inline std::u16string OdbcUtf8ToUtf16(std::string_view utf8)
 {
     return ToUtf16(std::u8string_view { reinterpret_cast<char8_t const*>(utf8.data()), utf8.size() });

--- a/src/Lightweight/SqlOdbcWide.hpp
+++ b/src/Lightweight/SqlOdbcWide.hpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "DataBinder/UnicodeConverter.hpp"
+
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <sql.h>
+
+namespace Lightweight::detail
+{
+
+// ODBC W variants assume `SQLWCHAR` is layout-compatible with `char16_t` (true on
+// Windows where it's `wchar_t`, and on Linux unixODBC where it's `unsigned short` —
+// both 16-bit). Anything else and the reinterpret_casts below would silently corrupt.
+static_assert(sizeof(SQLWCHAR) == sizeof(char16_t),
+              "ODBC W variants require a 16-bit code unit; SQLWCHAR shape mismatch");
+
+/// @brief Converts a UTF-8 string view into a `std::u16string` for ODBC W variants.
+/// Distinct from `ToUtf16(std::string const&)` in `UnicodeConverter.hpp`, which on
+/// Windows interprets its input as the system ANSI codepage (CP_ACP) — the very
+/// trap this whole switch to W variants exists to side-step.
+inline std::u16string OdbcUtf8ToUtf16(std::string_view utf8)
+{
+    return ToUtf16(std::u8string_view { reinterpret_cast<char8_t const*>(utf8.data()), utf8.size() });
+}
+
+/// @brief Reinterprets a `char16_t*` buffer as the `SQLWCHAR*` ODBC W variants want.
+/// Note: ODBC W input-string parameters are non-const (a legacy API quirk; the
+/// driver does not mutate them), so callers must hold their `std::u16string` non-const.
+inline SQLWCHAR* AsSqlWChar(char16_t* p) noexcept
+{
+    return reinterpret_cast<SQLWCHAR*>(p);
+}
+
+/// @brief Holds a UTF-16 buffer mapped from a UTF-8 input plus the (pointer, length)
+/// pair the ODBC W introspection / connect / prepare calls expect. Empty input
+/// produces a null pointer / zero length, mirroring the ODBC idiom of "pass nullptr
+/// when the caller does not want to filter on this field". The buffer's lifetime
+/// equals the `OdbcWideArg`'s, satisfying SQL_NTS for the duration of one call.
+struct OdbcWideArg
+{
+    std::u16string buffer;
+
+    explicit OdbcWideArg(std::string_view utf8):
+        buffer(utf8.empty() ? std::u16string {} : OdbcUtf8ToUtf16(utf8))
+    {
+    }
+
+    explicit OdbcWideArg(std::u16string utf16) noexcept:
+        buffer(std::move(utf16))
+    {
+    }
+
+    [[nodiscard]] SQLWCHAR* data() noexcept
+    {
+        return buffer.empty() ? nullptr : AsSqlWChar(buffer.data());
+    }
+
+    [[nodiscard]] SQLSMALLINT length() const noexcept
+    {
+        return static_cast<SQLSMALLINT>(buffer.size());
+    }
+};
+
+} // namespace Lightweight::detail

--- a/src/Lightweight/SqlSchema.cpp
+++ b/src/Lightweight/SqlSchema.cpp
@@ -2,6 +2,7 @@
 
 #include "SqlColumnTypeDefinitions.hpp"
 #include "SqlError.hpp"
+#include "SqlOdbcWide.hpp"
 #include "SqlSchema.hpp"
 #include "SqlStatement.hpp"
 
@@ -19,6 +20,8 @@ namespace Lightweight::SqlSchema
 
 using namespace std::string_literals;
 using namespace std::string_view_literals;
+
+using ::Lightweight::detail::OdbcWideArg;
 
 namespace
 {
@@ -46,16 +49,17 @@ namespace
 
     std::vector<TableWithSchema> AllTables(SqlStatement& stmt, std::string_view database, std::string_view schema)
     {
-
-        auto sqlResult = SQLTables(stmt.NativeHandle(),
-                                   (SQLCHAR*) (!database.empty() ? database.data() : nullptr),
-                                   (SQLSMALLINT) database.size(),
-                                   (SQLCHAR*) (!schema.empty() ? schema.data() : nullptr),
-                                   (SQLSMALLINT) schema.size(),
-                                   nullptr,
-                                   0,
-                                   nullptr,
-                                   0);
+        auto wDatabase = OdbcWideArg { database };
+        auto wSchema = OdbcWideArg { schema };
+        auto sqlResult = SQLTablesW(stmt.NativeHandle(),
+                                    wDatabase.data(),
+                                    wDatabase.length(),
+                                    wSchema.data(),
+                                    wSchema.length(),
+                                    nullptr,
+                                    0,
+                                    nullptr,
+                                    0);
         SqlErrorInfo::RequireStatementSuccess(sqlResult, stmt.NativeHandle(), "SQLTables");
 
         auto result = std::vector<TableWithSchema>();
@@ -86,25 +90,25 @@ namespace
                                                      FullyQualifiedTableName const& primaryKey,
                                                      FullyQualifiedTableName const& foreignKey)
     {
-        auto* pkCatalog = (SQLCHAR*) (!primaryKey.catalog.empty() ? primaryKey.catalog.c_str() : nullptr);
-        auto* pkSchema = (SQLCHAR*) (!primaryKey.schema.empty() ? primaryKey.schema.c_str() : nullptr);
-        auto* pkTable = (SQLCHAR*) (!primaryKey.table.empty() ? primaryKey.table.c_str() : nullptr);
-        auto* fkCatalog = (SQLCHAR*) (!foreignKey.catalog.empty() ? foreignKey.catalog.c_str() : nullptr);
-        auto* fkSchema = (SQLCHAR*) (!foreignKey.schema.empty() ? foreignKey.schema.c_str() : nullptr);
-        auto* fkTable = (SQLCHAR*) (!foreignKey.table.empty() ? foreignKey.table.c_str() : nullptr);
-        auto sqlResult = SQLForeignKeys(stmt.NativeHandle(),
-                                        pkCatalog,
-                                        (SQLSMALLINT) primaryKey.catalog.size(),
-                                        pkSchema,
-                                        (SQLSMALLINT) primaryKey.schema.size(),
-                                        pkTable,
-                                        (SQLSMALLINT) primaryKey.table.size(),
-                                        fkCatalog,
-                                        (SQLSMALLINT) foreignKey.catalog.size(),
-                                        fkSchema,
-                                        (SQLSMALLINT) foreignKey.schema.size(),
-                                        fkTable,
-                                        (SQLSMALLINT) foreignKey.table.size());
+        auto wPkCatalog = OdbcWideArg { primaryKey.catalog };
+        auto wPkSchema = OdbcWideArg { primaryKey.schema };
+        auto wPkTable = OdbcWideArg { primaryKey.table };
+        auto wFkCatalog = OdbcWideArg { foreignKey.catalog };
+        auto wFkSchema = OdbcWideArg { foreignKey.schema };
+        auto wFkTable = OdbcWideArg { foreignKey.table };
+        auto sqlResult = SQLForeignKeysW(stmt.NativeHandle(),
+                                         wPkCatalog.data(),
+                                         wPkCatalog.length(),
+                                         wPkSchema.data(),
+                                         wPkSchema.length(),
+                                         wPkTable.data(),
+                                         wPkTable.length(),
+                                         wFkCatalog.data(),
+                                         wFkCatalog.length(),
+                                         wFkSchema.data(),
+                                         wFkSchema.length(),
+                                         wFkTable.data(),
+                                         wFkTable.length());
 
         if (!SQL_SUCCEEDED(sqlResult))
             throw std::runtime_error(std::format("SQLForeignKeys failed: {}", stmt.LastError()));
@@ -193,17 +197,17 @@ namespace
 
             return sortedKeys;
         }
-        auto* pkCatalog = (SQLCHAR*) (!table.catalog.empty() ? table.catalog.c_str() : nullptr);
-        auto* pkSchema = (SQLCHAR*) (!table.schema.empty() ? table.schema.c_str() : nullptr);
-        auto* pkTable = (SQLCHAR*) (!table.table.empty() ? table.table.c_str() : nullptr);
+        auto wCatalog = OdbcWideArg { table.catalog };
+        auto wSchema = OdbcWideArg { table.schema };
+        auto wTable = OdbcWideArg { table.table };
 
-        auto sqlResult = SQLPrimaryKeys(stmt.NativeHandle(),
-                                        pkCatalog,
-                                        (SQLSMALLINT) table.catalog.size(),
-                                        pkSchema,
-                                        (SQLSMALLINT) table.schema.size(),
-                                        pkTable,
-                                        (SQLSMALLINT) table.table.size());
+        auto sqlResult = SQLPrimaryKeysW(stmt.NativeHandle(),
+                                         wCatalog.data(),
+                                         wCatalog.length(),
+                                         wSchema.data(),
+                                         wSchema.length(),
+                                         wTable.data(),
+                                         wTable.length());
         if (!SQL_SUCCEEDED(sqlResult))
             throw std::runtime_error(std::format("SQLPrimaryKeys failed: {}", stmt.LastError()));
 
@@ -230,19 +234,19 @@ namespace
 
     std::vector<std::string> AllUniqueColumns(SqlStatement& stmt, FullyQualifiedTableName const& table)
     {
-        auto* pkCatalog = (SQLCHAR*) (!table.catalog.empty() ? table.catalog.c_str() : nullptr);
-        auto* pkSchema = (SQLCHAR*) (!table.schema.empty() ? table.schema.c_str() : nullptr);
-        auto* pkTable = (SQLCHAR*) (!table.table.empty() ? table.table.c_str() : nullptr);
+        auto wCatalog = OdbcWideArg { table.catalog };
+        auto wSchema = OdbcWideArg { table.schema };
+        auto wTable = OdbcWideArg { table.table };
 
-        auto sqlResult = SQLStatistics(stmt.NativeHandle(),
-                                       pkCatalog,
-                                       (SQLSMALLINT) table.catalog.size(),
-                                       pkSchema,
-                                       (SQLSMALLINT) table.schema.size(),
-                                       pkTable,
-                                       (SQLSMALLINT) table.table.size(),
-                                       SQL_INDEX_UNIQUE,
-                                       SQL_ENSURE);
+        auto sqlResult = SQLStatisticsW(stmt.NativeHandle(),
+                                        wCatalog.data(),
+                                        wCatalog.length(),
+                                        wSchema.data(),
+                                        wSchema.length(),
+                                        wTable.data(),
+                                        wTable.length(),
+                                        SQL_INDEX_UNIQUE,
+                                        SQL_ENSURE);
 
         if (!SQL_SUCCEEDED(sqlResult))
             return {}; // Ignore errors or throw? Safest to ignore for now as some drivers might not support it fully.
@@ -292,20 +296,20 @@ namespace
             // Use a separate statement to avoid issues with pending cursors from previous operations
             auto indexStmt = SqlStatement { stmt.Connection() };
 
-            auto* pkCatalog = (SQLCHAR*) (!table.catalog.empty() ? table.catalog.c_str() : nullptr);
-            auto* pkSchema = (SQLCHAR*) (!table.schema.empty() ? table.schema.c_str() : nullptr);
-            auto* pkTable = (SQLCHAR*) (!table.table.empty() ? table.table.c_str() : nullptr);
+            auto wCatalog = OdbcWideArg { table.catalog };
+            auto wSchema = OdbcWideArg { table.schema };
+            auto wTable = OdbcWideArg { table.table };
 
             // Use SQL_INDEX_ALL to retrieve all index types
-            auto sqlResult = SQLStatistics(indexStmt.NativeHandle(),
-                                           pkCatalog,
-                                           (SQLSMALLINT) table.catalog.size(),
-                                           pkSchema,
-                                           (SQLSMALLINT) table.schema.size(),
-                                           pkTable,
-                                           (SQLSMALLINT) table.table.size(),
-                                           SQL_INDEX_ALL,
-                                           SQL_ENSURE);
+            auto sqlResult = SQLStatisticsW(indexStmt.NativeHandle(),
+                                            wCatalog.data(),
+                                            wCatalog.length(),
+                                            wSchema.data(),
+                                            wSchema.length(),
+                                            wTable.data(),
+                                            wTable.length(),
+                                            SQL_INDEX_ALL,
+                                            SQL_ENSURE);
 
             if (!SQL_SUCCEEDED(sqlResult))
                 return {};
@@ -495,15 +499,18 @@ void ReadAllTables(SqlStatement& stmt, std::string_view database, std::string_vi
         eventHandler.OnIndexes(indexes);
 
         auto columnStmt = SqlStatement { stmt.Connection() };
-        auto const sqlResult = SQLColumns(columnStmt.NativeHandle(),
-                                          (SQLCHAR*) database.data(),
-                                          (SQLSMALLINT) database.size(),
-                                          (SQLCHAR*) (!tableSchema.empty() ? tableSchema.data() : nullptr),
-                                          (SQLSMALLINT) tableSchema.size(),
-                                          (SQLCHAR*) tableName.data(),
-                                          (SQLSMALLINT) tableName.size(),
-                                          nullptr /* column name */,
-                                          0 /* column name length */);
+        auto wDatabase = OdbcWideArg { database };
+        auto wTableSchema = OdbcWideArg { tableSchema };
+        auto wTableName = OdbcWideArg { tableName };
+        auto const sqlResult = SQLColumnsW(columnStmt.NativeHandle(),
+                                           wDatabase.data(),
+                                           wDatabase.length(),
+                                           wTableSchema.data(),
+                                           wTableSchema.length(),
+                                           wTableName.data(),
+                                           wTableName.length(),
+                                           nullptr /* column name */,
+                                           0 /* column name length */);
         if (!SQL_SUCCEEDED(sqlResult))
             throw std::runtime_error(std::format("SQLColumns failed: {}", columnStmt.LastError()));
 

--- a/src/Lightweight/SqlScopedTraceLogger.hpp
+++ b/src/Lightweight/SqlScopedTraceLogger.hpp
@@ -4,6 +4,7 @@
 
 #include "Api.hpp"
 #include "SqlConnection.hpp"
+#include "SqlOdbcWide.hpp"
 #include "SqlStatement.hpp"
 
 #include <filesystem>
@@ -49,8 +50,14 @@ class LIGHTWEIGHT_API SqlScopedTraceLogger
     explicit SqlScopedTraceLogger(SQLHDBC hDbc, std::filesystem::path const& logFile):
         m_nativeConnection { hDbc }
     {
-        SQLSetConnectAttrA(m_nativeConnection, SQL_ATTR_TRACEFILE, (SQLPOINTER) logFile.string().c_str(), SQL_NTS);
-        SQLSetConnectAttrA(m_nativeConnection, SQL_ATTR_TRACE, (SQLPOINTER) SQL_OPT_TRACE_ON, SQL_IS_UINTEGER);
+        // Stay on the W path: the rest of the library puts the DBC handle into Unicode-app
+        // mode at connect time, so passing an ANSI trace-file name here would mix variants
+        // unnecessarily. `path::u16string()` does the platform-correct conversion (UTF-16
+        // is path's native form on Windows; UTF-8 → UTF-16 on POSIX).
+        auto wLogFile = logFile.u16string();
+        SQLSetConnectAttrW(
+            m_nativeConnection, SQL_ATTR_TRACEFILE, detail::AsSqlWChar(wLogFile.data()), SQL_NTS);
+        SQLSetConnectAttrW(m_nativeConnection, SQL_ATTR_TRACE, (SQLPOINTER) SQL_OPT_TRACE_ON, SQL_IS_UINTEGER);
     }
 
     SqlScopedTraceLogger(SqlScopedTraceLogger&&) = delete;
@@ -60,7 +67,7 @@ class LIGHTWEIGHT_API SqlScopedTraceLogger
 
     ~SqlScopedTraceLogger()
     {
-        SQLSetConnectAttrA(m_nativeConnection, SQL_ATTR_TRACE, (SQLPOINTER) SQL_OPT_TRACE_OFF, SQL_IS_UINTEGER);
+        SQLSetConnectAttrW(m_nativeConnection, SQL_ATTR_TRACE, (SQLPOINTER) SQL_OPT_TRACE_OFF, SQL_IS_UINTEGER);
     }
 };
 

--- a/src/Lightweight/SqlStatement.cpp
+++ b/src/Lightweight/SqlStatement.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "DataBinder/SqlRawColumn.hpp"
+#include "SqlOdbcWide.hpp"
 #include "SqlQuery.hpp"
 #include "SqlStatement.hpp"
 #include "Utils.hpp"
@@ -183,8 +184,14 @@ void SqlStatement::Prepare(std::string_view query) &
     // Unbinds the columns, if any
     RequireSuccess(SQLFreeStmt(m_hStmt, SQL_UNBIND));
 
-    // Prepares the statement
-    RequireSuccess(SQLPrepareA(m_hStmt, (SQLCHAR*) query.data(), (SQLINTEGER) query.size()));
+    // Prepares the statement on the W (Unicode) entry point so the ODBC driver stays
+    // on the same Unicode-app track that SQLDriverConnectW set up. Mixing A and W
+    // calls on the same handle works in theory (the Driver Manager auto-translates),
+    // but psqlODBC has historically treated SQL_C_CHAR parameter binds differently
+    // depending on the variant of the most recent statement-text call — so we keep
+    // the path uniformly W to side-step that.
+    auto wQuery = detail::OdbcWideArg { query };
+    RequireSuccess(SQLPrepareW(m_hStmt, wQuery.data(), static_cast<SQLINTEGER>(wQuery.buffer.size())));
     RequireSuccess(SQLNumParams(m_hStmt, &m_expectedParameterCount));
     m_data->indicators.resize(static_cast<size_t>(m_expectedParameterCount) + 1);
 }
@@ -204,7 +211,9 @@ SqlResultCursor SqlStatement::ExecuteDirect(std::string_view const& query, std::
 
     SqlLogger::GetLogger().OnExecuteDirect(query);
 
-    RequireSuccess(SQLExecDirectA(m_hStmt, (SQLCHAR*) query.data(), (SQLINTEGER) query.size()), location);
+    // Execute via the W entry point — see the rationale above SQLPrepareW.
+    auto wQuery = detail::OdbcWideArg { query };
+    RequireSuccess(SQLExecDirectW(m_hStmt, wQuery.data(), static_cast<SQLINTEGER>(wQuery.buffer.size())), location);
     return SqlResultCursor { *this };
 }
 

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -1324,4 +1324,188 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlWideString read from VARCHAR column", "[Sql
     }
 }
 
+// Pins the regression that motivated the SQLDriverConnectW switch: psqlODBC on
+// Windows used to put DBC handles opened with SQLDriverConnectA into ANSI mode and
+// run every SQL_C_CHAR payload through cp1252, which mangled UTF-8 input bytes ≥ 0x80
+// (`Hellö` came back as `HellÃ¶`) and dropped UTF-16 surrogate pairs (emoji came back
+// as `??`). The fix is the entire `[Lightweight] {SqlConnection,SqlStatement,
+// SqlSchema} ... via W variants` series of commits plus the BasicStringBinder cleanup;
+// these tests run on every backend so a future regression on any one of them surfaces.
+TEST_CASE_METHOD(SqlTestFixture, "Unicode round-trip across binders", "[SqlDataBinder][Unicode]")
+{
+    auto stmt = SqlStatement {};
+    stmt.MigrateDirect([](SqlMigrationQueryBuilder& migration) {
+        migration.CreateTable("UnicodeRoundTrip").Column("value", SqlColumnTypeDefinitions::NVarchar { 64 });
+    });
+
+    SECTION("std::u8string with single non-ASCII char")
+    {
+        // Was: u8"Hellö" round-tripped as `HellÃ¶` on PostgreSQL/Windows because the
+        // pre-fix PG hatch in BasicStringBinder bound the UTF-8 bytes as SQL_C_CHAR.
+        stmt.Prepare(stmt.Query("UnicodeRoundTrip").Insert().Set("value", SqlWildcard));
+        std::ignore = stmt.Execute(u8"Hellö"s);
+        stmt.Prepare(stmt.Query("UnicodeRoundTrip").Select().Field("value").All());
+        auto reader = stmt.Execute();
+        REQUIRE(reader.FetchRow());
+        CHECK(reader.GetColumn<std::u8string>(1) == u8"Hellö"s);
+    }
+
+    SECTION("std::u16string with supplementary-plane emoji")
+    {
+        // Was: u"Unicode \U0001F601" came back as `Unicode ??` on PostgreSQL/Windows
+        // because the surrogate pair could not be encoded as cp1252.
+        stmt.Prepare(stmt.Query("UnicodeRoundTrip").Insert().Set("value", SqlWildcard));
+        std::ignore = stmt.Execute(u"\U0001F601"s);
+        stmt.Prepare(stmt.Query("UnicodeRoundTrip").Select().Field("value").All());
+        auto reader = stmt.Execute();
+        REQUIRE(reader.FetchRow());
+        CHECK(reader.GetColumn<std::u16string>(1) == u"\U0001F601"s);
+    }
+
+    SECTION("mixed BMP + supplementary-plane via std::u16string")
+    {
+        // Tests that surrogate pairs sandwiched between BMP characters round-trip
+        // intact — i.e. the driver doesn't truncate / re-encode at the boundary.
+        stmt.Prepare(stmt.Query("UnicodeRoundTrip").Insert().Set("value", SqlWildcard));
+        std::ignore = stmt.Execute(u"Hello \U0001F601 World"s);
+        stmt.Prepare(stmt.Query("UnicodeRoundTrip").Select().Field("value").All());
+        auto reader = stmt.Execute();
+        REQUIRE(reader.FetchRow());
+        CHECK(reader.GetColumn<std::u16string>(1) == u"Hello \U0001F601 World"s);
+    }
+
+    SECTION("BindOutputColumns with std::u8string")
+    {
+        stmt.Prepare(stmt.Query("UnicodeRoundTrip").Insert().Set("value", SqlWildcard));
+        std::ignore = stmt.Execute(u8"Hellö"s);
+        stmt.Prepare(stmt.Query("UnicodeRoundTrip").Select().Field("value").All());
+        auto reader = stmt.Execute();
+        std::u8string actual;
+        reader.BindOutputColumns(&actual);
+        REQUIRE(reader.FetchRow());
+        CHECK(actual == u8"Hellö"s);
+    }
+
+    SECTION("std::wstring with mixed BMP + supplementary-plane")
+    {
+        // Pins the wchar_t arm of the W-binder dispatch — on Windows std::wstring
+        // routes through the Utf16StringType specialization (sizeof(wchar_t) == 2),
+        // on Linux through the Utf32StringType specialization (sizeof(wchar_t) == 4).
+        // Both must round-trip surrogate-pair payloads intact.
+        stmt.Prepare(stmt.Query("UnicodeRoundTrip").Insert().Set("value", SqlWildcard));
+        std::ignore = stmt.Execute(L"Hello \U0001F601 World"s);
+        stmt.Prepare(stmt.Query("UnicodeRoundTrip").Select().Field("value").All());
+        auto reader = stmt.Execute();
+        REQUIRE(reader.FetchRow());
+        CHECK(reader.GetColumn<std::wstring>(1) == L"Hello \U0001F601 World"s);
+    }
+}
+
+// Coverage for the SQL_C_WCHAR truncation arithmetic in
+// detail::GetRawColumnArrayData (BasicStringBinder.hpp). The function has two
+// re-fetch branches: (a) the driver reports total length up front and we re-
+// fetch into a sized-up buffer, (b) the driver reports SQL_NO_TOTAL and we
+// loop, doubling the buffer until we hit success. Both branches must compute
+// BufferLength in bytes (= chars * sizeof(CharType)) — a miscount on the
+// SQL_C_WCHAR path corrupts supplementary-plane data because each surrogate
+// pair occupies two char16_t units.
+//
+// Branch (a) is what the drivers in our test matrix (psqlODBC, ODBC Driver 18
+// for SQL Server) actually take for streaming columns, so these tests pin the
+// arithmetic for that branch. Branch (b) is rare in practice but its byte/char
+// math was previously off by sizeof(CharType); the tests below also serve as
+// forward-looking coverage if a future driver routes here.
+//
+// The streaming column type — NVARCHAR(MAX) on SQL Server, TEXT on Postgres /
+// SQLite — plus payloads that overflow the 255-char initial buffer in
+// GetColumnUtf16 are what get us into the re-fetch path at all.
+TEST_CASE_METHOD(SqlTestFixture, "GetRawColumnArrayData: long Unicode round-trip", "[SqlDataBinder][Unicode]")
+{
+    auto stmt = SqlStatement {};
+    stmt.MigrateDirect([](SqlMigrationQueryBuilder& migration) {
+        migration.CreateTable("LongUnicode").Column("value", SqlColumnTypeDefinitions::NVarchar { 0 });
+    });
+
+    SECTION("4 KiB std::u16string ASCII forces the truncation path")
+    {
+        auto const expected = MakeLargeText<char16_t>(4 * 1024);
+        stmt.Prepare(stmt.Query("LongUnicode").Insert().Set("value", SqlWildcard));
+        std::ignore = stmt.Execute(expected);
+        stmt.Prepare(stmt.Query("LongUnicode").Select().Field("value").All());
+        auto reader = stmt.Execute();
+        REQUIRE(reader.FetchRow());
+        CHECK(reader.GetColumn<std::u16string>(1) == expected);
+    }
+
+    SECTION("3 KiB std::u16string with supplementary-plane characters throughout")
+    {
+        // Each iteration appends one BMP letter + one surrogate pair (3 char16_t).
+        // 1024 iterations = 3072 char16_t (~6 KiB) — well past the 255-char buffer.
+        // Any miscount in the byte/char arithmetic of the re-fetch path
+        // desynchronizes the surrogate-pair boundary in a visible way.
+        std::u16string expected;
+        expected.reserve(3 * 1024);
+        for ([[maybe_unused]] auto i: std::views::iota(0, 1024))
+            expected += u"A\U0001F601";
+        stmt.Prepare(stmt.Query("LongUnicode").Insert().Set("value", SqlWildcard));
+        std::ignore = stmt.Execute(expected);
+        stmt.Prepare(stmt.Query("LongUnicode").Select().Field("value").All());
+        auto reader = stmt.Execute();
+        REQUIRE(reader.FetchRow());
+        CHECK(reader.GetColumn<std::u16string>(1) == expected);
+    }
+
+    SECTION("supplementary-plane surrogate pair straddles the 255-char buffer boundary")
+    {
+        // The initial GetColumnUtf16 buffer is 255 char16_t. Place a high surrogate
+        // at index 254 and the low surrogate at index 255 to verify that the
+        // re-fetch (whichever branch fires) does not split the pair across calls.
+        std::u16string expected(254, u'A');
+        expected += u"\U0001F601"; // surrogate pair occupies indices 254..255
+        expected += MakeLargeText<char16_t>(1024);
+        stmt.Prepare(stmt.Query("LongUnicode").Insert().Set("value", SqlWildcard));
+        std::ignore = stmt.Execute(expected);
+        stmt.Prepare(stmt.Query("LongUnicode").Select().Field("value").All());
+        auto reader = stmt.Execute();
+        REQUIRE(reader.FetchRow());
+        CHECK(reader.GetColumn<std::u16string>(1) == expected);
+    }
+
+    SECTION("4 KiB std::u8string round-trip via GetColumnUtf16")
+    {
+        // SqlDataBinder<Utf8StringType>::GetColumn fetches into a u16 scratch via
+        // GetColumnUtf16, then converts to UTF-8 — so the same fix must hold for
+        // u8 callers reading large columns.
+        auto const expected = MakeLargeText<char8_t>(4 * 1024);
+        stmt.Prepare(stmt.Query("LongUnicode").Insert().Set("value", SqlWildcard));
+        std::ignore = stmt.Execute(expected);
+        stmt.Prepare(stmt.Query("LongUnicode").Select().Field("value").All());
+        auto reader = stmt.Execute();
+        REQUIRE(reader.FetchRow());
+        CHECK(reader.GetColumn<std::u8string>(1) == expected);
+    }
+
+    SECTION("4 KiB std::wstring round-trip")
+    {
+        auto const expected = MakeLargeText<wchar_t>(4 * 1024);
+        stmt.Prepare(stmt.Query("LongUnicode").Insert().Set("value", SqlWildcard));
+        std::ignore = stmt.Execute(expected);
+        stmt.Prepare(stmt.Query("LongUnicode").Select().Field("value").All());
+        auto reader = stmt.Execute();
+        REQUIRE(reader.FetchRow());
+        CHECK(reader.GetColumn<std::wstring>(1) == expected);
+    }
+
+    SECTION("empty std::u16string hits the SQL_SUCCESS path with zero indicator")
+    {
+        std::u16string const expected;
+        stmt.Prepare(stmt.Query("LongUnicode").Insert().Set("value", SqlWildcard));
+        std::ignore = stmt.Execute(expected);
+        stmt.Prepare(stmt.Query("LongUnicode").Select().Field("value").All());
+        auto reader = stmt.Execute();
+        REQUIRE(reader.FetchRow());
+        CHECK(reader.GetColumn<std::u16string>(1) == expected);
+    }
+}
+
 // NOLINTEND(readability-container-size-empty, bugprone-throwing-static-initialization, bugprone-unchecked-optional-access)

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -1401,6 +1401,59 @@ TEST_CASE_METHOD(SqlTestFixture, "Unicode round-trip across binders", "[SqlDataB
     }
 }
 
+struct UnicodeAcrossDynamicStringTypes
+{
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id {};
+    Field<SqlDynamicUtf16String<256>> stringUtf16 {};
+    Field<SqlDynamicUtf32String<256>> stringUtf32 {};
+    Field<SqlDynamicWideString<256>> stringWide {};
+};
+
+TEST_CASE_METHOD(SqlTestFixture,
+                 "Unicode round-trip across DataMapper dynamic string types",
+                 "[DataMapper][Unicode]")
+{
+    auto dm = DataMapper {};
+    dm.CreateTable<UnicodeAcrossDynamicStringTypes>();
+
+    UnicodeAcrossDynamicStringTypes record {};
+    record.stringUtf16 = std::u16string { u"Hello \U0001F601 World" };
+    record.stringUtf32 = std::u32string { U"Hello \U0001F601 World" };
+    record.stringWide = std::wstring { L"Hello \U0001F601 World" };
+    dm.Create(record);
+
+    auto const result = dm.QuerySingle<UnicodeAcrossDynamicStringTypes>(record.id);
+    REQUIRE(result.has_value());
+    CHECK(result->stringUtf16.Value() == record.stringUtf16.Value());
+    CHECK(result->stringUtf32.Value() == record.stringUtf32.Value());
+    CHECK(result->stringWide.Value() == record.stringWide.Value());
+}
+
+struct UnicodeTrimmedFixedRow
+{
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id {};
+    Field<SqlTrimmedFixedString<32>> stringNarrow {};
+    Field<SqlTrimmedWideFixedString<32>> stringWide {};
+};
+
+TEST_CASE_METHOD(SqlTestFixture,
+                 "Trimmed fixed strings strip trailing padding through DataMapper",
+                 "[DataMapper][Unicode]")
+{
+    auto dm = DataMapper {};
+    dm.CreateTable<UnicodeTrimmedFixedRow>();
+
+    UnicodeTrimmedFixedRow row {};
+    row.stringNarrow = "Hello";
+    row.stringWide = L"Hellö";
+    dm.Create(row);
+
+    auto const result = dm.QuerySingle<UnicodeTrimmedFixedRow>(row.id);
+    REQUIRE(result.has_value());
+    CHECK(result->stringNarrow == SqlTrimmedFixedString<32> { "Hello" });
+    CHECK(result->stringWide == SqlTrimmedWideFixedString<32> { L"Hellö" });
+}
+
 // Coverage for the SQL_C_WCHAR truncation arithmetic in
 // detail::GetRawColumnArrayData (BasicStringBinder.hpp). The function has two
 // re-fetch branches: (a) the driver reports total length up front and we re-

--- a/src/tests/Utils.hpp
+++ b/src/tests/Utils.hpp
@@ -4,9 +4,12 @@
 
 #if defined(_WIN32) || defined(_WIN64)
     #include <Windows.h>
+    #include <crtdbg.h>
+    #include <cstdlib>
 #endif
 
 #include <Lightweight/Lightweight.hpp>
+#include <Lightweight/SqlOdbcWide.hpp>
 
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -362,9 +365,29 @@ class SqlTestFixture
 
     using MainProgramArgs = std::tuple<int, char**>;
 
+    /// @brief Suppress modal Windows error dialogs that would otherwise block
+    /// unattended runs (CI, scripted/AI agents) on `abort()`, CRT debug asserts,
+    /// or Win32 critical errors. The diagnostic still reaches stderr; it just
+    /// does not pop a window that needs a human click.
+    static void SuppressBlockingErrorDialogs()
+    {
+#if defined(_WIN32) || defined(_WIN64)
+        _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+        SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+    #if !defined(NDEBUG)
+        for (auto const reportType: { _CRT_ASSERT, _CRT_ERROR, _CRT_WARN })
+        {
+            _CrtSetReportMode(reportType, _CRTDBG_MODE_FILE);
+            _CrtSetReportFile(reportType, _CRTDBG_FILE_STDERR);
+        }
+    #endif
+#endif
+    }
+
     // NOLINTNEXTLINE(readability-function-cognitive-complexity)
     static std::variant<MainProgramArgs, int> Initialize(int argc, char** argv)
     {
+        SuppressBlockingErrorDialogs();
         Lightweight::SqlLogger::SetLogger(TestSuiteSqlLogger::GetLogger());
 
         using namespace std::string_view_literals;
@@ -473,17 +496,28 @@ class SqlTestFixture
 
         Lightweight::SqlConnection::SetPostConnectedHook(&SqlTestFixture::PostConnectedHook);
 
-        auto sqlConnection = Lightweight::SqlConnection();
-        if (!sqlConnection.IsAlive())
+        try
         {
-            std::println("Failed to connect to the database: {}", sqlConnection.LastError());
-            std::abort();
-        }
+            auto sqlConnection = Lightweight::SqlConnection();
+            if (!sqlConnection.IsAlive())
+            {
+                std::println(stderr, "Failed to connect to the database: {}", sqlConnection.LastError());
+                return { EXIT_FAILURE };
+            }
 
-        std::println("Running test cases against: {} ({}) (identified as: {})",
-                     sqlConnection.ServerName(),
-                     sqlConnection.ServerVersion(),
-                     sqlConnection.ServerType());
+            std::println("Running test cases against: {} ({}) (identified as: {})",
+                         sqlConnection.ServerName(),
+                         sqlConnection.ServerVersion(),
+                         sqlConnection.ServerType());
+        }
+        catch (std::exception const& e)
+        {
+            // Catch here so an unhandled exception does not call std::terminate ->
+            // abort(), which on Windows can pop a modal "Abort/Retry/Ignore" dialog
+            // and break unattended runs (CI, scripted/AI agents).
+            std::println(stderr, "Failed to connect to the database: {}", e.what());
+            return { EXIT_FAILURE };
+        }
 
         return MainProgramArgs { argc - (i - 1), argv + (i - 1) };
     }
@@ -492,17 +526,18 @@ class SqlTestFixture
     {
         if (odbcTrace)
         {
-            auto const traceFile = []() -> std::string_view {
+            // Stay on the W path so we don't mix variants on a Unicode-mode handle. The
+            // file path here is ASCII so the conversion is trivial; we hold the buffer in
+            // a local std::u16string so SQL_NTS sees it NUL-terminated.
 #if !defined(_WIN32) && !defined(_WIN64)
-                return "/dev/stdout";
+            auto wTraceFile = std::u16string { u"/dev/stdout" };
 #else
-                return "CONOUT$";
+            auto wTraceFile = std::u16string { u"CONOUT$" };
 #endif
-            }();
-
             SQLHDBC handle = connection.NativeHandle();
-            SQLSetConnectAttrA(handle, SQL_ATTR_TRACEFILE, (SQLPOINTER) traceFile.data(), SQL_NTS);
-            SQLSetConnectAttrA(handle, SQL_ATTR_TRACE, (SQLPOINTER) SQL_OPT_TRACE_ON, SQL_IS_UINTEGER);
+            SQLSetConnectAttrW(
+                handle, SQL_ATTR_TRACEFILE, Lightweight::detail::AsSqlWChar(wTraceFile.data()), SQL_NTS);
+            SQLSetConnectAttrW(handle, SQL_ATTR_TRACE, (SQLPOINTER) SQL_OPT_TRACE_ON, SQL_IS_UINTEGER);
         }
 
         using Lightweight::SqlServerType;
@@ -528,10 +563,10 @@ class SqlTestFixture
         auto stmt = Lightweight::SqlStatement();
         REQUIRE(stmt.IsAlive());
 
-        char dbName[100]; // Buffer to store the database name
-        SQLSMALLINT dbNameLen {};
-        SQLGetInfo(stmt.Connection().NativeHandle(), SQL_DATABASE_NAME, dbName, sizeof(dbName), &dbNameLen);
-        if (dbNameLen > 0)
+        // SqlConnection already exposes a properly-decoded UTF-8 view of SQL_DATABASE_NAME
+        // via DatabaseName() (W variant + ToUtf8 conversion). Reuse it instead of issuing
+        // another raw SQLGetInfoA here, which would mix variants on the same handle.
+        if (auto const dbName = stmt.Connection().DatabaseName(); !dbName.empty())
             testDatabaseName = dbName;
 
         DropAllTablesInDatabase(stmt);
@@ -631,15 +666,20 @@ class SqlTestFixture
         using namespace std::string_literals;
         auto result = std::vector<std::string>();
         auto const schemaName = GetDefaultSchemaName(stmt.Connection());
-        auto const sqlResult = SQLTables(stmt.NativeHandle(),
-                                         (SQLCHAR*) testDatabaseName.data(),
-                                         (SQLSMALLINT) testDatabaseName.size(),
-                                         (SQLCHAR*) schemaName.data(),
-                                         (SQLSMALLINT) schemaName.size(),
-                                         nullptr,
-                                         0,
-                                         (SQLCHAR*) "TABLE",
-                                         SQL_NTS);
+        // Use the W variant to stay on the same Unicode-app path the library uses; the
+        // OdbcWideArg buffers own their bytes across the call (SQL_NTS).
+        auto wDatabase = Lightweight::detail::OdbcWideArg { testDatabaseName };
+        auto wSchema = Lightweight::detail::OdbcWideArg { schemaName };
+        auto wTableType = Lightweight::detail::OdbcWideArg { std::u16string { u"TABLE" } };
+        auto const sqlResult = SQLTablesW(stmt.NativeHandle(),
+                                          wDatabase.data(),
+                                          wDatabase.length(),
+                                          wSchema.data(),
+                                          wSchema.length(),
+                                          nullptr,
+                                          0,
+                                          wTableType.data(),
+                                          SQL_NTS);
         if (SQL_SUCCEEDED(sqlResult))
         {
             auto cursor = Lightweight::SqlResultCursor(stmt);

--- a/src/tests/test_dbtool.py
+++ b/src/tests/test_dbtool.py
@@ -88,7 +88,18 @@ def load_connection_string_from_test_env(env_name):
 
 def run_command(cmd, check=True):
     print(f"Running: {' '.join(cmd)}")
-    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    # dbtool emits UTF-8 (table names, progress glyphs, etc.) regardless of platform.
+    # Without an explicit encoding, Python on Windows defaults to the console code
+    # page (cp1252) and crashes the reader thread with UnicodeDecodeError as soon as
+    # any non-ASCII byte appears, masking the real exit status.
+    result = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
     if result.returncode != 0:
         print("STDOUT:", result.stdout)
         print("STDERR:", result.stderr)

--- a/src/tools/dbtool/main.cpp
+++ b/src/tools/dbtool/main.cpp
@@ -1524,6 +1524,14 @@ MigrationManager& GetMigrationManager(Options const& options)
 
 int main(int argc, char** argv)
 {
+    // Disable stdout buffering for the entire process. With the default fully-buffered
+    // mode (or Windows-_IOLBF, which the MSVC runtime silently treats as fully-buffered),
+    // std::println output can be silently lost when a loaded DLL — notably psqlODBC's
+    // libpq on Windows — performs atexit work that bypasses the C++ runtime's stream
+    // flush. Symptom: `dbtool status` against PostgreSQL emits nothing despite running
+    // normally and exiting 0. Switching stdout to unbuffered keeps each println visible
+    // immediately. dbtool's output volume is low enough that the perf cost is irrelevant.
+    std::setvbuf(stdout, nullptr, _IONBF, 0);
     try
     {
         auto optionsResult = ParseArguments(argc, argv);

--- a/src/tools/dbtool/main.cpp
+++ b/src/tools/dbtool/main.cpp
@@ -12,6 +12,7 @@
 #include <Lightweight/SqlMigrationLock.hpp>
 #include <Lightweight/SqlSchema.hpp>
 
+#include <cstdio>
 #include <expected>
 #include <filesystem>
 #include <iostream>


### PR DESCRIPTION
The Lightweight ODBC layer used the A (ANSI) variants of every ODBC entry point — `SQLDriverConnectA`, `SQLConnectA`, `SQLPrepareA`, `SQLExecDirectA`, the bare `SQLTables`/`SQLColumns`/`SQLForeignKeys`/`SQLPrimaryKeys`/`SQLStatistics` (which resolve to A by default), `SQLGetInfoA`, `SQLGetDiagRecA`, and friends. psqlODBC inspects which variant of `SQLDriverConnect` was called *first* on a DBC handle and pins the entire handle into either ANSI or Unicode mode for its lifetime. ANSI mode runs every `SQL_C_CHAR` payload through the system codepage — cp1252 on Windows — so UTF-8 bytes ≥ 0x80 round-trip as their cp1252-decoded form re-encoded back to UTF-8. Concretely, on Windows + PostgreSQL:
- `u8\"Hellö\"` round-tripped as `HellÃ¶`
- `u\"Unicode \U0001F601\"` round-tripped as `Unicode ??` (surrogate pair lost)
- `100× ä` (200 UTF-8 bytes) into `VARCHAR(100)` was rejected with `value too long for type character varying(100)` because the driver re-encoded into 400 bytes for length checks
- BatchManager + corner-case tests with embedded `\n` round-tripped as `\r\n` (a separate psqlODBC default — `LFConversion=1`)
- `dbtool status` against PostgreSQL emitted nothing despite running normally and exiting 0 (libpq.dll's unload bypassed the C++ runtime's stream flush)

Linux runs were happy because there the cp1252 step is a no-op for the typical UTF-8 locale, so CI never caught any of this.

Calling the W variants from connect onward puts the handle into Unicode-app mode and lets the driver itself do encoding conversion correctly, including reassembling UTF-16 surrogate pairs into the server's UTF-8 wire format. After that, the existing `BasicStringBinder` PostgreSQL hatches that pre-converted to UTF-8 and bound as `SQL_C_CHAR` become wrong (they put us back on the cp1252 path), so this PR removes them and routes every Unicode payload through `SQL_C_WCHAR` uniformly.

The fix is committed in independently-shippable steps so each one is green on its own.

## Changes

- `SqlError`: collect ODBC diagnostics via `SQLGetDiagRecW`, decode the SQLWCHAR buffers back to UTF-8 with a noexcept-safe fallback. The body moves from the header into `SqlError.cpp` so the new UnicodeConverter dependency stays out of every translation unit that includes `SqlError.hpp`.
- `SqlConnection`: every connect / attr / info entry point switched to its W form. A new file-local `Utf8ToUtf16(string_view)` wrapper does the cast from UTF-8 `std::string` to `std::u16string`; a `GetInfoStringW` helper centralizes the `SQLGetInfoW` byte-vs-character convention. A `static_assert` pins `sizeof(SQLWCHAR) == sizeof(char16_t)` so the `reinterpret_cast` to `SQLWCHAR*` remains sound on Windows (`wchar_t`) and Linux unixODBC (`unsigned short`) alike.
- `SqlStatement`: `SQLPrepareW` + `SQLExecDirectW`. The query (UTF-8 `std::string_view`) is converted to a local `std::u16string` per call.
- `SqlSchema`: explicit `SQLTablesW` / `SQLColumnsW` / `SQLForeignKeysW` / `SQLPrimaryKeysW` / `SQLStatisticsW` with a small `OdbcWideArg` struct that holds the converted buffer and exposes the `(pointer, length)` pair the W introspection calls expect, with correct `nullptr` / zero semantics for empty arguments.
- `SqlVariant`: `SQLColAttributeW` (pure rename — string buffer is null).
- `SqlScopedTraceLogger` + test `Utils.hpp`: trace logger and test fixture moved to W. Also fixes a latent use-after-free on the trace-file path.
- `BasicStringBinder`: drop the PostgreSQL UTF-8 hatches from the `std::u16string` / `std::u32string` / `std::u8string` parameter binders; add a PostgreSQL-only UTF-16 / `SQL_C_WCHAR` path on the `std::string` binder that treats input as UTF-8 by convention.
- `scripts/tests/.test-env.yml`: add `LFConversion=0` to the postgres connection strings — independent psqlODBC default that translates LF↔CRLF on Windows and breaks byte-exact `\n` round-trips.
- `tests/DataBinderTests`: new `Unicode round-trip across binders` test that pins `Hellö`, U+1F601 emoji, and mixed BMP+supplementary-plane round-trips through every backend.
- `tests/Utils`: cherry-pick of the upstream `[tests] Utils: suppress Windows blocking error dialogs` change so abort-style failures don't block unattended runs.
- `dbtool`: switch stdout to unbuffered so `std::println` output isn't lost when libpq.dll's atexit path bypasses the C++ runtime's stream flush. `tests/test_dbtool.py` now decodes subprocess output as UTF-8 explicitly so dbtool's progress glyphs don't crash the reader thread on Windows.

Final state on Windows: SQLite (5065 assertions), MSSQL 2022 (5070 assertions), and PostgreSQL (5072 assertions) all pass cleanly across the full LightweightTest suite plus the dbtool integration test.