### PR TITLE
Strip OS prefix from CMake preset names

### DIFF
--- a/.agent/cpp-guidelines.md
+++ b/.agent/cpp-guidelines.md
@@ -31,12 +31,12 @@ This file is the canonical, project-internal C++ ruleset. Contributors and agent
 ### Forbidden constructs
 - **C-style loops are forbidden.** Use range-based `for` and the views above.
 - **No raw owning pointers.** `std::unique_ptr` / `std::shared_ptr` for ownership, RAII for resources.
-- **No `NOLINT` suppressions** — fix the underlying issue clang-tidy reports. The `linux-clang-debug` preset enables `clang-tidy` automatically.
+- **No `NOLINT` suppressions** — fix the underlying issue clang-tidy reports. The `clang-debug` preset enables `clang-tidy` automatically.
 - **No new third-party dependencies** without strong justification — vcpkg manifest at `vcpkg.json` lists what we already accept.
 
 ### Tooling
 - Run **`clang-format`** on every changed file (project `.clang-format` is authoritative).
-- Build with the matching preset (`linux-clang-debug` / `windows-clangcl-debug`); resolve every warning — `PEDANTIC_COMPILER_WERROR=ON`.
+- Build with the matching preset (`clang-debug` / `clangcl-debug`); resolve every warning — `PEDANTIC_COMPILER_WERROR=ON`.
 - All changes must be covered by unit tests; aim to **increase** code coverage with every PR.
 
 ## 2. Lightweight-specific patterns
@@ -96,7 +96,7 @@ The library uses C++20 member pointers by default and supports a C++26 reflectio
 
 - `clang-format` clean
 - `clang-tidy` clean (no `NOLINT`s added)
-- `linux-clang-debug` builds with no warnings
+- `clang-debug` builds with no warnings
 - Tests run green against `sqlite3`, `mssql2022`, `postgres`
 - New public APIs have doxygen + `[[nodiscard]]` where relevant
 - No new `if (server == …)` outside `QueryFormatter/`

--- a/.agent/testing.md
+++ b/.agent/testing.md
@@ -67,10 +67,10 @@ python3 src/tests/test_dbtool.py --dbtool … --test-env postgres
 
 | Preset | What it gives you |
 |--------|-------------------|
-| `linux-clang-debug` | ASan + UBSan + clang-tidy + pedantic warnings |
-| `linux-clang-asan-ubsan` | ASan + UBSan, no tidy (faster build for repro) |
-| `linux-clang-tsan` | ThreadSanitizer (use for pool/migration-lock changes) |
-| `linux-clang-coverage` / `linux-gcc-coverage` | LCOV / gcov |
+| `clang-debug` | ASan + UBSan + clang-tidy + pedantic warnings |
+| `clang-asan-ubsan` | ASan + UBSan, no tidy (faster build for repro) |
+| `clang-tsan` | ThreadSanitizer (use for pool/migration-lock changes) |
+| `clang-coverage` / `gcc-coverage` | LCOV / gcov |
 
 CI runs valgrind on the SQLite3 matrix entry only:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,9 +80,9 @@ jobs:
       - name: "install dependencies"
         run: sudo apt install -y cmake ninja-build doxygen g++-14 catch2 unixodbc-dev sqlite3 libsqlite3-dev uuid-dev libyaml-cpp-dev libzip-dev
       - name: "cmake"
-        run: cmake --preset linux-gcc-release -D LIGHTWEIGHT_BUILD_DOCUMENTATION=ON -D LIGHTWEIGHT_DOCS_WARN_AS_ERROR=ON
+        run: cmake --preset gcc-release -D LIGHTWEIGHT_BUILD_DOCUMENTATION=ON -D LIGHTWEIGHT_DOCS_WARN_AS_ERROR=ON
       - name: "check documentation"
-        run: cmake --build --preset linux-gcc-release --target doc
+        run: cmake --build --preset gcc-release --target doc
 
   check_clang_tidy:
     name: "Check clang-tidy"
@@ -111,7 +111,7 @@ jobs:
         run: sudo apt install -y cmake ninja-build catch2 unixodbc-dev sqlite3 libsqlite3-dev libsqliteodbc uuid-dev libyaml-cpp-dev gcc-14 libtbb-dev libzip-dev
       - name: "cmake"
         run: |
-          cmake --preset linux-clang-debug \
+          cmake --preset clang-debug \
                 -D CMAKE_CXX_COMPILER=clang++-${{ env.CLANG_TOOLS_VERSION }} \
                 -D CMAKE_C_COMPILER=clang-${{ env.CLANG_TOOLS_VERSION }} \
                 -B build
@@ -124,7 +124,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        preset: ["windows-cl-debug", "windows-clangcl-debug"]
+        preset: ["cl-debug", "clangcl-debug"]
     name: "Windows-${{ matrix.preset }}"
     runs-on: windows-2025
     steps:
@@ -153,7 +153,7 @@ jobs:
       # NB: Don't run tests here; the windows_dbms_test_matrix job below runs
       # the suite against each supported database in parallel.
       - name: "Install (stage tests for upload)"
-        if: ${{ matrix.preset == 'windows-cl-debug' }}
+        if: ${{ matrix.preset == 'cl-debug' }}
         shell: pwsh
         run: |
           cmake --install out/build/${{ matrix.preset }} `
@@ -169,10 +169,10 @@ jobs:
                       -Force -ErrorAction SilentlyContinue
           }
       - name: "Upload unit tests"
-        if: ${{ matrix.preset == 'windows-cl-debug' }}
+        if: ${{ matrix.preset == 'cl-debug' }}
         uses: actions/upload-artifact@v4
         with:
-          name: windows-cl-debug-tests
+          name: cl-debug-tests
           path: out/install/${{ matrix.preset }}/
           retention-days: 1
 
@@ -198,7 +198,7 @@ jobs:
       - name: "Download unit test binaries"
         uses: actions/download-artifact@v4
         with:
-          name: windows-cl-debug-tests
+          name: cl-debug-tests
           path: install
       - name: "Install Python YAML"
         shell: pwsh
@@ -387,12 +387,12 @@ jobs:
               -DCMAKE_INSTALL_PREFIX="/usr/local" \
               -DPEDANTIC_COMPILER_WERROR=OFF \
               -DLIGHTWEIGHT_BUILD_SHARED=ON \
-              --preset linux-gcc-release
+              --preset gcc-release
       - name: "build"
-        run: cmake --build --preset linux-gcc-release -- -j3
+        run: cmake --build --preset gcc-release -- -j3
       # NB: Don't run the tests here, as we want to run them later for each individual database
       # - name: "tests"
-      #   run: ctest --preset linux-gcc-release
+      #   run: ctest --preset gcc-release
       # NB: Don't run valgrind test here, as we want to run them later for each individual database
       # - name: "Run tests through valgrind (without model tests)"
       #   run: |
@@ -401,13 +401,13 @@ jobs:
       #       --leak-check=full \
       #       --leak-resolution=high \
       #       --num-callers=64 \
-      #       out/build/linux-gcc-release/src/tests/LightweightTest '~[model]'
+      #       out/build/gcc-release/src/tests/LightweightTest '~[model]'
       - name: "package tar.gz"
         run: |
-          cpack --preset linux-gcc-release
-          cp out/package/linux-gcc-debug/Lightweight-*-Linux.tar.gz ./Lightweight-Linux-CI.tar.gz
+          cpack --preset gcc-release
+          cp out/package/gcc-debug/Lightweight-*-Linux.tar.gz ./Lightweight-Linux-CI.tar.gz
       - name: "Move tests to root directory"
-        run: mv out/build/linux-gcc-release/src/tests/LightweightTest .
+        run: mv out/build/gcc-release/src/tests/LightweightTest .
       - name: "Upload unit tests"
         if: ${{ matrix.compiler == 'GCC 14' && matrix.cxx == '23' }}
         uses: actions/upload-artifact@v4
@@ -474,7 +474,7 @@ jobs:
       - name: "Install build dependencies"
         run: sudo apt install -y cmake ninja-build catch2 unixodbc-dev sqlite3 libsqlite3-dev libsqliteodbc uuid-dev libyaml-cpp-dev g++-14 libstdc++-14-dev libzip-dev
       - name: "Configure cmake"
-        run: cmake --preset linux-gcc-release -B build -D CMAKE_CXX_COMPILER=g++-14 -D LIGHTWEIGHT_BUILD_MODULES=ON
+        run: cmake --preset gcc-release -B build -D CMAKE_CXX_COMPILER=g++-14 -D LIGHTWEIGHT_BUILD_MODULES=ON
       - name: "Build chinook example"
         run: cmake --build build --target chinook
       - name: "Run chinook example"
@@ -611,17 +611,17 @@ jobs:
           sudo sed -i 's/^\[SQLite3\]$/[SQLite3 ODBC Driver]/' /etc/odbcinst.ini
       - name: "cmake"
         run: |
-          cmake --preset linux-clang-${{ matrix.sanitizer }} \
+          cmake --preset clang-${{ matrix.sanitizer }} \
                 -D CMAKE_CXX_COMPILER=clang++-${{ env.CLANG_TOOLS_VERSION }} \
                 -D CMAKE_C_COMPILER=clang-${{ env.CLANG_TOOLS_VERSION }}
       - name: "build"
-        run: cmake --build --preset linux-clang-${{ matrix.sanitizer }} -- -j$(nproc)
+        run: cmake --build --preset clang-${{ matrix.sanitizer }} -- -j$(nproc)
       - name: "Run tests with ${{ matrix.sanitizer }}"
         env:
           ASAN_OPTIONS: "detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
           UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ github.workspace }}/.github/ubsan.suppressions"
           TSAN_OPTIONS: "second_deadlock_stack=1"
         run: |
-          ./out/build/linux-clang-${{ matrix.sanitizer }}/src/tests/LightweightTest --test-env=sqlite3
+          ./out/build/clang-${{ matrix.sanitizer }}/src/tests/LightweightTest --test-env=sqlite3
 
   # }}}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -36,12 +36,12 @@ jobs:
             libstdc++-14-dev
 
       - name: Configure CMake
-        run: cmake --preset linux-gcc-debug -D CMAKE_CXX_COMPILER=g++-14
+        run: cmake --preset gcc-debug -D CMAKE_CXX_COMPILER=g++-14
 
       - name: Build project
-        run: cmake --build --preset linux-gcc-debug -- -j$(nproc)
+        run: cmake --build --preset gcc-debug -- -j$(nproc)
 
       - name: Verify build
         run: |
           echo "Build completed successfully"
-          ls -la out/build/linux-gcc-debug/src/tests/LightweightTest
+          ls -la out/build/gcc-debug/src/tests/LightweightTest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,10 +43,10 @@ jobs:
         run: sudo apt install -y cmake ninja-build catch2 unixodbc-dev sqlite3 libsqlite3-dev libsqliteodbc valgrind uuid-dev g++-14 libyaml-cpp-dev doxygen
 
       - name: CMake configure
-        run: cmake --preset linux-gcc-release -D LIGHTWEIGHT_BUILD_DOCUMENTATION=ON
+        run: cmake --preset gcc-release -D LIGHTWEIGHT_BUILD_DOCUMENTATION=ON
 
       - name: Build documentation
-        run: cmake --build --preset linux-gcc-release --target doc
+        run: cmake --build --preset gcc-release --target doc
 
       # Build presentation
       - name: Setup Node.js

--- a/.vimspector.json
+++ b/.vimspector.json
@@ -5,7 +5,7 @@
             "adapter": "vscode-cpptools",
             "configuration": {
                 "request": "launch",
-                "program": "${workspaceRoot}/out/build/linux-clang-debug/src/tests/LightweightTest",
+                "program": "${workspaceRoot}/out/build/clang-debug/src/tests/LightweightTest",
                 "args": [
                     "--trace-sql", "BelongsTo"
                 ],
@@ -25,7 +25,7 @@
             "adapter": "vscode-cpptools",
             "configuration": {
                 "request": "launch",
-                "program": "${workspaceRoot}/out/build/linux-clang-debug/src/tests/LightweightTest",
+                "program": "${workspaceRoot}/out/build/clang-debug/src/tests/LightweightTest",
                 "args": [
                 ],
                 "environment": [
@@ -50,7 +50,7 @@
             "adapter": "vscode-cpptools",
             "configuration": {
                 "request": "launch",
-                "program": "${workspaceRoot}/out/build/linux-clang-debug/src/tests/LightweightTest",
+                "program": "${workspaceRoot}/out/build/clang-debug/src/tests/LightweightTest",
                 "args": [
                 ],
                 "environment": [
@@ -75,7 +75,7 @@
             "adapter": "vscode-cpptools",
             "configuration": {
                 "request": "launch",
-                "program": "${workspaceRoot}/out/build/linux-clang-debug/src/tests/LightweightTest",
+                "program": "${workspaceRoot}/out/build/clang-debug/src/tests/LightweightTest",
                 "args": [
                 ],
                 "environment": [

--- a/AGENT.md
+++ b/AGENT.md
@@ -81,7 +81,7 @@ Drive behaviour with descriptor tables, not scattered `switch (server)` ladders.
 - **`std::span`** for arrays and contiguous sequences.
 - **`auto` type deduction** for readability; **structured bindings** for tuple-like returns.
 - **`clang-format` after every change** — use the project `.clang-format`.
-- **`clang-tidy` reports must be fixed at the source.** Never silence with `NOLINT` — address the underlying issue. The `linux-clang-debug` preset enables `clang-tidy` automatically.
+- **`clang-tidy` reports must be fixed at the source.** Never silence with `NOLINT` — address the underlying issue. The `clang-debug` preset enables `clang-tidy` automatically.
 - **All changes covered by unit tests.** Aim to **increase** coverage with every PR.
 - **No raw owning pointers.** Use `std::unique_ptr` / `std::shared_ptr` for ownership; RAII for resources.
 - **No new third-party dependencies** without strong justification.
@@ -100,29 +100,29 @@ Drive behaviour with descriptor tables, not scattered `switch (server)` ladders.
 CMake presets live in `CMakePresets.json`. Common entry points:
 
 ```sh
-# Linux — Clang Debug with PEDANTIC + ASan + UBSan + clang-tidy (the default agent preset)
-cmake --preset linux-clang-debug
-cmake --build --preset linux-clang-debug
-ctest --preset linux-clang-debug
+# Clang Debug with PEDANTIC + ASan + UBSan + clang-tidy (the default agent preset; Linux + macOS)
+cmake --preset clang-debug
+cmake --build --preset clang-debug
+ctest --preset clang-debug
 
 # Linux — GCC Debug
-cmake --preset linux-gcc-debug && cmake --build --preset linux-gcc-debug
+cmake --preset gcc-debug && cmake --build --preset gcc-debug
 
-# Linux — Coverage (HTML in out/build/linux-clang-coverage/)
-cmake --preset linux-clang-coverage
-cmake --build --preset linux-clang-coverage
+# Linux — Coverage (HTML in out/build/clang-coverage/)
+cmake --preset clang-coverage
+cmake --build --preset clang-coverage
 
 # Linux — sanitizer-only presets
-cmake --preset linux-clang-asan-ubsan
-cmake --preset linux-clang-tsan
+cmake --preset clang-asan-ubsan
+cmake --preset clang-tsan
 
 # Windows — MSVC CL Debug (requires VCPKG_ROOT in env)
-cmake --preset windows-cl-debug
-cmake --build --preset windows-cl-debug
+cmake --preset cl-debug
+cmake --build --preset cl-debug
 
 # Windows — clang-cl Debug
-cmake --preset windows-clangcl-debug
-cmake --build --preset windows-clangcl-debug
+cmake --preset clangcl-debug
+cmake --build --preset clangcl-debug
 ```
 
 `PEDANTIC_COMPILER_WERROR=ON` is the default for Windows presets — warnings break the build, fix them at the source.
@@ -165,9 +165,9 @@ LightweightTest --test-env=postgres
 # 4. Run the dbtool integration suite per DB. The script needs the dbtool
 #    binary and the directory holding the dummy_migration_plugin DLLs that
 #    its test fixtures dlopen. Adjust paths to your build dir (the example
-#    below is for the windows-clangcl-debug preset).
-DBTOOL=$PWD/out/build/windows-clangcl-debug/target/dbtool.exe
-PLUGINS=$PWD/out/build/windows-clangcl-debug/tests/plugins
+#    below is for the clangcl-debug preset).
+DBTOOL=$PWD/out/build/clangcl-debug/target/dbtool.exe
+PLUGINS=$PWD/out/build/clangcl-debug/tests/plugins
 python3 src/tests/test_dbtool.py --dbtool "$DBTOOL" --plugins-dir "$PLUGINS" --test-env sqlite3
 python3 src/tests/test_dbtool.py --dbtool "$DBTOOL" --plugins-dir "$PLUGINS" --test-env mssql2022
 python3 src/tests/test_dbtool.py --dbtool "$DBTOOL" --plugins-dir "$PLUGINS" --test-env postgres
@@ -205,14 +205,14 @@ Add the capability check to `SqlQueryFormatter` (e.g., `bool SupportsX() const`)
 ## Workflow (post-implementation checklist)
 
 1. Run `clang-format` on every changed `.hpp` / `.cpp` (project `.clang-format`).
-2. Build the relevant preset (`linux-clang-debug` for full coverage of warnings + clang-tidy + ASan/UBSan; `windows-clangcl-debug` if Windows-side changes). Resolve all warnings — `PEDANTIC_COMPILER_WERROR` is on.
+2. Build the relevant preset (`clang-debug` for full coverage of warnings + clang-tidy + ASan/UBSan; `clangcl-debug` if Windows-side changes). Resolve all warnings — `PEDANTIC_COMPILER_WERROR` is on.
 3. **Run the full test suite against every supported database.** At minimum: `sqlite3`, `mssql2022`, `postgres`. Use `scripts/tests/docker-databases.py --start --wait mssql2022 postgres` to spin up the non-SQLite containers. Document any DB skipped with the reason.
-4. Run `clang-tidy` (it runs automatically under `linux-clang-debug`); fix every finding at the source — never `NOLINT`.
+4. Run `clang-tidy` (it runs automatically under `clang-debug`); fix every finding at the source — never `NOLINT`.
 5. If touching public headers or user-visible behaviour, update `docs/` (`data-binder.md`, `sql-migrations.md`, `dbtool.md`, `usage.md`, `how-to.md`, `best-practices.md`, etc.).
-6. Run the sanitizer presets when relevant (`linux-clang-asan-ubsan`, `linux-clang-tsan`) — required for changes touching pools, threading, or raw buffer arithmetic.
+6. Run the sanitizer presets when relevant (`clang-asan-ubsan`, `clang-tsan`) — required for changes touching pools, threading, or raw buffer arithmetic.
 7. Execute `/simplify` to reduce duplication and code-quality issues. If the simplify pass surfaces issues out of scope, **ask** the user whether to address them in this PR; if yes, include them; if no, ignore and move on.
 8. In the PR / commit summary include:
    - **Performance impact** — with measurements where possible (use `src/benchmark/` if applicable).
    - **Risk assessment** — what could break per DBMS, threading, ABI, ODBC version compatibility.
-   - **Code coverage** — results from `linux-clang-coverage` if coverage was a goal.
+   - **Code coverage** — results from `clang-coverage` if coverage was a goal.
    - **Databases tested** — explicit list with versions (`sqlite3`, `mssql2022 (Docker)`, `postgres (Docker 16.4)`).

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -37,8 +37,8 @@
                 "CMAKE_CXX_COMPILER": "cl"
             }
         },
-        { "name": "windows-cl-debug",   "inherits": ["windows-cl-common"], "displayName": "Windows - MSVC CL - Debug"   },
-        { "name": "windows-cl-release", "inherits": ["windows-cl-common"], "displayName": "Windows - MSVC CL - Release" },
+        { "name": "cl-debug",   "inherits": ["windows-cl-common"], "displayName": "MSVC CL Debug"   },
+        { "name": "cl-release", "inherits": ["windows-cl-common"], "displayName": "MSVC CL Release" },
         {
             "name": "windows-clangcl-common",
             "hidden": true,
@@ -48,10 +48,9 @@
                 "CMAKE_C_COMPILER": "clang-cl"
             }
         },
-        { "name": "windows-clangcl-debug",  "inherits": ["windows-clangcl-common"], "displayName": "Windows - MSVC ClangCL - Debug",   "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug"   } },
-        { "name": "windows-clangcl-release","inherits": ["windows-clangcl-common"], "displayName": "Windows - MSVC ClangCL - Release", "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" } },
+        { "name": "clangcl-debug",  "inherits": ["windows-clangcl-common"], "displayName": "MSVC ClangCL Debug",   "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug"   } },
+        { "name": "clangcl-release","inherits": ["windows-clangcl-common"], "displayName": "MSVC ClangCL Release", "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" } },
         { "name": "linux-common",           "hidden": true, "inherits": ["common"], "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Linux" } },
-        { "name": "macos-common",           "hidden": true, "inherits": ["common"], "condition": { "lhs": "${hostSystemName}", "type": "equals", "rhs": "Darwin" } },
         { "name": "debug",                  "hidden": true, "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" } },
         { "name": "release",                "hidden": true, "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" } },
         { "name": "pedantic",               "hidden": true, "cacheVariables": { "PEDANTIC_COMPILER": "ON", "PEDANTIC_COMPILER_WERROR": "ON" } },
@@ -61,60 +60,86 @@
         { "name": "linux-common-release",   "hidden": true, "inherits": "release",      "cacheVariables": { "CMAKE_INSTALL_PREFIX": "/usr/local" } },
         { "name": "linux-clang",            "hidden": true, "inherits": "linux-common", "cacheVariables": { "CMAKE_CXX_COMPILER": "clang++" } },
         { "name": "linux-gcc",              "hidden": true, "inherits": "linux-common", "cacheVariables": { "CMAKE_CXX_COMPILER": "g++" } },
-        { "name": "linux-clang-release",    "displayName": "Linux (Clang) Release", "inherits": ["linux-clang", "linux-common-release"] },
-        { "name": "linux-clang-debug",      "displayName": "Linux (Clang) Debug", "inherits": ["linux-clang", "debug", "pedantic", "asan-ubsan"], "cacheVariables": { "ENABLE_TIDY": "ON" } },
-        { "name": "linux-gcc-release",      "displayName": "Linux (GCC) Release", "inherits": ["linux-gcc", "linux-common-release"] },
-        { "name": "linux-gcc-debug",        "displayName": "Linux (GCC) Debug", "inherits": ["linux-gcc", "debug", "pedantic"] },
-        { "name": "linux-clang-asan-ubsan", "displayName": "Linux (Clang) ASan+UBSan", "inherits": ["linux-clang", "debug", "asan-ubsan"] },
-        { "name": "linux-clang-tsan",       "displayName": "Linux (Clang) ThreadSanitizer", "inherits": ["linux-clang", "debug", "tsan"] },
-        { "name": "linux-clang-coverage",   "displayName": "Linux (Clang) Coverage", "inherits": ["linux-clang", "debug", "coverage"] },
-        { "name": "linux-gcc-coverage",     "displayName": "Linux (GCC) Coverage", "inherits": ["linux-gcc", "debug", "coverage"] },
-        { "name": "macos-release",          "displayName": "MacOS Release", "inherits": ["macos-common", "release"] },
-        { "name": "macos-debug",            "displayName": "MacOS Debug", "inherits": ["macos-common", "debug"] }
+        {
+            "name": "clang-release",
+            "displayName": "Clang Release",
+            "inherits": ["common", "release"],
+            "condition": {
+                "type": "anyOf",
+                "conditions": [
+                    { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Linux" },
+                    { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Darwin" }
+                ]
+            },
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_INSTALL_PREFIX": "/usr/local"
+            }
+        },
+        {
+            "name": "clang-debug",
+            "displayName": "Clang Debug",
+            "inherits": ["common", "debug", "pedantic", "asan-ubsan"],
+            "condition": {
+                "type": "anyOf",
+                "conditions": [
+                    { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Linux" },
+                    { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Darwin" }
+                ]
+            },
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER": "clang++",
+                "ENABLE_TIDY": "ON"
+            }
+        },
+        { "name": "gcc-release",      "displayName": "GCC Release", "inherits": ["linux-gcc", "linux-common-release"] },
+        { "name": "gcc-debug",        "displayName": "GCC Debug", "inherits": ["linux-gcc", "debug", "pedantic"] },
+        { "name": "clang-asan-ubsan", "displayName": "Clang ASan+UBSan", "inherits": ["linux-clang", "debug", "asan-ubsan"] },
+        { "name": "clang-tsan",       "displayName": "Clang ThreadSanitizer", "inherits": ["linux-clang", "debug", "tsan"] },
+        { "name": "clang-coverage",   "displayName": "Clang Coverage", "inherits": ["linux-clang", "debug", "coverage"] },
+        { "name": "gcc-coverage",     "displayName": "GCC Coverage", "inherits": ["linux-gcc", "debug", "coverage"] }
     ],
     "buildPresets": [
-        { "name": "windows-cl-debug",        "displayName": "Windows - MSVC CL - Debug",        "configurePreset": "windows-cl-debug",        "configuration": "Debug" },
-        { "name": "windows-cl-release",      "displayName": "Windows - MSVC CL - Release",      "configurePreset": "windows-cl-release",      "configuration": "Release" },
-        { "name": "windows-clangcl-debug",   "displayName": "Windows - MSVC ClangCL - Debug",   "configurePreset": "windows-clangcl-debug",   "configuration": "Debug" },
-        { "name": "windows-clangcl-release", "displayName": "Windows - MSVC ClangCL - Release", "configurePreset": "windows-clangcl-release", "configuration": "Release" },
-        { "name": "linux-clang-debug",       "displayName": "Linux - Clang - Debug", "configurePreset": "linux-clang-debug" },
-        { "name": "linux-clang-release",     "displayName": "Linux - Clang - RelWithDebInfo", "configurePreset": "linux-clang-release" },
-        { "name": "linux-gcc-debug",         "displayName": "Linux - GCC - Debug", "configurePreset": "linux-gcc-debug" },
-        { "name": "linux-gcc-release",       "displayName": "Linux - GCC - RelWithDebInfo", "configurePreset": "linux-gcc-release" },
-        { "name": "macos-debug",             "displayName": "MacOS - Debug", "configurePreset": "macos-debug" },
-        { "name": "macos-release",           "displayName": "MacOS - RelWithDebInfo", "configurePreset": "macos-release" },
-        { "name": "linux-clang-asan-ubsan",  "displayName": "Linux - Clang - ASan+UBSan", "configurePreset": "linux-clang-asan-ubsan" },
-        { "name": "linux-clang-tsan",        "displayName": "Linux - Clang - ThreadSanitizer", "configurePreset": "linux-clang-tsan" },
-        { "name": "linux-clang-coverage",    "displayName": "Linux - Clang - Coverage", "configurePreset": "linux-clang-coverage" },
-        { "name": "linux-gcc-coverage",      "displayName": "Linux - GCC - Coverage", "configurePreset": "linux-gcc-coverage" }
+        { "name": "cl-debug",        "displayName": "MSVC CL Debug",        "configurePreset": "cl-debug",        "configuration": "Debug" },
+        { "name": "cl-release",      "displayName": "MSVC CL Release",      "configurePreset": "cl-release",      "configuration": "Release" },
+        { "name": "clangcl-debug",   "displayName": "MSVC ClangCL Debug",   "configurePreset": "clangcl-debug",   "configuration": "Debug" },
+        { "name": "clangcl-release", "displayName": "MSVC ClangCL Release", "configurePreset": "clangcl-release", "configuration": "Release" },
+        { "name": "clang-debug",       "displayName": "Clang Debug", "configurePreset": "clang-debug" },
+        { "name": "clang-release",     "displayName": "Clang RelWithDebInfo", "configurePreset": "clang-release" },
+        { "name": "gcc-debug",         "displayName": "GCC Debug", "configurePreset": "gcc-debug" },
+        { "name": "gcc-release",       "displayName": "GCC RelWithDebInfo", "configurePreset": "gcc-release" },
+        { "name": "clang-asan-ubsan",  "displayName": "Clang ASan+UBSan", "configurePreset": "clang-asan-ubsan" },
+        { "name": "clang-tsan",        "displayName": "Clang ThreadSanitizer", "configurePreset": "clang-tsan" },
+        { "name": "clang-coverage",    "displayName": "Clang Coverage", "configurePreset": "clang-coverage" },
+        { "name": "gcc-coverage",      "displayName": "GCC Coverage", "configurePreset": "gcc-coverage" }
     ],
     "testPresets": [
-        { "name": "windows-cl-debug", "configurePreset": "windows-cl-debug", "configuration": "Debug", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
-        { "name": "windows-cl-release", "configurePreset": "windows-cl-release", "configuration": "Release", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
-        { "name": "windows-clangcl-debug", "configurePreset": "windows-clangcl-debug", "configuration": "Debug", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
-        { "name": "windows-clangcl-release", "configurePreset": "windows-clangcl-release", "configuration": "Release", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
-        { "name": "linux-gcc-debug", "configurePreset": "linux-gcc-debug", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
-        { "name": "linux-gcc-release", "configurePreset": "linux-gcc-release", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
-        { "name": "linux-clang-debug", "configurePreset": "linux-clang-debug", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
-        { "name": "linux-clang-release", "configurePreset": "linux-clang-release", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
-        { "name": "linux-clang-asan-ubsan", "configurePreset": "linux-clang-asan-ubsan", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
-        { "name": "linux-clang-tsan", "configurePreset": "linux-clang-tsan", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
-        { "name": "linux-clang-coverage", "configurePreset": "linux-clang-coverage", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
-        { "name": "linux-gcc-coverage", "configurePreset": "linux-gcc-coverage", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } }
+        { "name": "cl-debug", "configurePreset": "cl-debug", "configuration": "Debug", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
+        { "name": "cl-release", "configurePreset": "cl-release", "configuration": "Release", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
+        { "name": "clangcl-debug", "configurePreset": "clangcl-debug", "configuration": "Debug", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
+        { "name": "clangcl-release", "configurePreset": "clangcl-release", "configuration": "Release", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
+        { "name": "gcc-debug", "configurePreset": "gcc-debug", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
+        { "name": "gcc-release", "configurePreset": "gcc-release", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
+        { "name": "clang-debug", "configurePreset": "clang-debug", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
+        { "name": "clang-release", "configurePreset": "clang-release", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
+        { "name": "clang-asan-ubsan", "configurePreset": "clang-asan-ubsan", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
+        { "name": "clang-tsan", "configurePreset": "clang-tsan", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
+        { "name": "clang-coverage", "configurePreset": "clang-coverage", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
+        { "name": "gcc-coverage", "configurePreset": "gcc-coverage", "output": {"outputOnFailure": true}, "execution": { "noTestsAction": "error", "stopOnFailure": true } }
     ],
     "packagePresets": [
         {
-            "name": "linux-gcc-debug",
+            "name": "gcc-debug",
             "packageName": "Lightweight",
-            "packageDirectory": "${sourceDir}/out/package/linux-gcc-debug",
-            "configurePreset": "linux-gcc-debug",
+            "packageDirectory": "${sourceDir}/out/package/gcc-debug",
+            "configurePreset": "gcc-debug",
             "generators": [ "TGZ" ]
         },
         {
-            "name": "linux-gcc-release",
+            "name": "gcc-release",
             "packageName": "Lightweight",
-            "packageDirectory": "${sourceDir}/out/package/linux-gcc-debug",
-            "configurePreset": "linux-gcc-release",
+            "packageDirectory": "${sourceDir}/out/package/gcc-debug",
+            "configurePreset": "gcc-release",
             "generators": [ "TGZ" ]
         }
     ]

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ NamingConvention: CamelCase
 Now you can configure cmake to compile example
 
 ``` sh
-cmake --preset linux-clang-debug -DLIGHWEIGHT_EXAMPLE=ON -B build
+cmake --preset clang-debug -DLIGHWEIGHT_EXAMPLE=ON -B build
 ```
 
 Finally, compile and run the example

--- a/cmake/Coverage.cmake
+++ b/cmake/Coverage.cmake
@@ -15,9 +15,9 @@
 #   - genhtml (for HTML report generation)
 #
 # Usage:
-#   cmake --preset linux-clang-coverage
-#   cmake --build --preset linux-clang-coverage
-#   cmake --build --preset linux-clang-coverage --target coverage
+#   cmake --preset clang-coverage
+#   cmake --build --preset clang-coverage
+#   cmake --build --preset clang-coverage --target coverage
 
 option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
 

--- a/docs/dbtool.md
+++ b/docs/dbtool.md
@@ -17,11 +17,11 @@ Key features:
 Build dbtool as part of the Lightweight project:
 
 ```bash
-cmake --preset linux-clang-release
-cmake --build out/build/linux-clang-release --target dbtool
+cmake --preset clang-release
+cmake --build out/build/clang-release --target dbtool
 ```
 
-The binary will be located at `out/build/linux-clang-release/src/tools/dbtool/dbtool`.
+The binary will be located at `out/build/clang-release/src/tools/dbtool/dbtool`.
 
 ## Configuration
 

--- a/docs/lup-migration-plugin.md
+++ b/docs/lup-migration-plugin.md
@@ -77,23 +77,23 @@ lup2dbtool guarantees:
 
 1. Generate migrations using lup2dbtool:
 ```bash
-./out/build/linux-clang-debug/src/tools/lup2dbtool/lup2dbtool \
+./out/build/clang-debug/src/tools/lup2dbtool/lup2dbtool \
     --input-dir /path/to/legacy_sql_migrations_dir \
     --output ./src/tools/LupMigrationsPlugin/generated/GeneratedMigrations.cpp
 ```
 
 2. Build the plugin:
 ```bash
-cmake --build ./out/build/linux-clang-debug --target LupMigrationsPlugin
+cmake --build ./out/build/clang-debug --target LupMigrationsPlugin
 ```
 
-3. The plugin is output to `out/build/linux-clang-debug/plugins/LupMigrationsPlugin.so`
+3. The plugin is output to `out/build/clang-debug/plugins/LupMigrationsPlugin.so`
 
 ### Using with dbtool
 
 ```bash
-./out/build/linux-clang-debug/src/tools/dbtool/dbtool migrate \
-    --plugins-dir ./out/build/linux-clang-debug/plugins \
+./out/build/clang-debug/src/tools/dbtool/dbtool migrate \
+    --plugins-dir ./out/build/clang-debug/plugins \
     --connection-string "DRIVER=SQLite3;Database=lup.db"
 ```
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -119,7 +119,7 @@ enable_testing()
 
 # Optional extra arguments to pass to test executables
 # Usage: cmake -DLIGHTWEIGHT_TEST_ARGS="--test-env=sqlite3" ...
-# Or:    ctest --preset linux-clang-debug (after configuring with the above)
+# Or:    ctest --preset clang-debug (after configuring with the above)
 set(LIGHTWEIGHT_TEST_ARGS "" CACHE STRING "Extra arguments to pass to test executables")
 separate_arguments(LIGHTWEIGHT_TEST_ARGS_LIST NATIVE_COMMAND "${LIGHTWEIGHT_TEST_ARGS}")
 

--- a/src/tools/test_chinook.sh
+++ b/src/tools/test_chinook.sh
@@ -6,7 +6,7 @@
 set -e
 
 PROJECT_ROOT="$(realpath $(dirname "$0")/../..)"
-BUILD_DIR="${PROJECT_ROOT}/out/build/linux-clang-debug"
+BUILD_DIR="${PROJECT_ROOT}/out/build/clang-debug"
 DDL2CPP="${DDL2CPP:-${BUILD_DIR}/src/tools/ddl2cpp}"
 TEST_ENV=""
 


### PR DESCRIPTION
Public CMake preset names used to lead with the host OS (`linux-clang-debug`, `windows-clangcl-debug`, `macos-debug`, ...). For developers who hop between platforms on the same checkout this was redundant noise — each preset is already gated by `hostSystemName`, so the OS segment never disambiguated two usable presets, it only lengthened typing and broke shell history when switching machines. This PR strips the prefix.

## Changes

- Renamed public configure/build/test/package presets (matching build/test/package entries renamed in lockstep):
  - `linux-clang-debug` + `macos-debug` -> `clang-debug`
  - `linux-clang-release` + `macos-release` -> `clang-release`
  - `linux-gcc-{debug,release,coverage}` -> `gcc-{debug,release,coverage}`
  - `linux-clang-{asan-ubsan,tsan,coverage}` -> `clang-{asan-ubsan,tsan,coverage}`
  - `windows-cl-{debug,release}` -> `cl-{debug,release}`
  - `windows-clangcl-{debug,release}` -> `clangcl-{debug,release}`
- `clang-debug` and `clang-release` are now single presets gated by `anyOf Linux/Darwin`. macOS gains pedantic + ASan + UBSan + clang-tidy under `clang-debug` (deliberate behavior change; macOS users will need `clang-tidy` on `PATH`).
- Hidden helpers untouched, except `macos-common` (no remaining consumers after the merge) which is removed.
- Updated every downstream reference: CI workflows (`build.yml`, `docs.yml`, `copilot-setup-steps.yml`) including the renamed `cl-debug-tests` artifact and build/package paths under `out/build/<preset>/` and `out/package/<preset>/`; agent guidelines (`AGENT.md`, `.agent/cpp-guidelines.md`, `.agent/testing.md`); user docs (`docs/dbtool.md`, `docs/lup-migration-plugin.md`); `README.md`; `.vimspector.json` debugger program paths; `src/tools/test_chinook.sh` `BUILD_DIR`; `cmake/Coverage.cmake` usage comment; `src/tests/CMakeLists.txt` comment.

Note for developers pulling this change: existing `out/build/linux-clang-debug/` etc. directories become orphaned and can be safely deleted.