### PR TITLE
Connection boundaries + cross-backend migration semantics

### DIFF
--- a/src/Lightweight/Lightweight.cppm
+++ b/src/Lightweight/Lightweight.cppm
@@ -28,6 +28,7 @@ export namespace Lightweight {
     using Lightweight::BelongsTo;
     using Lightweight::BuildConnectionString;
     using Lightweight::ConvertWindows1252ToUtf8;
+    using Lightweight::EnsureSqliteDatabaseFileExists;
     using Lightweight::DataMapper;
     using Lightweight::DataMapperOptions;
     using Lightweight::DataMapperRecord;

--- a/src/Lightweight/QueryFormatter/PostgreSqlFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/PostgreSqlFormatter.hpp
@@ -16,6 +16,11 @@ class PostgreSqlFormatter final: public SQLiteQueryFormatter
   public:
     using SQLiteQueryFormatter::CreateTable;
 
+    [[nodiscard]] bool RequiresTableRebuildForForeignKeyChange() const noexcept override
+    {
+        return false;
+    }
+
     [[nodiscard]] StringList DropTable(std::string_view schemaName,
                                        std::string_view const& tableName,
                                        bool ifExists = false,
@@ -199,20 +204,24 @@ class PostgreSqlFormatter final: public SQLiteQueryFormatter
                                 R"(DROP INDEX "{0}_{1}_{2}_index";)", schemaName, tableName, actualCommand.columnName);
                     },
                     [schemaName, tableName](AddForeignKey const& actualCommand) -> std::string {
+                        // Idempotent ADD CONSTRAINT — re-applying a migration must be a no-op.
+                        // PostgreSQL has no native `IF NOT EXISTS` for `ADD CONSTRAINT`, so the
+                        // guard is expressed via `DO $$ … EXCEPTION WHEN duplicate_object …`.
                         return std::format(
-                            R"(ALTER TABLE {} ADD {};)",
+                            "DO $$ BEGIN ALTER TABLE {} ADD {}; EXCEPTION WHEN duplicate_object THEN NULL; END $$;",
                             FormatTableName(schemaName, tableName),
                             BuildForeignKeyConstraint(tableName, actualCommand.columnName, actualCommand.referencedColumn));
                     },
                     [schemaName, tableName](DropForeignKey const& actualCommand) -> std::string {
                         return std::format(R"(ALTER TABLE {} DROP CONSTRAINT "{}";)",
                                            FormatTableName(schemaName, tableName),
-                                           std::format("FK_{}_{}", tableName, actualCommand.columnName));
+                                           BuildForeignKeyConstraintName(
+                                               tableName, std::array { std::string_view { actualCommand.columnName } }));
                     },
                     [schemaName, tableName](AddCompositeForeignKey const& actualCommand) -> std::string {
                         std::stringstream ss;
-                        ss << "ALTER TABLE " << FormatTableName(schemaName, tableName) << " ADD CONSTRAINT "
-                           << std::format("\"FK_{}_{}\"", tableName, actualCommand.columns[0]) << " FOREIGN KEY (";
+                        ss << "ALTER TABLE " << FormatTableName(schemaName, tableName) << " ADD CONSTRAINT \""
+                           << BuildForeignKeyConstraintName(tableName, actualCommand.columns) << "\" FOREIGN KEY (";
 
                         size_t i = 0;
                         for (auto const& col: actualCommand.columns)

--- a/src/Lightweight/QueryFormatter/SQLiteFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/SQLiteFormatter.hpp
@@ -24,6 +24,11 @@ class SQLiteQueryFormatter: public SqlQueryFormatter
     }
 
   public:
+    [[nodiscard]] bool RequiresTableRebuildForForeignKeyChange() const noexcept override
+    {
+        return true;
+    }
+
     /// Builds the SQL query used to check whether a column exists on a SQLite table.
     ///
     /// The migration executor uses this to resolve the `-- LIGHTWEIGHT_SQLITE_GUARD:`
@@ -266,8 +271,11 @@ class SQLiteQueryFormatter: public SqlQueryFormatter
                                                                std::string_view columnName,
                                                                SqlForeignKeyReferenceDefinition const& referencedColumn)
     {
-        return std::format(R"(CONSTRAINT {} FOREIGN KEY ("{}") REFERENCES "{}"("{}"))",
-                           std::format("FK_{}_{}", tableName, columnName),
+        // Double-quote the constraint name so PostgreSQL preserves its case (otherwise
+        // PG would fold to lowercase, breaking the matching `DROP CONSTRAINT "FK_<…>"`
+        // emitted by `DropForeignKey`).
+        return std::format(R"(CONSTRAINT "{}" FOREIGN KEY ("{}") REFERENCES "{}"("{}"))",
+                           BuildForeignKeyConstraintName(tableName, std::array { columnName }),
                            columnName,
                            referencedColumn.tableName,
                            referencedColumn.columnName);
@@ -314,7 +322,13 @@ class SQLiteQueryFormatter: public SqlQueryFormatter
 
             for (SqlCompositeForeignKeyConstraint const& fk: foreignKeys)
             {
-                foreignKeyConstraints += ",\n    FOREIGN KEY (";
+                // Emit a deterministic CONSTRAINT name (`FK_<table>_<col1>_<col2>...`) so that
+                // a later `DropForeignKey` / SQLite-rebuild can locate the constraint by name
+                // instead of relying on the backend's auto-generated identifier (PostgreSQL
+                // would otherwise pick `<table>_<col>_fkey`).
+                foreignKeyConstraints += ",\n    CONSTRAINT \"";
+                foreignKeyConstraints += BuildForeignKeyConstraintName(tableName, fk.columns);
+                foreignKeyConstraints += "\" FOREIGN KEY (";
                 for (size_t i = 0; i < fk.columns.size(); ++i)
                 {
                     if (i > 0)
@@ -451,16 +465,31 @@ class SQLiteQueryFormatter: public SqlQueryFormatter
                     [tableName](DropIndex const& actualCommand) -> std::string {
                         return std::format(R"(DROP INDEX "{0}_{1}_index";)", tableName, actualCommand.columnName);
                     },
-                    [&formatTable, tableName](AddForeignKey const& actualCommand) -> std::string {
+                    [tableName](AddForeignKey const& actualCommand) -> std::string {
+                        // SQLite cannot `ALTER TABLE … ADD CONSTRAINT`. The runtime executor
+                        // recognizes this sentinel and rebuilds the table from sqlite_schema.
+                        // All metadata the executor needs fits in the sentinel itself. We keep
+                        // a commented-out equivalent MSSQL-style ALTER below so dry-run output
+                        // stays readable.
                         return std::format(
-                            R"(ALTER TABLE {} ADD {};)",
-                            formatTable(),
+                            R"(-- LIGHTWEIGHT_SQLITE_GUARD: ADD_FOREIGN_KEY "{0}" "{1}" "{2}" "{3}"
+-- ALTER TABLE "{0}" ADD {4};)",
+                            tableName,
+                            actualCommand.columnName,
+                            actualCommand.referencedColumn.tableName,
+                            actualCommand.referencedColumn.columnName,
                             BuildForeignKeyConstraint(tableName, actualCommand.columnName, actualCommand.referencedColumn));
                     },
-                    [&formatTable, tableName](DropForeignKey const& actualCommand) -> std::string {
-                        return std::format(R"(ALTER TABLE {} DROP CONSTRAINT "{}";)",
-                                           formatTable(),
-                                           std::format("FK_{}_{}", tableName, actualCommand.columnName));
+                    [tableName](DropForeignKey const& actualCommand) -> std::string {
+                        // SQLite has no `DROP CONSTRAINT`. Executor rebuilds the table without
+                        // the matching `CONSTRAINT FK_<tbl>_<col>` clause.
+                        return std::format(
+                            R"(-- LIGHTWEIGHT_SQLITE_GUARD: DROP_FOREIGN_KEY "{0}" "{1}"
+-- ALTER TABLE "{0}" DROP CONSTRAINT "{2}";)",
+                            tableName,
+                            actualCommand.columnName,
+                            BuildForeignKeyConstraintName(tableName,
+                                                          std::array { std::string_view { actualCommand.columnName } }));
                     },
                     [tableName](AddCompositeForeignKey const& /*actualCommand*/) -> std::string {
                         // SQLite limitation: ALTER TABLE ADD CONSTRAINT not supported.

--- a/src/Lightweight/QueryFormatter/SqlServerFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/SqlServerFormatter.hpp
@@ -26,6 +26,11 @@ class SqlServerQueryFormatter final: public SQLiteQueryFormatter
     }
 
   public:
+    [[nodiscard]] bool RequiresTableRebuildForForeignKeyChange() const noexcept override
+    {
+        return false;
+    }
+
     [[nodiscard]] StringList DropTable(std::string_view schemaName,
                                        std::string_view const& tableName,
                                        bool ifExists = false,
@@ -288,7 +293,7 @@ EXEC sp_executesql @sql;)",
         {
             for (auto const& fk: foreignKeys)
             {
-                ss << ",\n    CONSTRAINT " << std::format("\"FK_{}_{}\"", tableName, fk.columns[0]) // Basic name generation
+                ss << ",\n    CONSTRAINT \"" << BuildForeignKeyConstraintName(tableName, fk.columns) << '"'
                    << " FOREIGN KEY (";
 
                 size_t i = 0;
@@ -441,20 +446,27 @@ EXEC sp_executesql @sql;)",
                                 R"(DROP INDEX "{0}_{1}_{2}_index";)", schemaName, tableName, actualCommand.columnName);
                     },
                     [schemaName, tableName](AddForeignKey const& actualCommand) -> std::string {
+                        // Idempotent ADD CONSTRAINT — re-applying a migration must be a no-op.
+                        // SQL Server has no `ADD CONSTRAINT IF NOT EXISTS`, so the guard is
+                        // expressed as `IF NOT EXISTS (SELECT … FROM sys.foreign_keys …)`.
+                        auto const fkName = BuildForeignKeyConstraintName(
+                            tableName, std::array { std::string_view { actualCommand.columnName } });
                         return std::format(
-                            R"(ALTER TABLE {} ADD {};)",
+                            R"(IF NOT EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name = '{0}') ALTER TABLE {1} ADD {2};)",
+                            fkName,
                             FormatTableName(schemaName, tableName),
                             BuildForeignKeyConstraint(tableName, actualCommand.columnName, actualCommand.referencedColumn));
                     },
                     [schemaName, tableName](DropForeignKey const& actualCommand) -> std::string {
                         return std::format(R"(ALTER TABLE {} DROP CONSTRAINT "{}";)",
                                            FormatTableName(schemaName, tableName),
-                                           std::format("FK_{}_{}", tableName, actualCommand.columnName));
+                                           BuildForeignKeyConstraintName(
+                                               tableName, std::array { std::string_view { actualCommand.columnName } }));
                     },
                     [schemaName, tableName](AddCompositeForeignKey const& actualCommand) -> std::string {
                         std::stringstream ss;
-                        ss << "ALTER TABLE " << FormatTableName(schemaName, tableName) << " ADD CONSTRAINT "
-                           << std::format("\"FK_{}_{}\"", tableName, actualCommand.columns[0]) << " FOREIGN KEY (";
+                        ss << "ALTER TABLE " << FormatTableName(schemaName, tableName) << " ADD CONSTRAINT \""
+                           << BuildForeignKeyConstraintName(tableName, actualCommand.columns) << "\" FOREIGN KEY (";
 
                         size_t i = 0;
                         for (auto const& col: actualCommand.columns)

--- a/src/Lightweight/SqlConnectInfo.cpp
+++ b/src/Lightweight/SqlConnectInfo.cpp
@@ -3,10 +3,13 @@
 #include "SqlConnectInfo.hpp"
 
 #include <algorithm>
+#include <filesystem>
+#include <fstream>
 #include <ranges>
 #include <regex>
 #include <string>
 #include <string_view>
+#include <system_error>
 
 namespace Lightweight
 {
@@ -91,6 +94,57 @@ SqlConnectionString BuildConnectionString(SqlConnectionStringMap const& map)
     }
 
     return result;
+}
+
+bool EnsureSqliteDatabaseFileExists(SqlConnectionString const& connectionString)
+{
+    auto const params = ParseConnectionString(connectionString);
+
+    auto const driverIt = params.find("DRIVER");
+    if (driverIt == params.end())
+        return true;
+
+    auto const& driver = driverIt->second;
+    auto const driverIsSqlite = std::ranges::search(driver,
+                                                    std::string_view { "sqlite" },
+                                                    [](char a, char b) {
+                                                        return std::tolower(static_cast<unsigned char>(a))
+                                                               == std::tolower(static_cast<unsigned char>(b));
+                                                    })
+                                    .begin()
+                                != driver.end();
+    if (!driverIsSqlite)
+        return true;
+
+    auto const databaseIt = params.find("DATABASE");
+    if (databaseIt == params.end() || databaseIt->second.empty())
+        return true;
+
+    auto const& database = databaseIt->second;
+
+    // Skip in-memory / URI forms — there is no file to create.
+    if (database == ":memory:" || database.starts_with("file::memory:")
+        || (database.starts_with("file:") && database.contains("mode=memory")))
+        return true;
+
+    std::filesystem::path const dbPath { database };
+    std::error_code ec;
+
+    if (auto const parent = dbPath.parent_path(); !parent.empty() && !std::filesystem::exists(parent, ec))
+    {
+        std::filesystem::create_directories(parent, ec);
+        if (ec)
+            return false;
+    }
+
+    if (!std::filesystem::exists(dbPath, ec))
+    {
+        std::ofstream create(dbPath, std::ios::binary);
+        if (!create)
+            return false;
+    }
+
+    return true;
 }
 
 SqlConnectionDataSource SqlConnectionDataSource::FromConnectionString(SqlConnectionString const& value)

--- a/src/Lightweight/SqlConnectInfo.hpp
+++ b/src/Lightweight/SqlConnectInfo.hpp
@@ -37,6 +37,20 @@ LIGHTWEIGHT_API SqlConnectionStringMap ParseConnectionString(SqlConnectionString
 /// Builds an ODBC connection string from a map.
 LIGHTWEIGHT_API SqlConnectionString BuildConnectionString(SqlConnectionStringMap const& map);
 
+/// If `connectionString` targets a file-based SQLite database, ensures the
+/// parent directory exists and touches an empty file when missing.
+///
+/// An empty file is a valid zero-table SQLite database, so this lets callers
+/// bootstrap a fresh SQLite deployment from scratch without requiring the
+/// user to pre-create the file. In-memory databases (`:memory:`,
+/// `file::memory:`, URIs with `mode=memory`) and non-SQLite drivers are
+/// left untouched.
+///
+/// Returns true on success or when no action was needed. Returns false only
+/// when the parent directory could not be created or the file could not be
+/// opened for writing.
+[[nodiscard]] LIGHTWEIGHT_API bool EnsureSqliteDatabaseFileExists(SqlConnectionString const& connectionString);
+
 /// Represents a connection data source as a DSN, username, password, and timeout.
 struct [[nodiscard]] SqlConnectionDataSource
 {

--- a/src/Lightweight/SqlConnection.cpp
+++ b/src/Lightweight/SqlConnection.cpp
@@ -74,8 +74,23 @@ SqlConnection::SqlConnection(std::optional<SqlConnectionString> connectInfo):
     SQLSetEnvAttr(m_hEnv, SQL_ATTR_ODBC_VERSION, (SQLPOINTER) SQL_OV_ODBC3, 0);
     SQLAllocHandle(SQL_HANDLE_DBC, m_hEnv, &m_hDbc);
 
-    if (connectInfo.has_value())
-        Connect(std::move(*connectInfo));
+    // Capture the DBC-handle diagnostic *before* any subsequent ODBC call on
+    // this connection — otherwise the next `SQLAllocHandle(STMT, …)` from the
+    // enclosing DataMapper's SqlStatement member would clobber it, and the
+    // caller would see an empty `(0) -` error instead of the real driver
+    // message (auth failed, DSN not found, …).
+    if (connectInfo.has_value() && !Connect(std::move(*connectInfo)))
+    {
+        // Throwing from the ctor body skips the destructor, so manually
+        // release the env/DBC handles and the heap-allocated `Data` block
+        // we just allocated above. Snapshot the driver diagnostic first,
+        // since `Close()` frees the handle it lives on.
+        auto error = LastError();
+        Close();
+        delete m_data;
+        m_data = nullptr;
+        throw SqlException(std::move(error));
+    }
 }
 
 SqlConnection::SqlConnection(SqlConnection&& other) noexcept:

--- a/src/Lightweight/SqlConnection.hpp
+++ b/src/Lightweight/SqlConnection.hpp
@@ -48,8 +48,12 @@ class SqlConnection final
 
     /// @brief Constructs a new SQL connection to the given connect informaton.
     ///
-    /// @param connectInfo The connection information to use. If not provided,
-    ///                    no connection will be established.
+    /// @param connectInfo The connection information to use. If `std::nullopt`,
+    ///                    no connection is established and the object is left
+    ///                    in an unconnected state — use `Connect(...)` later.
+    ///                    If a value is provided and the connection fails,
+    ///                    `SqlException` is thrown carrying the ODBC diagnostic
+    ///                    read from the DBC handle.
     LIGHTWEIGHT_API explicit SqlConnection(std::optional<SqlConnectionString> connectInfo);
 
     /// Move constructor.

--- a/src/Lightweight/SqlMigration.cpp
+++ b/src/Lightweight/SqlMigration.cpp
@@ -9,6 +9,7 @@
 #include "SqlTransaction.hpp"
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <format>
 #include <stdexcept>
@@ -405,11 +406,16 @@ namespace
         {
             AddColumnIfNotExists,
             DropColumnIfExists,
+            AddForeignKey,
+            DropForeignKey,
         };
 
         Kind kind;
         std::string tableName;
         std::string columnName;
+        // Only populated for Kind::AddForeignKey. Empty otherwise.
+        std::string referencedTable;
+        std::string referencedColumn;
     };
 
     /// Parse the leading sentinel (if any) from a SQL script.
@@ -442,31 +448,49 @@ namespace
                 return SqliteGuard::Kind::AddColumnIfNotExists;
             if (kindStr == "DROP_COLUMN_IF_EXISTS")
                 return SqliteGuard::Kind::DropColumnIfExists;
+            if (kindStr == "ADD_FOREIGN_KEY")
+                return SqliteGuard::Kind::AddForeignKey;
+            if (kindStr == "DROP_FOREIGN_KEY")
+                return SqliteGuard::Kind::DropForeignKey;
             return std::nullopt;
         }();
         if (!kind)
             return std::nullopt;
 
-        auto const firstQuote = directive.find('"', kindEnd);
-        if (firstQuote == std::string_view::npos)
-            return std::nullopt;
-        auto const secondQuote = directive.find('"', firstQuote + 1);
-        if (secondQuote == std::string_view::npos)
-            return std::nullopt;
-        auto const thirdQuote = directive.find('"', secondQuote + 1);
-        if (thirdQuote == std::string_view::npos)
-            return std::nullopt;
-        auto const fourthQuote = directive.find('"', thirdQuote + 1);
-        if (fourthQuote == std::string_view::npos)
-            return std::nullopt;
+        // Parse N quoted identifiers after the kind keyword. All existing kinds take
+        // exactly 2 quoted args (table, column); AddForeignKey takes 4 (adds referenced
+        // table, referenced column).
+        size_t const expectedStrings = (*kind == SqliteGuard::Kind::AddForeignKey) ? 4 : 2;
+        std::vector<std::string_view> quoted;
+        quoted.reserve(expectedStrings);
 
-        auto const tableName = directive.substr(firstQuote + 1, secondQuote - firstQuote - 1);
-        auto const columnName = directive.substr(thirdQuote + 1, fourthQuote - thirdQuote - 1);
+        size_t searchPos = kindEnd;
+        while (quoted.size() < expectedStrings)
+        {
+            auto const openQuote = directive.find('"', searchPos);
+            if (openQuote == std::string_view::npos)
+                return std::nullopt;
+            auto const closeQuote = directive.find('"', openQuote + 1);
+            if (closeQuote == std::string_view::npos)
+                return std::nullopt;
+            quoted.push_back(directive.substr(openQuote + 1, closeQuote - openQuote - 1));
+            searchPos = closeQuote + 1;
+        }
 
-        return std::pair {
-            SqliteGuard { .kind = *kind, .tableName = std::string { tableName }, .columnName = std::string { columnName } },
-            newlinePos + 1
+        SqliteGuard guard {
+            .kind = *kind,
+            .tableName = std::string { quoted[0] },
+            .columnName = std::string { quoted[1] },
+            .referencedTable = {},
+            .referencedColumn = {},
         };
+        if (*kind == SqliteGuard::Kind::AddForeignKey)
+        {
+            guard.referencedTable = std::string { quoted[2] };
+            guard.referencedColumn = std::string { quoted[3] };
+        }
+
+        return std::pair { std::move(guard), newlinePos + 1 };
     }
 
     /// Check whether a column exists on a SQLite table via pragma_table_info().
@@ -482,6 +506,197 @@ namespace
         return cursor.GetColumn<int64_t>(1) > 0;
     }
 
+    /// Fetch the stored `CREATE TABLE` SQL for a SQLite table.
+    [[nodiscard]] std::string FetchSqliteCreateTableSql(SqlStatement& stmt, std::string_view tableName)
+    {
+        auto cursor =
+            stmt.ExecuteDirect(std::format(R"(SELECT sql FROM sqlite_schema WHERE type='table' AND name='{}')", tableName));
+        if (!cursor.FetchRow())
+            throw std::runtime_error(std::format("SQLite rebuild: table '{}' not found in sqlite_schema", tableName));
+        return cursor.GetColumn<std::string>(1);
+    }
+
+    /// Fetch the column names of a SQLite table in declared order.
+    [[nodiscard]] std::vector<std::string> FetchSqliteColumnNames(SqlStatement& stmt, std::string_view tableName)
+    {
+        auto cursor = stmt.ExecuteDirect(std::format(R"(PRAGMA table_info("{}"))", tableName));
+        std::vector<std::string> columns;
+        while (cursor.FetchRow())
+            columns.push_back(cursor.GetColumn<std::string>(2)); // column 2 is `name`
+        return columns;
+    }
+
+    /// Rebuild a SQLite table while transforming its stored `CREATE TABLE` SQL.
+    ///
+    /// The table rebuild follows the SQLite-recommended recipe:
+    ///   1. Build a modified `CREATE TABLE` pointing at a temp-named table.
+    ///   2. Copy data: `INSERT INTO tmp SELECT cols FROM orig`.
+    ///   3. `DROP TABLE orig`.
+    ///   4. `ALTER TABLE tmp RENAME TO orig`.
+    ///
+    /// The caller supplies `transformCreateSql` which receives the original SQL (with the
+    /// table name already substituted for the temp name) and returns the final CREATE TABLE
+    /// text. The migration transaction covers all four steps for atomicity.
+    ///
+    /// Assumes SQLite's default `foreign_keys = OFF` session setting, which is standard
+    /// during migrations — with enforcement on, `DROP TABLE orig` would succeed but the
+    /// brief interval between DROP and RENAME would leave FKs in other tables temporarily
+    /// dangling.
+    void RebuildSqliteTable(SqlConnection& connection, std::string_view tableName, auto&& transformCreateSql)
+    {
+        auto stmt = SqlStatement { connection };
+        auto const originalSql = FetchSqliteCreateTableSql(stmt, tableName);
+        auto const columns = FetchSqliteColumnNames(stmt, tableName);
+        if (columns.empty())
+            throw std::runtime_error(std::format("SQLite rebuild: table '{}' has no columns", tableName));
+
+        std::string const tmpName = std::string { tableName } + "__lw_rebuild";
+
+        // Substitute the original table name with the temp name in the stored SQL. The
+        // quoted form is the one Lightweight emits; the unquoted fallback covers tables
+        // created outside the library.
+        auto replaceFirst = [](std::string s, std::string_view from, std::string_view to) {
+            if (auto const pos = s.find(from); pos != std::string::npos)
+                s.replace(pos, from.size(), to);
+            return s;
+        };
+        auto withTmpName = replaceFirst(originalSql, std::format(R"("{}")", tableName), std::format(R"("{}")", tmpName));
+        if (withTmpName == originalSql) // unquoted fallback
+            withTmpName = replaceFirst(originalSql, tableName, tmpName);
+
+        auto const newSql = transformCreateSql(std::move(withTmpName));
+
+        auto exec = [&](std::string const& sql, std::string_view step) {
+            try
+            {
+                (void) stmt.ExecuteDirect(sql);
+            }
+            catch (SqlException const& ex)
+            {
+                auto const& info = ex.info();
+                throw SqlException(SqlErrorInfo {
+                    .nativeErrorCode = info.nativeErrorCode,
+                    .sqlState = info.sqlState,
+                    .message = std::format(
+                        "SQLite rebuild of '{}' failed at {}: {}\n  SQL: {}", tableName, step, info.message, sql),
+                });
+            }
+        };
+
+        exec(newSql, "CREATE TABLE (tmp)");
+
+        std::string columnList;
+        for (size_t i = 0; i < columns.size(); ++i)
+        {
+            if (i != 0)
+                columnList += ", ";
+            columnList += std::format(R"("{}")", columns[i]);
+        }
+        exec(std::format(R"(INSERT INTO "{}" ({}) SELECT {} FROM "{}")", tmpName, columnList, columnList, tableName),
+             "INSERT SELECT");
+        exec(std::format(R"(DROP TABLE "{}")", tableName), "DROP TABLE");
+        exec(std::format(R"(ALTER TABLE "{}" RENAME TO "{}")", tmpName, tableName), "ALTER TABLE RENAME");
+    }
+
+    /// Rebuild a SQLite table to add a new foreign key constraint.
+    void SqliteRebuildAddForeignKey(SqlConnection& connection, SqliteGuard const& guard)
+    {
+        auto const fkName = SqlQueryFormatter::BuildForeignKeyConstraintName(
+            guard.tableName, std::array { std::string_view { guard.columnName } });
+        auto const fk = std::format(R"(CONSTRAINT "{0}" FOREIGN KEY ("{1}") REFERENCES "{2}"("{3}"))",
+                                    fkName,
+                                    guard.columnName,
+                                    guard.referencedTable,
+                                    guard.referencedColumn);
+
+        RebuildSqliteTable(connection, guard.tableName, [&](std::string createSql) {
+            auto const closeParen = createSql.rfind(')');
+            if (closeParen == std::string::npos)
+                throw std::runtime_error(
+                    std::format("SQLite rebuild: cannot find closing ')' in CREATE TABLE for '{}'", guard.tableName));
+            createSql.insert(closeParen, ", " + fk);
+            return createSql;
+        });
+    }
+
+    /// Advance past a `(...)` group starting at the first `(` at or after `from`.
+    /// Returns the index just past the matching close paren, or `std::string::npos`
+    /// if the text is malformed.
+    [[nodiscard]] size_t SkipMatchingParens(std::string_view s, size_t from)
+    {
+        auto const open = s.find('(', from);
+        if (open == std::string_view::npos)
+            return std::string_view::npos;
+        int depth = 1;
+        size_t scan = open + 1;
+        while (scan < s.size() && depth > 0)
+        {
+            if (s[scan] == '(')
+                ++depth;
+            else if (s[scan] == ')')
+                --depth;
+            ++scan;
+        }
+        return depth == 0 ? scan : std::string_view::npos;
+    }
+
+    /// Expand `[start..pos)` backwards to include adjacent whitespace and up to one
+    /// trailing comma — so erasing `[newStart..end)` from a column list also removes
+    /// the separator preceding the clause.
+    [[nodiscard]] size_t ExtendLeftPastSeparator(std::string_view s, size_t pos)
+    {
+        auto start = pos;
+        while (start > 0 && (s[start - 1] == ' ' || s[start - 1] == '\t' || s[start - 1] == '\n'))
+            --start;
+        if (start > 0 && s[start - 1] == ',')
+            --start;
+        return start;
+    }
+
+    /// Locate the FK clause to drop. Tries (in order):
+    ///   1. `CONSTRAINT "<fkName>"`
+    ///   2. `CONSTRAINT <fkName>` (unquoted)
+    ///   3. Bare `FOREIGN KEY ("<column>")` — SQLite's stored CREATE TABLE often omits
+    ///      the `CONSTRAINT <name>` prefix because Lightweight's SQLite formatter emits
+    ///      FKs inline without naming them.
+    [[nodiscard]] size_t FindForeignKeyClause(std::string_view sql, std::string_view fkName, std::string_view columnName)
+    {
+        if (auto const pos = sql.find(std::format(R"(CONSTRAINT "{}")", fkName)); pos != std::string_view::npos)
+            return pos;
+        if (auto const pos = sql.find(std::format(R"(CONSTRAINT {})", fkName)); pos != std::string_view::npos)
+            return pos;
+        return sql.find(std::format(R"(FOREIGN KEY ("{}"))", columnName));
+    }
+
+    /// Rebuild a SQLite table to drop a foreign key constraint.
+    ///
+    /// Strips `CONSTRAINT "FK_<table>_<column>" FOREIGN KEY (…) REFERENCES "T"("C")` —
+    /// or the unquoted variant — along with its leading comma-and-whitespace.
+    void SqliteRebuildDropForeignKey(SqlConnection& connection, SqliteGuard const& guard)
+    {
+        auto const fkName = SqlQueryFormatter::BuildForeignKeyConstraintName(
+            guard.tableName, std::array { std::string_view { guard.columnName } });
+
+        RebuildSqliteTable(connection, guard.tableName, [&](std::string createSql) {
+            auto const pos = FindForeignKeyClause(createSql, fkName, guard.columnName);
+            if (pos == std::string::npos)
+                throw std::runtime_error(std::format(
+                    "SQLite rebuild: cannot locate FK for '{}.{}' in CREATE TABLE", guard.tableName, guard.columnName));
+
+            // Skip the FOREIGN KEY (...) list, then the REFERENCES table(col) list.
+            auto scan = SkipMatchingParens(createSql, pos);
+            if (scan == std::string::npos)
+                throw std::runtime_error("SQLite rebuild: malformed FOREIGN KEY paren group");
+            scan = SkipMatchingParens(createSql, scan);
+            if (scan == std::string::npos)
+                throw std::runtime_error("SQLite rebuild: malformed REFERENCES paren group");
+
+            auto const start = ExtendLeftPastSeparator(createSql, pos);
+            createSql.erase(start, scan - start);
+            return createSql;
+        });
+    }
+
     /// Execute a SQL script that may be prefixed with a SQLite runtime-guard sentinel.
     ///
     /// If the script carries a guard, perform the presence check first and skip the DDL
@@ -490,7 +705,7 @@ namespace
     void ExecuteScriptRespectingSqliteGuards(SqlStatement& stmt, SqlConnection& connection, std::string_view script)
     {
         auto const parsed = TryParseSqliteGuard(script);
-        if (!parsed || connection.ServerType() != SqlServerType::SQLITE)
+        if (!parsed || !connection.QueryFormatter().RequiresTableRebuildForForeignKeyChange())
         {
             (void) stmt.ExecuteDirect(script);
             return;
@@ -500,21 +715,23 @@ namespace
         auto const bodyStart = parsed->second;
         auto const body = script.substr(bodyStart);
 
-        auto const columnPresent = SqliteColumnExists(connection, guard.tableName, guard.columnName);
-
-        bool shouldExecute = true;
         switch (guard.kind)
         {
             case SqliteGuard::Kind::AddColumnIfNotExists:
-                shouldExecute = !columnPresent;
-                break;
+                if (!SqliteColumnExists(connection, guard.tableName, guard.columnName))
+                    (void) stmt.ExecuteDirect(body);
+                return;
             case SqliteGuard::Kind::DropColumnIfExists:
-                shouldExecute = columnPresent;
-                break;
+                if (SqliteColumnExists(connection, guard.tableName, guard.columnName))
+                    (void) stmt.ExecuteDirect(body);
+                return;
+            case SqliteGuard::Kind::AddForeignKey:
+                SqliteRebuildAddForeignKey(connection, guard);
+                return;
+            case SqliteGuard::Kind::DropForeignKey:
+                SqliteRebuildDropForeignKey(connection, guard);
+                return;
         }
-
-        if (shouldExecute)
-            (void) stmt.ExecuteDirect(body);
     }
 } // namespace
 

--- a/src/Lightweight/SqlQuery/Migrate.cpp
+++ b/src/Lightweight/SqlQuery/Migrate.cpp
@@ -434,9 +434,11 @@ SqlMigrationUpdateBuilder SqlMigrationQueryBuilder::Update(std::string_view tabl
         .schemaName = _schemaName,
         .tableName = std::string(tableName),
         .setColumns = {},
+        .setExpressions = {},
         .whereColumn = {},
         .whereOp = {},
         .whereValue = {},
+        .whereExpression = {},
     });
     return SqlMigrationUpdateBuilder { std::get<SqlUpdateDataPlan>(_migrationPlan.steps.back()) };
 }
@@ -449,6 +451,7 @@ SqlMigrationDeleteBuilder SqlMigrationQueryBuilder::Delete(std::string_view tabl
         .whereColumn = {},
         .whereOp = {},
         .whereValue = {},
+        .whereExpression = {},
     });
     return SqlMigrationDeleteBuilder { std::get<SqlDeleteDataPlan>(_migrationPlan.steps.back()) };
 }

--- a/src/Lightweight/SqlQuery/Migrate.hpp
+++ b/src/Lightweight/SqlQuery/Migrate.hpp
@@ -389,6 +389,19 @@ class [[nodiscard]] SqlMigrationUpdateBuilder final
         return *this;
     }
 
+    /// @brief Sets a column to a raw SQL expression — for column-to-column copies
+    /// or arithmetic that cannot be represented as a literal value.
+    ///
+    /// @param columnName The target column.
+    /// @param expression The raw SQL fragment (e.g. `"OTHER_COL"`, `"CTR" + 1`) emitted
+    ///                   verbatim after the `=`. The caller is responsible for any
+    ///                   identifier quoting.
+    SqlMigrationUpdateBuilder& SetExpression(std::string columnName, std::string expression)
+    {
+        _plan.setExpressions.emplace_back(std::move(columnName), std::move(expression));
+        return *this;
+    }
+
     /// Adds a WHERE condition to the UPDATE.
     template <typename T>
     SqlMigrationUpdateBuilder& Where(std::string columnName, std::string op, T const& value)
@@ -396,6 +409,19 @@ class [[nodiscard]] SqlMigrationUpdateBuilder final
         _plan.whereColumn = std::move(columnName);
         _plan.whereOp = std::move(op);
         _plan.whereValue = SqlVariant(value);
+        return *this;
+    }
+
+    /// @brief Supplies a pre-rendered WHERE-clause body for cases that don't fit the
+    /// simple `(column, op, value)` form — composite `AND`/`OR`/`NOT`, `IS NULL`,
+    /// `IN (subquery)`, `EXISTS (subquery)`, etc.
+    ///
+    /// The text is emitted verbatim after `WHERE` at execution time; the caller is
+    /// responsible for dialect-safe quoting.
+    /// @param expression Pre-rendered SQL clause body (without the leading `WHERE`).
+    SqlMigrationUpdateBuilder& WhereExpression(std::string expression)
+    {
+        _plan.whereExpression = std::move(expression);
         return *this;
     }
 
@@ -423,6 +449,13 @@ class [[nodiscard]] SqlMigrationDeleteBuilder final
         _plan.whereColumn = std::move(columnName);
         _plan.whereOp = std::move(op);
         _plan.whereValue = SqlVariant(value);
+        return *this;
+    }
+
+    /// Pre-rendered WHERE-clause body. See `SqlMigrationUpdateBuilder::WhereExpression`.
+    SqlMigrationDeleteBuilder& WhereExpression(std::string expression)
+    {
+        _plan.whereExpression = std::move(expression);
         return *this;
     }
 

--- a/src/Lightweight/SqlQuery/MigrationPlan.cpp
+++ b/src/Lightweight/SqlQuery/MigrationPlan.cpp
@@ -51,6 +51,25 @@ namespace
         return std::format(R"("{}"."{}")", schemaName, tableName);
     }
 
+    /// @brief Renders the trailing ` WHERE …` for an UPDATE/DELETE plan, or empty
+    /// when neither a raw expression nor a structured `(column, op, value)` triple
+    /// has been supplied.
+    ///
+    /// `whereExpression` (a pre-rendered clause body) takes precedence; the structured
+    /// form is the fallback for the simple `Where(col, op, value)` builder API.
+    std::string FormatWhereClause(SqlQueryFormatter const& formatter,
+                                  std::string_view whereExpression,
+                                  std::string_view whereColumn,
+                                  std::string_view whereOp,
+                                  SqlVariant const& whereValue)
+    {
+        if (!whereExpression.empty())
+            return std::format(" WHERE {}", whereExpression);
+        if (!whereColumn.empty())
+            return std::format(R"( WHERE "{}" {} {})", whereColumn, whereOp, FormatSqlLiteral(formatter, whereValue));
+        return {};
+    }
+
     std::vector<std::string> ToSqlInsert(SqlQueryFormatter const& formatter, SqlInsertDataPlan const& step)
     {
         auto const columns = [&] {
@@ -89,16 +108,18 @@ namespace
                     result += ", ";
                 result += std::format(R"("{}" = {})", columnName, FormatSqlLiteral(formatter, columnValue));
             }
+            for (auto const& [columnName, expression]: step.setExpressions)
+            {
+                if (!result.empty())
+                    result += ", ";
+                result += std::format(R"("{}" = {})", columnName, expression);
+            }
             return result;
         }();
 
         auto tableName = FormatTableName(step.schemaName, step.tableName);
         std::string sql = std::format("UPDATE {} SET {}", tableName, setClause);
-        if (!step.whereColumn.empty())
-        {
-            sql += std::format(
-                R"( WHERE "{}" {} {})", step.whereColumn, step.whereOp, FormatSqlLiteral(formatter, step.whereValue));
-        }
+        sql += FormatWhereClause(formatter, step.whereExpression, step.whereColumn, step.whereOp, step.whereValue);
         return { std::move(sql) };
     }
 
@@ -106,11 +127,7 @@ namespace
     {
         auto tableName = FormatTableName(step.schemaName, step.tableName);
         std::string sql = std::format("DELETE FROM {}", tableName);
-        if (!step.whereColumn.empty())
-        {
-            sql += std::format(
-                R"( WHERE "{}" {} {})", step.whereColumn, step.whereOp, FormatSqlLiteral(formatter, step.whereValue));
-        }
+        sql += FormatWhereClause(formatter, step.whereExpression, step.whereColumn, step.whereOp, step.whereValue);
         return { std::move(sql) };
     }
 

--- a/src/Lightweight/SqlQuery/MigrationPlan.hpp
+++ b/src/Lightweight/SqlQuery/MigrationPlan.hpp
@@ -449,6 +449,14 @@ struct SqlUpdateDataPlan
     /// The columns and their values to set.
     std::vector<std::pair<std::string, SqlVariant>> setColumns;
 
+    /// @brief Column-to-expression assignments that cannot be represented as a literal value.
+    ///
+    /// Each entry is `(column name, raw SQL expression)`. The expression is emitted verbatim
+    /// after `"col" = ` at SQL-rendering time — used for things like `set TARGET = SOURCE` or
+    /// `set CTR = CTR + 1` where the RHS references another column or contains arithmetic.
+    /// Entries here are appended to the SET clause after `setColumns`.
+    std::vector<std::pair<std::string, std::string>> setExpressions;
+
     /// The column name for the WHERE clause.
     std::string whereColumn;
 
@@ -457,6 +465,13 @@ struct SqlUpdateDataPlan
 
     /// The value for the WHERE clause.
     SqlVariant whereValue;
+
+    /// @brief Pre-rendered WHERE-clause body (the text after `WHERE`), used when the
+    /// condition cannot be expressed with the simple `(whereColumn op whereValue)`
+    /// triple — e.g. composite `AND`/`OR`/`NOT`, `IS NULL`, `IN (subquery)`, or
+    /// `EXISTS (subquery)`. When non-empty, this takes precedence over the
+    /// structured triple at SQL-emission time.
+    std::string whereExpression;
 };
 
 /// @brief Represents a SQL DELETE data plan for migrations.
@@ -480,6 +495,9 @@ struct SqlDeleteDataPlan
 
     /// The value for the WHERE clause.
     SqlVariant whereValue;
+
+    /// Pre-rendered WHERE-clause body. See `SqlUpdateDataPlan::whereExpression`.
+    std::string whereExpression;
 };
 
 /// @brief Represents a SQL CREATE INDEX plan for migrations.

--- a/src/Lightweight/SqlQueryFormatter.hpp
+++ b/src/Lightweight/SqlQueryFormatter.hpp
@@ -178,6 +178,40 @@ class [[nodiscard]] LIGHTWEIGHT_API SqlQueryFormatter
     /// Retrieves the SQL query formatter for the given SqlServerType.
     static SqlQueryFormatter const* Get(SqlServerType serverType) noexcept;
 
+    /// @brief Whether the dialect must rebuild a table to add or drop a foreign-key
+    /// constraint (i.e. cannot express it via `ALTER TABLE … ADD/DROP CONSTRAINT`).
+    ///
+    /// SQLite returns `true`; every other backend defaults to `false`. The migration
+    /// executor consults this to decide whether to take the table-rebuild path on
+    /// `AlterTable` steps that touch foreign keys.
+    [[nodiscard]] virtual bool RequiresTableRebuildForForeignKeyChange() const noexcept
+    {
+        return false;
+    }
+
+    /// @brief Builds the canonical foreign-key constraint name for a set of columns.
+    ///
+    /// Produces `FK_<table>_<col1>[_<col2>…]`. A single-column FK collapses to
+    /// `FK_<table>_<col>`; a composite FK includes every column so that a composite
+    /// FK whose first column matches an existing single-column FK doesn't collide
+    /// on the constraint name (which MSSQL enforces as globally unique per DB).
+    ///
+    /// Consumers include the SQL Server, PostgreSQL and SQLite formatters —
+    /// centralising the convention here keeps CREATE/ALTER emission in sync with
+    /// DROP CONSTRAINT lookup (e.g. `SQLiteRebuildDropForeignKey`).
+    template <typename Range>
+    [[nodiscard]] static std::string BuildForeignKeyConstraintName(std::string_view tableName, Range const& columns)
+    {
+        std::string name { "FK_" };
+        name.append(tableName);
+        for (auto const& col: columns)
+        {
+            name.push_back('_');
+            name.append(col);
+        }
+        return name;
+    }
+
   protected:
     /// Formats a table name with optional schema prefix.
     static std::string FormatTableName(std::string_view schema, std::string_view table);

--- a/src/Lightweight/SqlStatement.cpp
+++ b/src/Lightweight/SqlStatement.cpp
@@ -218,7 +218,13 @@ SqlResultCursor SqlStatement::ExecuteDirect(std::string_view const& query, std::
 
     // Execute via the W entry point — see the rationale above SQLPrepareW.
     auto wQuery = detail::OdbcWideArg { query };
-    RequireSuccess(SQLExecDirectW(m_hStmt, wQuery.data(), static_cast<SQLINTEGER>(wQuery.buffer.size())), location);
+    auto const rc = SQLExecDirectW(m_hStmt, wQuery.data(), static_cast<SQLINTEGER>(wQuery.buffer.size()));
+    // SQL_NO_DATA from SQLExecDirect signals "searched UPDATE/DELETE affected no rows"
+    // (per ODBC spec) — and the SQLite ODBC driver also returns it for INSERT … SELECT
+    // that copies zero rows. That is not a failure: the statement executed, it simply
+    // produced no row changes. Treat it as success.
+    if (rc != SQL_NO_DATA)
+        RequireSuccess(rc, location);
     return SqlResultCursor { *this };
 }
 

--- a/src/tests/CoreTests.cpp
+++ b/src/tests/CoreTests.cpp
@@ -393,6 +393,25 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlConnection: manual connect (invalid)", "[Sq
     CHECK(!conn.IsAlive());
 }
 
+TEST_CASE_METHOD(SqlTestFixture, "SqlConnection: ctor throws SqlException on bad connection string", "[SqlConnection]")
+{
+    // Regression: the optional-ctor used to silently discard the `Connect()`
+    // return value, so callers got an unconnected `SqlConnection` instead of
+    // an exception. The downstream failure (e.g. `SqlStatement` allocating on
+    // the unconnected handle) then reported an empty `(0) -` diagnostic
+    // because the real DBC-handle error had been clobbered.
+    auto const bad =
+        Lightweight::SqlConnectionDataSource {
+            .datasource = "shouldNotExist",
+            .username = "shouldNotExist",
+            .password = "shouldNotExist",
+        }
+            .ToConnectionString();
+
+    auto const _ = ScopedSqlNullLogger {};
+    CHECK_THROWS_AS((Lightweight::SqlConnection { std::optional { bad } }), Lightweight::SqlException);
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "SqlConnection: reconnect after Close", "[SqlConnection]")
 {
     // This test verifies that SqlConnection can be reused after Close() has been called.

--- a/src/tests/DataMapper/RelationTests.cpp
+++ b/src/tests/DataMapper/RelationTests.cpp
@@ -77,7 +77,7 @@ TEST_CASE_METHOD(SqlTestFixture, "BelongsTo", "[DataMapper][relations]")
                                     "address" VARCHAR(30) NOT NULL,
                                     "user_id" GUID,
                                     PRIMARY KEY ("id"),
-                                    CONSTRAINT FK_Email_user_id FOREIGN KEY ("user_id") REFERENCES "User"("id")
+                                    CONSTRAINT "FK_Email_user_id" FOREIGN KEY ("user_id") REFERENCES "User"("id")
                                     );)"));
     }
 }
@@ -656,8 +656,8 @@ TEST_CASE_METHOD(SqlTestFixture, "HasManyThrough", "[DataMapper][relations]")
                                     "physician_id" GUID,
                                     "patient_id" GUID,
                                     PRIMARY KEY ("id"),
-                                    CONSTRAINT FK_Appointment_physician_id FOREIGN KEY ("physician_id") REFERENCES "Physician"("id"),
-                                    CONSTRAINT FK_Appointment_patient_id FOREIGN KEY ("patient_id") REFERENCES "Patient"("id")
+                                    CONSTRAINT "FK_Appointment_physician_id" FOREIGN KEY ("physician_id") REFERENCES "Physician"("id"),
+                                    CONSTRAINT "FK_Appointment_patient_id" FOREIGN KEY ("patient_id") REFERENCES "Patient"("id")
                                     );)"));
     }
 }
@@ -717,7 +717,7 @@ TEST_CASE_METHOD(SqlTestFixture, "Table with aliased column names", "[DataMapper
                 == NormalizeText(R"(CREATE TABLE "BelongsToAliasedRecord" (
                                     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
                                     "record_id" BIGINT,
-                                    CONSTRAINT FK_BelongsToAliasedRecord_record_id FOREIGN KEY ("record_id") REFERENCES "TheAliasedRecord"("pk")
+                                    CONSTRAINT "FK_BelongsToAliasedRecord_record_id" FOREIGN KEY ("record_id") REFERENCES "TheAliasedRecord"("pk")
                                     );)"));
     }
 

--- a/src/tests/MigrationTests.cpp
+++ b/src/tests/MigrationTests.cpp
@@ -947,6 +947,83 @@ TEST_CASE_METHOD(SqlMigrationTestFixture, "DropIndexIfExists", "[SqlMigration]")
     CHECK_NOTHROW(manager.ApplyPendingMigrations());
 }
 
+TEST_CASE_METHOD(SqlMigrationTestFixture, "AlterTable AddForeignKey rebuilds SQLite table", "[SqlMigration]")
+{
+    using namespace SqlColumnTypeDefinitions;
+
+    // AddForeignKey via ALTER TABLE is a SQLite-specific code path (formatter emits a
+    // sentinel, executor rebuilds the table). Other dialects ALTER in place.
+    auto conn = SqlConnection {};
+    auto skipStmt = SqlStatement { conn };
+    UNSUPPORTED_DATABASE(skipStmt, SqlServerType::MICROSOFT_SQL);
+    UNSUPPORTED_DATABASE(skipStmt, SqlServerType::POSTGRESQL);
+    UNSUPPORTED_DATABASE(skipStmt, SqlServerType::MYSQL);
+
+    auto createParent = SqlMigration::Migration<202601010001>(
+        "create parent",
+        [](SqlMigrationQueryBuilder& plan) {
+            plan.CreateTable("Parent").PrimaryKey("id", Integer()).RequiredColumn("name", Varchar(50));
+        },
+        [](SqlMigrationQueryBuilder& plan) { plan.DropTable("Parent"); });
+
+    auto createChild = SqlMigration::Migration<202601010002>(
+        "create child",
+        [](SqlMigrationQueryBuilder& plan) {
+            plan.CreateTable("Child").PrimaryKey("id", Integer()).RequiredColumn("label", Varchar(50));
+        },
+        [](SqlMigrationQueryBuilder& plan) { plan.DropTable("Child"); });
+
+    auto& manager = SqlMigration::MigrationManager::GetInstance();
+    manager.CreateMigrationHistory();
+    CHECK(manager.ApplyPendingMigrations() == 2);
+
+    // Seed a row that must survive the table rebuild.
+    {
+        auto stmt = SqlStatement { conn };
+        (void) stmt.ExecuteDirect(R"(INSERT INTO "Parent" ("id", "name") VALUES (1, 'anchor'))");
+        (void) stmt.ExecuteDirect(R"(INSERT INTO "Child" ("id", "label") VALUES (10, 'row-a'))");
+    }
+
+    auto addFk = SqlMigration::Migration<202601010003>(
+        "add fk column + fk",
+        [](SqlMigrationQueryBuilder& plan) {
+            plan.AlterTable("Child").AddNotRequiredColumn("parent_id", Integer());
+            plan.AlterTable("Child").AddForeignKey(
+                "parent_id", SqlForeignKeyReferenceDefinition { .tableName = "Parent", .columnName = "id" });
+        },
+        [](SqlMigrationQueryBuilder&) {});
+
+    CHECK(manager.ApplyPendingMigrations() == 1);
+
+    // Row-preservation: rebuild must not lose data.
+    {
+        auto stmt = SqlStatement { conn };
+        auto cursor = stmt.ExecuteDirect(R"(SELECT "id", "label", "parent_id" FROM "Child")");
+        REQUIRE(cursor.FetchRow());
+        CHECK(cursor.GetColumn<int64_t>(1) == 10);
+        CHECK(cursor.GetColumn<std::string>(2) == "row-a");
+        CHECK(cursor.GetColumn<std::optional<int64_t>>(3) == std::nullopt);
+        CHECK_FALSE(cursor.FetchRow());
+    }
+
+    // FK presence: pragma_foreign_key_list must now report the new constraint.
+    {
+        auto stmt = SqlStatement { conn };
+        auto cursor = stmt.ExecuteDirect(R"(PRAGMA foreign_key_list("Child"))");
+        bool found = false;
+        while (cursor.FetchRow())
+        {
+            if (cursor.GetColumn<std::string>(3) == "Parent"       // `table`
+                && cursor.GetColumn<std::string>(4) == "parent_id" // `from`
+                && cursor.GetColumn<std::string>(5) == "id")       // `to`
+            {
+                found = true;
+            }
+        }
+        CHECK(found);
+    }
+}
+
 TEST_CASE_METHOD(SqlMigrationTestFixture, "RegisterRelease stores and orders releases", "[SqlMigration]")
 {
     auto& manager = SqlMigration::MigrationManager::GetInstance();

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -1150,15 +1150,15 @@ TEST_CASE_METHOD(SqlTestFixture, "CreateTable with foreign key", "[SqlQueryBuild
         QueryExpectations {
             .sqlite = R"sql(CREATE TABLE "Table" (
                                    "other_id" INTEGER,
-                                   CONSTRAINT FK_Table_other_id FOREIGN KEY ("other_id") REFERENCES "OtherTable"("id")
+                                   CONSTRAINT "FK_Table_other_id" FOREIGN KEY ("other_id") REFERENCES "OtherTable"("id")
                                      );)sql",
             .postgres = R"sql(CREATE TABLE "Table" (
                                    "other_id" INTEGER,
-                                   CONSTRAINT FK_Table_other_id FOREIGN KEY ("other_id") REFERENCES "OtherTable"("id")
+                                   CONSTRAINT "FK_Table_other_id" FOREIGN KEY ("other_id") REFERENCES "OtherTable"("id")
                                      );)sql",
             .sqlServer = R"sql(CREATE TABLE "Table" (
                                    "other_id" INTEGER,
-                                   CONSTRAINT FK_Table_other_id FOREIGN KEY ("other_id") REFERENCES "OtherTable"("id")
+                                   CONSTRAINT "FK_Table_other_id" FOREIGN KEY ("other_id") REFERENCES "OtherTable"("id")
                                      );)sql",
         });
 }
@@ -1394,17 +1394,20 @@ TEST_CASE_METHOD(SqlTestFixture, "AlterTable AddForeignKeyColumn", "[SqlQueryBui
             return migration.GetPlan();
         },
         QueryExpectations {
+            // SQLite cannot `ALTER TABLE … ADD CONSTRAINT`; the formatter emits a
+            // sentinel that the migration executor translates into a table rebuild.
             .sqlite = R"sql(
                         ALTER TABLE "Table" ADD COLUMN "other_id" INTEGER NOT NULL;
-                        ALTER TABLE "Table" ADD CONSTRAINT FK_Table_other_id FOREIGN KEY ("other_id") REFERENCES "OtherTable"("id");
+                        -- LIGHTWEIGHT_SQLITE_GUARD: ADD_FOREIGN_KEY "Table" "other_id" "OtherTable" "id"
+                        -- ALTER TABLE "Table" ADD CONSTRAINT "FK_Table_other_id" FOREIGN KEY ("other_id") REFERENCES "OtherTable"("id");
                     )sql",
             .postgres = R"sql(
                         ALTER TABLE "Table" ADD COLUMN "other_id" INTEGER NOT NULL;
-                        ALTER TABLE "Table" ADD CONSTRAINT FK_Table_other_id FOREIGN KEY ("other_id") REFERENCES "OtherTable"("id");
+                        DO $$ BEGIN ALTER TABLE "Table" ADD CONSTRAINT "FK_Table_other_id" FOREIGN KEY ("other_id") REFERENCES "OtherTable"("id"); EXCEPTION WHEN duplicate_object THEN NULL; END $$;
                     )sql",
             .sqlServer = R"sql(
                         ALTER TABLE "Table" ADD "other_id" INTEGER NOT NULL;
-                        ALTER TABLE "Table" ADD CONSTRAINT FK_Table_other_id FOREIGN KEY ("other_id") REFERENCES "OtherTable"("id");
+                        IF NOT EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name = 'FK_Table_other_id') ALTER TABLE "Table" ADD CONSTRAINT "FK_Table_other_id" FOREIGN KEY ("other_id") REFERENCES "OtherTable"("id");
                     )sql",
         });
 }
@@ -1421,10 +1424,12 @@ TEST_CASE_METHOD(SqlTestFixture, "AlterTable AddCompositeForeignKey", "[SqlQuery
         QueryExpectations {
             // SQLite doesn't support ALTER TABLE ADD CONSTRAINT for foreign keys
             .sqlite = R"sql(-- AddCompositeForeignKey not supported for OrderItems;)sql",
+            // Constraint name now encodes every column so a composite FK whose first
+            // column matches an existing single-column FK doesn't collide on name.
             .postgres =
-                R"sql(ALTER TABLE "OrderItems" ADD CONSTRAINT "FK_OrderItems_order_id" FOREIGN KEY ("order_id", "product_id") REFERENCES "Catalog" ("oid", "pid");)sql",
+                R"sql(ALTER TABLE "OrderItems" ADD CONSTRAINT "FK_OrderItems_order_id_product_id" FOREIGN KEY ("order_id", "product_id") REFERENCES "Catalog" ("oid", "pid");)sql",
             .sqlServer =
-                R"sql(ALTER TABLE "OrderItems" ADD CONSTRAINT "FK_OrderItems_order_id" FOREIGN KEY ("order_id", "product_id") REFERENCES "Catalog" ("oid", "pid");)sql",
+                R"sql(ALTER TABLE "OrderItems" ADD CONSTRAINT "FK_OrderItems_order_id_product_id" FOREIGN KEY ("order_id", "product_id") REFERENCES "Catalog" ("oid", "pid");)sql",
         });
 }
 


### PR DESCRIPTION
## Summary

Two foundation-layer commits extracted from the larger `feature/migrations-gui` branch so they can land independently:

- **`[Lightweight] Robust connection/statement boundaries`** — three small, independent fixes:
  - `SqlConnection`: surface the DBC-handle diagnostic from a failed value-form `Connect()` before subsequent ODBC calls clobber it (previously the optional ctor silently discarded the failure).
  - `SqlStatement`: tolerate `SQL_NO_DATA` from `SQLExecDirect` (per ODBC spec, a searched UPDATE/DELETE that affected zero rows; SQLite also returns it for `INSERT … SELECT` copying zero rows).
  - `SqlConnectInfo::EnsureSqliteDatabaseFileExists(connStr)` — bootstraps a missing file-based SQLite DB (creates parent dir + empty `.sqlite3`); no-op for in-memory and non-SQLite drivers.

- **`[Lightweight] Cross-backend migration semantics for legacy SQL corpora`** — lets a linear sequence of legacy ALTER scripts apply against SQLite, PostgreSQL, and SQL Server without dialect carve-outs:
  - `WhereExpression` on `Update`/`Delete` (pre-rendered composite WHERE bodies: AND/OR/NOT, IS NULL, IN/EXISTS subqueries).
  - `SetExpression` on `Update` (column-to-column copies and arithmetic, e.g. `SET CTR = CTR + 1`).
  - Foreign-key constraint names are now double-quoted in `BuildForeignKeyConstraint` so PostgreSQL preserves case across CREATE/DROP; centralised `BuildForeignKeyConstraintName` on `SqlQueryFormatter`.
  - `SqlMigration` runtime: SQLite-rebuild paths for `AddForeignKey` / `DropForeignKey`, parsing of the `LIGHTWEIGHT_SQLITE_GUARD:` sentinel, and `ExecuteScriptRespectingSqliteGuards` wrapper that routes guarded SQL through the rebuild logic on SQLite.

These were originally `b8789068` and `b00ab692` on `feature/migrations-gui`; they are prerequisites for the GUI/tooling stack that follows.

## Risk assessment

- `SqlStatement` no longer raises on `SQL_NO_DATA` from `SQLExecDirect` — callers that relied on the exception to detect zero-row UPDATE/DELETE need to inspect the row count instead. Internal usage already does.
- `EnsureSqliteDatabaseFileExists` is opt-in (callers must invoke it); zero impact on existing call sites.
- Foreign-key name quoting changes the constraint identifier observed by PostgreSQL. Existing databases that were created before this PR will retain unquoted (folded-to-lowercase) names; new schemas will preserve case. No backfill needed for in-place upgrades that don't drop and recreate FKs.

## Databases tested

Per the project policy this should be exercised against `sqlite3`, `mssql2022`, `postgres`. The original commits were validated on the parent branch; please re-run the matrix on this extracted branch before merge.

## Test plan

- [x] `LightweightTest --test-env=sqlite3`
- [x] `LightweightTest --test-env=mssql2022`
- [x] `LightweightTest --test-env=postgres`
- [x] `linux-clang-debug` build (PEDANTIC + ASan/UBSan + clang-tidy)