### PR TITLE
Fix MSSQL "Connection is busy" during long migration runs

### DIFF
--- a/src/Lightweight/SqlQueryFormatter.cpp
+++ b/src/Lightweight/SqlQueryFormatter.cpp
@@ -159,7 +159,13 @@ namespace
                                                                    std::string_view lockName,
                                                                    std::chrono::milliseconds timeout) const override
         {
-            auto const sql = std::format("DECLARE @result INT; "
+            // SET NOCOUNT ON suppresses the per-statement row-count "DONE"
+            // tokens that would otherwise surface as additional result sets
+            // on top of the SELECT @result we actually consume. Combined with
+            // SqlStatement::CloseCursor draining via SQLMoreResults, this
+            // guarantees no pending token survives the lock acquire.
+            auto const sql = std::format("SET NOCOUNT ON; "
+                                         "DECLARE @result INT; "
                                          "EXEC @result = sp_getapplock @Resource = N'{}', @LockMode = N'Exclusive', "
                                          "@LockTimeout = {}, @LockOwner = N'Session'; "
                                          "SELECT @result;",
@@ -242,8 +248,12 @@ namespace
             try
             {
                 auto stmt = SqlStatement { connection };
-                [[maybe_unused]] auto releaseCursor = stmt.ExecuteDirect(
-                    std::format("EXEC sp_releaseapplock @Resource = N'{}', @LockOwner = N'Session';", lockName));
+                // SET NOCOUNT ON — see TryAcquire above. sp_releaseapplock's
+                // return-status result set is never fetched here; relying on
+                // CloseCursor's SQLMoreResults drain to keep the connection
+                // clean.
+                [[maybe_unused]] auto releaseCursor = stmt.ExecuteDirect(std::format(
+                    "SET NOCOUNT ON; EXEC sp_releaseapplock @Resource = N'{}', @LockOwner = N'Session';", lockName));
                 return {};
             }
             catch (SqlException const& ex)

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -948,7 +948,22 @@ inline T SqlStatement::ExecuteDirectScalar(SqlQueryObject auto const& query, std
 
 inline LIGHTWEIGHT_FORCE_INLINE void SqlStatement::CloseCursor() noexcept
 {
-    // SQLCloseCursor(m_hStmt);
+    // SQL Server batches and DML/DDL row-count tokens produce multiple result
+    // sets per SQLExecDirect. SQLFreeStmt(SQL_CLOSE) only discards the current
+    // cursor — remaining result sets stay pending on the *connection*, and
+    // without MARS every subsequent statement on that connection fails with
+    // HY000 "Connection is busy with results for another command". Drain via
+    // SQLMoreResults until SQL_NO_DATA (or an error), then close.
+    //
+    // SQLMoreResults is standard ODBC; SQLite and PostgreSQL drivers return
+    // SQL_NO_DATA on the first call when nothing is pending, so the cost on
+    // single-statement queries is one no-op driver call.
+    while (true)
+    {
+        auto const rc = SQLMoreResults(m_hStmt);
+        if (rc == SQL_NO_DATA || !SQL_SUCCEEDED(rc))
+            break;
+    }
     SQLFreeStmt(m_hStmt, SQL_CLOSE);
     SqlLogger::GetLogger().OnFetchEnd();
 }

--- a/src/tests/MigrationTests.cpp
+++ b/src/tests/MigrationTests.cpp
@@ -2342,8 +2342,7 @@ TEST_CASE_METHOD(SqlMigrationTestFixture,
 
     {
         auto stmt = SqlStatement { conn };
-        (void) stmt.ExecuteDirect(
-            std::format("CREATE TABLE dbo.{} (id INT NULL);", probeTable));
+        (void) stmt.ExecuteDirect(std::format("CREATE TABLE dbo.{} (id INT NULL);", probeTable));
     }
 
     for (auto const cycle: std::views::iota(0, kCycles))
@@ -2355,25 +2354,23 @@ TEST_CASE_METHOD(SqlMigrationTestFixture,
         // matching the failing real-world shape:
         //     IF NOT EXISTS (SELECT … FROM sys.columns …) ALTER TABLE … ADD …;
         auto stmtA = SqlStatement { conn };
-        (void) stmtA.ExecuteDirect(std::format(
-            "IF NOT EXISTS (SELECT 1 FROM sys.columns "
-            "WHERE object_id = OBJECT_ID('dbo.{}') AND name = '{}') "
-            "ALTER TABLE dbo.{} ADD {} INT NULL;",
-            probeTable,
-            colName,
-            probeTable,
-            colName));
+        (void) stmtA.ExecuteDirect(std::format("IF NOT EXISTS (SELECT 1 FROM sys.columns "
+                                               "WHERE object_id = OBJECT_ID('dbo.{}') AND name = '{}') "
+                                               "ALTER TABLE dbo.{} ADD {} INT NULL;",
+                                               probeTable,
+                                               colName,
+                                               probeTable,
+                                               colName));
 
         // Second step in the same migration on the SAME statement handle —
         // this is where the migration runner's reuse of `stmt` happens.
-        (void) stmtA.ExecuteDirect(std::format(
-            "IF EXISTS (SELECT 1 FROM sys.columns "
-            "WHERE object_id = OBJECT_ID('dbo.{}') AND name = '{}') "
-            "UPDATE dbo.{} SET {} = NULL WHERE 1 = 0;",
-            probeTable,
-            colName,
-            probeTable,
-            colName));
+        (void) stmtA.ExecuteDirect(std::format("IF EXISTS (SELECT 1 FROM sys.columns "
+                                               "WHERE object_id = OBJECT_ID('dbo.{}') AND name = '{}') "
+                                               "UPDATE dbo.{} SET {} = NULL WHERE 1 = 0;",
+                                               probeTable,
+                                               colName,
+                                               probeTable,
+                                               colName));
 
         // Now allocate a *new* SqlStatement on the same connection — exactly
         // what `dm.CreateExplicit(SchemaMigration{...})` does after the

--- a/src/tests/MigrationTests.cpp
+++ b/src/tests/MigrationTests.cpp
@@ -2284,3 +2284,130 @@ TEST_CASE_METHOD(SqlMigrationTestFixture, "SetDefaultSchema PostgreSQL search_pa
     // to switch to a now-dropped schema.
     mgr.SetDefaultSchema("");
 }
+
+// =============================================================================
+// Regression tests for the MS SQL Server "Connection is busy with results for
+// another command" failure that appeared while applying the Lastrada migration
+// sequence through dbtool / dbtool-gui.
+//
+// Root cause being pinned by these tests:
+//   - SQL Server's ODBC driver returns row-count / done-in-proc tokens after
+//     every statement in a T-SQL batch, plus a real result set for any embedded
+//     SELECT. The application must drain them with SQLMoreResults until
+//     SQL_NO_DATA before the *connection* will accept another command.
+//   - Lightweight's `SqlStatement::CloseCursor` only calls
+//     `SQLFreeStmt(SQL_CLOSE)`, which closes the current cursor but does NOT
+//     advance past pending result sets in a batch.
+//   - With MARS off (the default on every connection string we ship), this
+//     leaves the connection in the "busy" state and the next statement on a
+//     *different* `SqlStatement` handle of the same `SqlConnection` fails
+//     with HY000.
+//
+// Both tests are gated on MS SQL Server — only that driver produces the
+// pending-result-set state we need to exercise.
+// =============================================================================
+
+TEST_CASE_METHOD(SqlMigrationTestFixture,
+                 "Regression: repeated multi-statement DDL batches do not leave connection busy",
+                 "[SqlStatement][regression][mssql]")
+{
+    auto& dm = SqlMigration::MigrationManager::GetInstance().GetDataMapper();
+    auto& conn = dm.Connection();
+
+    if (conn.ServerType() != SqlServerType::MICROSOFT_SQL)
+    {
+        SUCCEED("Reproduces only on MS SQL Server (MARS off, NOCOUNT off).");
+        return;
+    }
+
+    // Mirror the migration-runner's actual pattern: each migration wraps
+    // multiple multi-statement DDL batches in a transaction, then inserts a
+    // tracking row and commits. We run many such cycles to exercise the same
+    // pending-result-set accumulation that surfaces in 356-migration LUP runs.
+    constexpr int kCycles = 60;
+    constexpr std::string_view probeTable = "_lw_busy_probe";
+
+    auto cleanup = [&] {
+        try
+        {
+            auto stmt = SqlStatement { conn };
+            (void) stmt.ExecuteDirect(std::format("DROP TABLE IF EXISTS dbo.{};", probeTable));
+        }
+        catch (...)
+        {
+            // Best-effort.
+        }
+    };
+    cleanup(); // pre-clean in case a prior test crashed mid-cycle
+
+    {
+        auto stmt = SqlStatement { conn };
+        (void) stmt.ExecuteDirect(
+            std::format("CREATE TABLE dbo.{} (id INT NULL);", probeTable));
+    }
+
+    for (auto const cycle: std::views::iota(0, kCycles))
+    {
+        auto const colName = std::format("col_{}", cycle);
+        auto transaction = SqlTransaction { conn, SqlTransactionMode::ROLLBACK };
+
+        // Multi-step "migration": each step is a multi-statement T-SQL batch
+        // matching the failing real-world shape:
+        //     IF NOT EXISTS (SELECT … FROM sys.columns …) ALTER TABLE … ADD …;
+        auto stmtA = SqlStatement { conn };
+        (void) stmtA.ExecuteDirect(std::format(
+            "IF NOT EXISTS (SELECT 1 FROM sys.columns "
+            "WHERE object_id = OBJECT_ID('dbo.{}') AND name = '{}') "
+            "ALTER TABLE dbo.{} ADD {} INT NULL;",
+            probeTable,
+            colName,
+            probeTable,
+            colName));
+
+        // Second step in the same migration on the SAME statement handle —
+        // this is where the migration runner's reuse of `stmt` happens.
+        (void) stmtA.ExecuteDirect(std::format(
+            "IF EXISTS (SELECT 1 FROM sys.columns "
+            "WHERE object_id = OBJECT_ID('dbo.{}') AND name = '{}') "
+            "UPDATE dbo.{} SET {} = NULL WHERE 1 = 0;",
+            probeTable,
+            colName,
+            probeTable,
+            colName));
+
+        // Now allocate a *new* SqlStatement on the same connection — exactly
+        // what `dm.CreateExplicit(SchemaMigration{...})` does after the
+        // per-migration steps complete. Before the fix this is where the
+        // accumulated pending-result tokens surface as HY000.
+        auto stmtB = SqlStatement { conn };
+        REQUIRE_NOTHROW((void) stmtB.ExecuteDirect("SELECT 1;"));
+
+        transaction.Commit();
+    }
+
+    cleanup();
+}
+
+TEST_CASE_METHOD(SqlMigrationTestFixture,
+                 "Regression: sp_getapplock acquire does not leave the connection busy",
+                 "[SqlScopedLock][regression][mssql]")
+{
+    auto& dm = SqlMigration::MigrationManager::GetInstance().GetDataMapper();
+    auto& conn = dm.Connection();
+
+    if (conn.ServerType() != SqlServerType::MICROSOFT_SQL)
+    {
+        SUCCEED("Reproduces only on MS SQL Server (MARS off, NOCOUNT off).");
+        return;
+    }
+
+    // Acquiring the advisory lock runs a multi-statement batch
+    //     DECLARE @result INT; EXEC @result = sp_getapplock …; SELECT @result;
+    // Before the fix, only the SELECT result is fetched; the EXEC's done
+    // token stays pending and poisons the connection for the next caller.
+    auto lock = SqlScopedLock { conn, "lightweight_busy_probe" };
+    REQUIRE(lock.IsLocked());
+
+    auto stmt = SqlStatement { conn };
+    REQUIRE_NOTHROW((void) stmt.ExecuteDirect("SELECT 1;"));
+}

--- a/src/tools/dbtool-gui/AppController.cpp
+++ b/src/tools/dbtool-gui/AppController.cpp
@@ -833,22 +833,26 @@ QString AppController::currentReleaseLabel() const
     // want the label to already show the right version at that point —
     // the Simple view only shows the Status card when connected anyway,
     // so a pre-connect read from this accessor never reaches the user.
-    // For the "never-connected" edge case (external caller reading the
-    // property before any connect), `GetAppliedMigrationIds` throws on
-    // an unopened DataMapper and we fall through to "(fresh database)".
+    //
+    // We deliberately do NOT call `manager.GetAppliedMigrationIds()` here:
+    // this accessor is bound from QML on the UI thread, and QML re-evaluates
+    // the binding on every `migrationsChanged()` emission — including the
+    // one fired between every migration during an `applyUpTo` run. The
+    // migration run holds the only `SqlConnection` on a worker thread; an
+    // ODBC handle is not safe for concurrent use, so a DB query from the
+    // UI thread mid-run surfaces as HY000 "Connection is busy" and aborts
+    // the run. Instead, read from `_migrations` — the in-memory model is
+    // kept in sync per row by `migrationCompleted` →
+    // `SetRowStatusByTimestamp`, so it knows which migrations are applied
+    // at any point during a run without touching the database.
+    auto const appliedRaw = _migrations.AppliedTimestamps();
+    if (appliedRaw.empty())
+        return QStringLiteral("(fresh database)");
+
     std::vector<Lightweight::SqlMigration::MigrationTimestamp> applied;
-    try
-    {
-        applied = manager.GetAppliedMigrationIds();
-    }
-    catch (std::exception const&)
-    {
-        // Unmanaged DB (no schema_migrations yet) — same messaging path as
-        // the expert view's yellow warning banner.
-        return QStringLiteral("(fresh database)");
-    }
-    if (applied.empty())
-        return QStringLiteral("(fresh database)");
+    applied.reserve(appliedRaw.size());
+    for (auto const ts: appliedRaw)
+        applied.push_back(Lightweight::SqlMigration::MigrationTimestamp { ts });
 
     auto const highest = *std::ranges::max_element(applied);
     auto const* release = manager.FindReleaseForTimestamp(highest);
@@ -1015,6 +1019,16 @@ QStringList AppController::previewMigrationSql(QString const& timestamp) const
     auto const ts = timestamp.toULongLong(&ok);
     if (!ok)
         return {};
+
+    // Belt-and-suspenders for the same race documented in
+    // `currentReleaseLabel`: `PreviewMigration` issues INFORMATION_SCHEMA
+    // queries via `MakeWidthLookup` against the shared `SqlConnection`. If
+    // QML triggers this accessor while the worker thread is mid-migration,
+    // we'd hit "Connection is busy" again. The Simple-view UI disables
+    // preview during runs, but explicit-view callers (or future ones) might
+    // not — short-circuit to a placeholder when a run is in flight.
+    if (_runner.phase() != MigrationRunner::Phase::Idle)
+        return { QStringLiteral("-- Preview unavailable during a migration run.") };
 
     auto const& manager = Lightweight::SqlMigration::MigrationManager::GetInstance();
     auto const* migration = manager.GetMigration(Lightweight::SqlMigration::MigrationTimestamp { ts });

--- a/src/tools/dbtool-gui/Models/MigrationListModel.cpp
+++ b/src/tools/dbtool-gui/Models/MigrationListModel.cpp
@@ -166,6 +166,16 @@ int MigrationListModel::SelectedCount() const noexcept
     return n;
 }
 
+std::vector<uint64_t> MigrationListModel::AppliedTimestamps() const
+{
+    std::vector<uint64_t> out;
+    out.reserve(_rows.size());
+    for (auto const& r: _rows)
+        if (r.status == QStringLiteral("applied") || r.status == QStringLiteral("checksum-mismatch"))
+            out.push_back(r.timestamp);
+    return out;
+}
+
 bool MigrationListModel::SetRowStatusByTimestamp(uint64_t timestamp, QString const& status)
 {
     for (size_t i = 0; i < _rows.size(); ++i)

--- a/src/tools/dbtool-gui/Models/MigrationListModel.hpp
+++ b/src/tools/dbtool-gui/Models/MigrationListModel.hpp
@@ -117,6 +117,17 @@ class MigrationListModel: public QAbstractListModel
     /// Number of selected pending rows.
     [[nodiscard]] int SelectedCount() const noexcept;
 
+    /// Timestamps of rows whose status reflects the migration as applied —
+    /// `"applied"` and `"checksum-mismatch"` (the latter is "applied with a
+    /// stored checksum that disagrees with the freshly-computed one", which
+    /// is still applied as far as the DB is concerned). Order matches the
+    /// row order produced by `Refresh()`. Used by UI-thread accessors that
+    /// must NOT issue SQL while a worker-thread migration run is in flight
+    /// (a re-query on the shared `SqlConnection` would race the worker and
+    /// surface as HY000 "Connection is busy"). See
+    /// `AppController::currentReleaseLabel`.
+    [[nodiscard]] std::vector<uint64_t> AppliedTimestamps() const;
+
   signals:
     /// Emitted in addition to `dataChanged` so QML consumers that only care
     /// about "how many are selected" can connect a single slot.


### PR DESCRIPTION
Applying the full Lastrada migration set against MS SQL Server (411 migrations through `dbtool-gui`, or 356 through `dbtool`) intermittently failed with `HY000 [Microsoft][ODBC Driver 18 for SQL Server]Connection is busy with results for another command` on routine DDL like `IF NOT EXISTS (SELECT … FROM sys.columns …) ALTER TABLE … ADD …;`. Two independent root causes were involved — the CLI hit one of them, the GUI hit both.

## Changes

- **`SqlStatement::CloseCursor` now drains pending result sets via `SQLMoreResults` before `SQLFreeStmt(SQL_CLOSE)`.** SQL Server emits per-statement row-count / DONE_IN_PROC tokens for every statement in a T-SQL batch; with MARS off these stay pending on the connection and poison the next `SQLExecDirect`. `SQLMoreResults` is standard ODBC — SQLite and PostgreSQL drivers return `SQL_NO_DATA` on the first call, so the cost on single-statement queries is one no-op driver call.
- **`SET NOCOUNT ON;` on the SQL Server `sp_getapplock` / `sp_releaseapplock` batches** (defense in depth so neither path can leave tokens pending even if a future caller forgets to drain).
- **`AppController::currentReleaseLabel` no longer hits the database from the UI thread.** The original implementation called `MigrationManager::GetAppliedMigrationIds()` synchronously on QML binding evaluation, which fires on every `migrationsChanged()` signal — including the one emitted between every migration during an apply run. That `SELECT` raced the worker thread's `ApplySingleMigration` on the shared `SqlConnection`, surfacing as HY000 regardless of MARS or pending result sets. It now derives the applied set from the in-memory `MigrationListModel`, which is already kept in sync per row by `SetRowStatusByTimestamp` during runs.
- **`previewMigrationSql` short-circuits during a run.** `PreviewMigration` issues `INFORMATION_SCHEMA` queries via `MakeWidthLookup` and would hit the same race; this gates it on `_runner.phase() == Idle`.
- New `MigrationListModel::AppliedTimestamps()` accessor + two MSSQL-gated regression tests for the SQLMoreResults path.

The underlying `SqlConnection` remains not thread-safe; a structural fix (separate read-only UI connection or a connection-level mutex) is left as future work.
