### PR TITLE
Fix #485: SqlFixedString round-trip truncates values that fill capacity

### DIFF
--- a/src/Lightweight/DataBinder/BasicStringBinder.hpp
+++ b/src/Lightweight/DataBinder/BasicStringBinder.hpp
@@ -286,11 +286,22 @@ struct SqlDataBinder<AnsiStringType>
             cb.PlanPostProcessOutputColumn(
                 [stmt, column, indicator, result]() { PostProcessOutputColumn(stmt, column, result, indicator); });
 
+        // Per ODBC spec, BufferLength for SQL_C_CHAR must include space for the
+        // null terminator. SqlFixedString<N> backs its data with _data[N+1] for
+        // exactly this reason; pass Capacity+1 to let the driver write a full
+        // N-char value plus null. Dynamic strings keep the current behaviour.
+        SQLLEN const bufferLength = [result]() -> SQLLEN {
+            if constexpr (requires { AnsiStringType::Capacity; })
+                return static_cast<SQLLEN>(AnsiStringType::Capacity) + 1;
+            else
+                return static_cast<SQLLEN>(StringTraits::Size(result));
+        }();
+
         return SQLBindCol(stmt,
                           column,
                           SQL_C_CHAR,
                           (SQLPOINTER) StringTraits::Data(result),
-                          (SQLLEN) StringTraits::Size(result),
+                          bufferLength,
                           indicator);
     }
 
@@ -338,8 +349,10 @@ struct SqlDataBinder<AnsiStringType>
         if constexpr (requires { AnsiStringType::Capacity; })
         {
             StringTraits::Resize(result, AnsiStringType::Capacity);
+            // BufferLength for SQL_C_CHAR must include space for the null terminator;
+            // _data is sized N+1 to accommodate it.
             SQLRETURN const rv =
-                SQLGetData(stmt, column, SQL_C_CHAR, StringTraits::Data(result), AnsiStringType::Capacity, indicator);
+                SQLGetData(stmt, column, SQL_C_CHAR, StringTraits::Data(result), AnsiStringType::Capacity + 1, indicator);
             if (rv == SQL_SUCCESS || rv == SQL_NO_DATA)
             {
                 if (*indicator == SQL_NULL_DATA)

--- a/src/Lightweight/DataBinder/BasicStringBinder.hpp
+++ b/src/Lightweight/DataBinder/BasicStringBinder.hpp
@@ -290,19 +290,14 @@ struct SqlDataBinder<AnsiStringType>
         // null terminator. SqlFixedString<N> backs its data with _data[N+1] for
         // exactly this reason; pass Capacity+1 to let the driver write a full
         // N-char value plus null. Dynamic strings keep the current behaviour.
-        SQLLEN const bufferLength = [result]() -> SQLLEN {
+        SQLLEN const bufferLength = [&]() -> SQLLEN {
             if constexpr (requires { AnsiStringType::Capacity; })
                 return static_cast<SQLLEN>(AnsiStringType::Capacity) + 1;
             else
                 return static_cast<SQLLEN>(StringTraits::Size(result));
         }();
 
-        return SQLBindCol(stmt,
-                          column,
-                          SQL_C_CHAR,
-                          (SQLPOINTER) StringTraits::Data(result),
-                          bufferLength,
-                          indicator);
+        return SQLBindCol(stmt, column, SQL_C_CHAR, (SQLPOINTER) StringTraits::Data(result), bufferLength, indicator);
     }
 
     static void PostProcessOutputColumn(SQLHSTMT stmt, SQLUSMALLINT column, AnsiStringType* result, SQLLEN* indicator)

--- a/src/Lightweight/DataBinder/SqlFixedString.hpp
+++ b/src/Lightweight/DataBinder/SqlFixedString.hpp
@@ -471,9 +471,9 @@ struct SqlBasicStringOperations<SqlFixedString<N, T, Mode>>
     LIGHTWEIGHT_FORCE_INLINE static void TrimRight(ValueType* boundOutputString, SQLLEN indicator) noexcept
     {
 #if defined(_WIN32)
-        size_t n = (std::min) (static_cast<size_t>(indicator) / sizeof(CharType), N - 1);
+        size_t n = (std::min) (static_cast<size_t>(indicator) / sizeof(CharType), N);
 #else
-        size_t n = std::min(static_cast<size_t>(indicator), N - 1);
+        size_t n = std::min(static_cast<size_t>(indicator), N);
 #endif
         // Strip trailing whitespace and null characters
         while (n > 0 && (std::isspace((*boundOutputString)[n - 1]) || (*boundOutputString)[n - 1] == '\0'))

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -1453,9 +1453,8 @@ TEST_CASE_METHOD(SqlTestFixture, "Trimmed fixed strings strip trailing padding t
 // Regression for #485: BasicStringBinder::OutputColumn passes BufferLength=N
 // (not N+1) to SQLBindCol, so ODBC truncates any value of length N to N-1
 // data chars + null. The bug only surfaces when the stored value fills the
-// full capacity with no trailing whitespace -- typical case is 3-letter
-// ISO 4217 codes in a CHAR(3) column. Surfaced downstream as LASTRADA DEV-6285
-// (empty cbc:DocumentCurrencyCode in XRechnung exports for non-Euro invoices).
+// full capacity with no trailing whitespace -- e.g. a 3-letter currency code
+// stored in a CHAR(3) column.
 struct FullCapacityFixedRow
 {
     Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id {};

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -1450,6 +1450,35 @@ TEST_CASE_METHOD(SqlTestFixture, "Trimmed fixed strings strip trailing padding t
     CHECK(result->stringWide == SqlTrimmedWideFixedString<32> { L"Hellö" });
 }
 
+// Regression for #485: BasicStringBinder::OutputColumn passes BufferLength=N
+// (not N+1) to SQLBindCol, so ODBC truncates any value of length N to N-1
+// data chars + null. The bug only surfaces when the stored value fills the
+// full capacity with no trailing whitespace -- typical case is 3-letter
+// ISO 4217 codes in a CHAR(3) column. Surfaced downstream as LASTRADA DEV-6285
+// (empty cbc:DocumentCurrencyCode in XRechnung exports for non-Euro invoices).
+struct FullCapacityFixedRow
+{
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id {};
+    Field<SqlTrimmedFixedString<3>> code {};
+};
+
+TEST_CASE_METHOD(SqlTestFixture,
+                 "Trimmed fixed string preserves a value that fills its capacity",
+                 "[DataMapper][SqlFixedString][regression]")
+{
+    auto dm = DataMapper {};
+    dm.CreateTable<FullCapacityFixedRow>();
+
+    FullCapacityFixedRow row {};
+    row.code = "EUR";
+    dm.Create(row);
+
+    auto const result = dm.QuerySingle<FullCapacityFixedRow>(row.id);
+    REQUIRE(result.has_value());
+    CHECK(result->code.Value().size() == 3);
+    CHECK(result->code.Value().str() == "EUR");
+}
+
 // Coverage for the SQL_C_WCHAR truncation arithmetic in
 // detail::GetRawColumnArrayData (BasicStringBinder.hpp). The function has two
 // re-fetch branches: (a) the driver reports total length up front and we re-


### PR DESCRIPTION
Closes #485.

## Problem

`BasicStringBinder<...>::OutputColumn` and `::GetColumn` were passing `BufferLength = Capacity` (i.e., `N`) to `SQLBindCol` / `SQLGetData` when binding an `SqlFixedString<N>`-derived field. ODBC's `SQL_C_CHAR` semantics require `BufferLength` to include space for the null terminator, so the driver truncated any value of length `N` to `N − 1` data chars + null.

`SqlFixedString<N>` already backs its data with `_data[N + 1]` so the terminator slot exists; the binder just wasn't telling ODBC about it.

The bug was masked for almost every consumer because real-world values rarely fill the full capacity with no trailing whitespace. We tripped over it in a downstream codebase (LASTRADA, ticket DEV-6285) via `Light::Field<Light::SqlTrimmedFixedString<3>>` mapped to a `WAEHRUNGEN.NAME CHAR(3)` column storing 3-letter ISO 4217 codes (`EUR`, `CHF`, `GBP`, `USD`, …). The codes came back as 2-char prefixes (`"EU"`, `"CH"`, `"GB"`, `"US"`), silently breaking ISO 4217 lookup and producing an empty `cbc:DocumentCurrencyCode` in XRechnung exports for non-Euro invoices.

## Approach

TDD — failing test in commit 1, fix in commit 2.

### Test (commit 1, `e5ebfc01`)

Adds `Trimmed fixed string preserves a value that fills its capacity` next to the existing `UnicodeTrimmedFixedRow` test in `DataBinderTests.cpp`. It uses `SqlTrimmedFixedString<3>` and the value `"EUR"` to hit `indicator == N` with a non-whitespace last byte — the precise condition the existing `SqlFixedString: TrimRight` test does not cover (its calls pass `indicator < N` and so always have slack).

### Fix (commit 2, `3a29c5b2`)

Two binder paths and one trim path:

1. `BasicStringBinder.hpp::OutputColumn` — for fixed-capacity types, pass `Capacity + 1` to `SQLBindCol` instead of `Size(result)`. Dynamic strings keep their existing behaviour.
2. `BasicStringBinder.hpp::GetColumn` (the `if constexpr (requires { Capacity; })` branch) — pass `Capacity + 1` to `SQLGetData`.
3. `SqlFixedString.hpp::TrimRight` — change the cap on `n` from `N − 1` to `N`. The previous `N − 1` was consistent with the truncated buffer (since ODBC could only have written `N − 1` data chars anyway). With `BufferLength` corrected, capping at `N − 1` would leave `_size` permanently one short of the actual content.

Existing tests are unaffected because they all operate on values shorter than `N` with trailing whitespace, where both `N − 1` and `N` give the same trim result.

## Test matrix

I haven't been able to run Lightweight's full test suite locally (no preconfigured ODBC test DB on this box). CI on this PR will exercise both the new regression test and the rest of the suite across the supported drivers. Happy to iterate if anything else trips.