### PR TITLE
Extend query builder to have sub query builder for optional values

### DIFF
--- a/docs/sqlquery.md
+++ b/docs/sqlquery.md
@@ -94,6 +94,34 @@ interface. Here we present a compressed list of functions that can be used to cr
     - `Where(SqlQualifiedTableColumnName { .tableName = "Table_A", .columnName = "a" }, 42)` such call translated into `WHERE "Table_A"."a" = 42`
   - `Or()`, `And()` and `Not()` logical functions to apply to the next call
     - Example of usage `Where("a",1).Or().Where("b",1)`
+  - `If(optional).ThenWhere(column[, binaryOp])` — conditional WHERE driven by a `std::optional`
+    - `ThenWhere(column)` appends `WHERE column = *value` only when the optional holds a value; when the optional is empty the call is a no-op and the underlying query is left untouched. Returns the underlying builder, so it can be chained between other clauses.
+    - `ThenWhere(column, binaryOp)` mirrors `Where(column, binaryOp, value)` — emits `WHERE column <binaryOp> *value` (e.g. `">="`, `"<"`, `"!="`, `"LIKE"`) under the same empty/populated rules. Useful for range-style filters over `SqlDateTime`, numeric columns, etc.
+    - Works with any column-name overload accepted by `Where` — plain strings, `SqlQualifiedTableColumnName`, and `FullyQualifiedNameOf<&Record::field>`.
+    - Available on every builder that derives from `SqlWhereClauseBuilder`: `Select`, `Update`, and `Delete`.
+    - Example — combining equality and range filters, any of which can be absent:
+      ```cpp
+      std::optional<int>         userId = MaybeUserIdFromRequest();
+      std::optional<SqlDateTime> since  = MaybeSinceFromRequest();
+      std::optional<SqlDateTime> until  = MaybeUntilFromRequest();
+
+      auto query = q.FromTable("Events")
+                    .Select()
+                    .Field("id")
+                    .If(userId).ThenWhere(FullyQualifiedNameOf<&Events::userId>)
+                    .If(since).ThenWhere(FullyQualifiedNameOf<&Events::createdAt>, ">=")
+                    .If(until).ThenWhere(FullyQualifiedNameOf<&Events::createdAt>, "<")
+                    .OrderBy("id")
+                    .All();
+      // userId={42}, since={2026-01-01}, until={2026-05-18T12:30:45}
+      //   -> WHERE "Events"."userId" = 42
+      //      AND "Events"."createdAt" >= '2026-01-01T00:00:00.000'
+      //      AND "Events"."createdAt" <  '2026-05-18T12:30:45.000'
+      // userId={}, since={}, until={2026-05-18T12:30:45}
+      //   -> WHERE "Events"."createdAt" < '2026-05-18T12:30:45.000'
+      // userId={}, since={}, until={}
+      //   -> no WHERE clause is emitted
+      ```
   -  `Inner`|`LeftOuter`|`RightOuter`|`FullOuter` + `Join`
     - See documentation for `SqlJoinConditionBuilder` for details 
 - End

--- a/src/Lightweight/Lightweight.cppm
+++ b/src/Lightweight/Lightweight.cppm
@@ -43,7 +43,6 @@ using Lightweight::FieldWithStorage;
 using Lightweight::FormatName;
 using Lightweight::FormatType;
 using Lightweight::FullyQualifiedNameOf;
-using Lightweight::FullyQualifiedNamesOf;
 using Lightweight::GetPrimaryKeyField;
 using Lightweight::HasAutoIncrementPrimaryKey;
 using Lightweight::HasMany;
@@ -216,9 +215,7 @@ using Lightweight::Unwrap;
 
 using Lightweight::is_belongs_to;
 
-using Lightweight::operator!=;
 using Lightweight::operator<<;
-using Lightweight::operator==;
 
 namespace Aggregate
 {

--- a/src/Lightweight/SqlQuery/Core.hpp
+++ b/src/Lightweight/SqlQuery/Core.hpp
@@ -1009,6 +1009,7 @@ namespace detail
 
 } // namespace detail
 
+/// Starts a conditional WHERE chain gated by a `std::optional` value.
 template <typename Derived>
 template <typename T>
 inline LIGHTWEIGHT_FORCE_INLINE auto SqlWhereClauseBuilder<Derived>::If(std::optional<T> const& value) noexcept

--- a/src/Lightweight/SqlQuery/Core.hpp
+++ b/src/Lightweight/SqlQuery/Core.hpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <concepts>
+#include <optional>
 #include <ranges>
 
 namespace Lightweight
@@ -209,6 +210,33 @@ class [[nodiscard]] SqlWhereClauseBuilder
 
     /// Constructs or extends a raw WHERE clause.
     [[nodiscard]] Derived& WhereRaw(std::string_view sqlConditionExpression);
+
+    /// @brief Starts a conditional WHERE chain driven by a `std::optional<T>` value.
+    ///
+    /// The returned sub-builder exposes two `ThenWhere` overloads:
+    /// `ThenWhere(column)` appends `WHERE column = *value`, and
+    /// `ThenWhere(column, binaryOp)` appends `WHERE column <binaryOp> *value`
+    /// (e.g. `">="`, `"<"`, `"!="`). Both overloads emit nothing when @p value
+    /// is empty and return the underlying builder for further chaining.
+    ///
+    /// The optional is captured by reference and must outlive the chain.
+    ///
+    /// @tparam T The contained value type held by the optional.
+    /// @param value The optional whose presence gates the conditional WHERE.
+    /// @return A sub-builder exposing `ThenWhere(column)` and `ThenWhere(column, binaryOp)`.
+    ///
+    /// Example:
+    /// @code
+    /// std::optional<int> val { 42 };
+    /// builder.If(val).ThenWhere(FullyQualifiedNameOf<&Table::value>);
+    /// // Appends: WHERE "Table"."value" = 42
+    ///
+    /// std::optional<SqlDateTime> since = ...;
+    /// builder.If(since).ThenWhere(FullyQualifiedNameOf<&Events::createdAt>, ">=");
+    /// // Appends: WHERE "Events"."createdAt" >= '2026-05-18T12:30:45.000'  (when since holds a value)
+    /// @endcode
+    template <typename T>
+    [[nodiscard]] auto If(std::optional<T> const& value) noexcept;
 
     /// Constructs or extends a WHERE clause to test for a binary operation.
     template <typename ColumnName, typename T>
@@ -911,6 +939,81 @@ template <typename OnChainCallable>
 Derived& SqlWhereClauseBuilder<Derived>::FullOuterJoin(TableName auto joinTable, OnChainCallable const& onClauseBuilder)
 {
     return Join(JoinType::FULL, joinTable, onClauseBuilder);
+}
+
+namespace detail
+{
+
+    /// @brief Sub-builder returned by `SqlWhereClauseBuilder::If`.
+    ///
+    /// Captures the underlying builder and a gating `std::optional`. Calling
+    /// `ThenWhere(column)` or `ThenWhere(column, binaryOp)` commits the chain:
+    /// when the optional holds a value it appends `WHERE column = *value` (or
+    /// `WHERE column <binaryOp> *value` for the explicit-operator overload);
+    /// either way it returns the underlying builder so further methods can be
+    /// chained.
+    template <typename Derived, typename T>
+    class [[nodiscard]] ConditionalWhereBuilder
+    {
+      public:
+        /// Constructs the sub-builder, binding to the underlying builder and the gating optional.
+        constexpr ConditionalWhereBuilder(Derived& builder, std::optional<T> const& value) noexcept:
+            _builder { builder },
+            _value { value }
+        {
+        }
+
+        /// Commits the conditional WHERE for @p column. Appends
+        /// `WHERE column = *value` when the gating optional holds a value;
+        /// otherwise the builder is left untouched.
+        /// @param column The column name (string, `SqlQualifiedTableColumnName`, etc.).
+        /// @return Reference to the underlying query builder.
+        template <typename ColumnName>
+        [[nodiscard]] Derived& ThenWhere(ColumnName const& column) const
+        {
+            if (_value.has_value())
+                return _builder.Where(column, *_value);
+            return _builder;
+        }
+
+        /// Commits the conditional WHERE for @p column using an explicit binary
+        /// operator. Appends `WHERE column <binaryOp> *value` when the gating
+        /// optional holds a value; otherwise the builder is left untouched.
+        /// Mirrors the `Where(column, binaryOp, value)` overload — use it for
+        /// range-style filters such as `">="`, `"<"`, `"!="`, or `"LIKE"`.
+        /// @param column The column name (string, `SqlQualifiedTableColumnName`, etc.).
+        /// @param binaryOp The SQL binary operator (e.g. `">="`, `"<"`, `"!="`).
+        /// @return Reference to the underlying query builder.
+        ///
+        /// Example:
+        /// @code
+        /// std::optional<SqlDateTime> since = ...;
+        /// std::optional<SqlDateTime> until = ...;
+        /// q.FromTable("Events").Select().Field("id")
+        ///     .If(since).ThenWhere(FullyQualifiedNameOf<&Events::createdAt>, ">=")
+        ///     .If(until).ThenWhere(FullyQualifiedNameOf<&Events::createdAt>, "<")
+        ///     .All();
+        /// @endcode
+        template <typename ColumnName>
+        [[nodiscard]] Derived& ThenWhere(ColumnName const& column, std::string_view binaryOp) const
+        {
+            if (_value.has_value())
+                return _builder.Where(column, binaryOp, *_value);
+            return _builder;
+        }
+
+      private:
+        Derived& _builder;
+        std::optional<T> const& _value;
+    };
+
+} // namespace detail
+
+template <typename Derived>
+template <typename T>
+inline LIGHTWEIGHT_FORCE_INLINE auto SqlWhereClauseBuilder<Derived>::If(std::optional<T> const& value) noexcept
+{
+    return detail::ConditionalWhereBuilder<Derived, T> { static_cast<Derived&>(*this), value };
 }
 
 template <typename Derived>

--- a/src/Lightweight/SqlSchema.hpp
+++ b/src/Lightweight/SqlSchema.hpp
@@ -59,19 +59,24 @@ namespace SqlSchema
     /// `Lightweight::SqlQualifiedTableColumnName`.
     struct ColumnIdentifier
     {
+        /// Fully qualified table the column belongs to.
         FullyQualifiedTableName table;
+        /// Column name within the table.
         std::string column;
 
+        /// Equality compares both the owning table and the column name.
         bool operator==(ColumnIdentifier const& other) const noexcept
         {
             return table == other.table && column == other.column;
         }
 
+        /// Inequality is the negation of equality.
         bool operator!=(ColumnIdentifier const& other) const noexcept
         {
             return !(*this == other);
         }
 
+        /// Lexicographic ordering by (table, column) so ColumnIdentifier can be used as a key in ordered containers.
         bool operator<(ColumnIdentifier const& other) const noexcept
         {
             return std::tie(table, column) < std::tie(other.table, other.column);
@@ -81,7 +86,9 @@ namespace SqlSchema
     /// Identifies an ordered set of columns within a single table (for composite keys / indexes).
     struct ColumnIdentifierSequence
     {
+        /// Fully qualified table the column sequence belongs to.
         FullyQualifiedTableName table;
+        /// Ordered list of column names (order is significant for composite keys / indexes).
         std::vector<std::string> columns;
     };
 

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -383,7 +383,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.IfThenWhere FullyQualifi
                 .Select()
                 .Field("a")
                 .If(populated)
-                .ThenWhere(FullyQualifiedNameOf<&IfThenWhereTable::value>)
+                .ThenWhere(FullyQualifiedNameOf<Member(IfThenWhereTable::value)>)
                 .All();
         },
         QueryExpectations::All(R"SQL(SELECT "a" FROM "IfThenWhereTable"

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -347,6 +347,164 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.WhereNull", "[SqlQueryBu
                                      WHERE "Column1" IS NULL)SQL"));
 }
 
+namespace
+{
+struct IfThenWhereTable
+{
+    Field<int> value;
+};
+} // namespace
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.IfThenWhere optional empty", "[SqlQueryBuilder]")
+{
+    std::optional<int> const empty {};
+    CheckSqlQueryBuilder(
+        [&](SqlQueryBuilder& q) { return q.FromTable("Table").Select().Field("a").If(empty).ThenWhere("Column1").All(); },
+        QueryExpectations::All(R"SQL(SELECT "a" FROM "Table")SQL"));
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.IfThenWhere optional populated", "[SqlQueryBuilder]")
+{
+    std::optional<int> const populated { 42 };
+    CheckSqlQueryBuilder(
+        [&](SqlQueryBuilder& q) {
+            return q.FromTable("Table").Select().Field("a").If(populated).ThenWhere("Column1").All();
+        },
+        QueryExpectations::All(R"SQL(SELECT "a" FROM "Table"
+                                     WHERE "Column1" = 42)SQL"));
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.IfThenWhere FullyQualifiedNameOf", "[SqlQueryBuilder]")
+{
+    std::optional<int> const populated { 7 };
+    CheckSqlQueryBuilder(
+        [&](SqlQueryBuilder& q) {
+            return q.FromTable(RecordTableName<IfThenWhereTable>)
+                .Select()
+                .Field("a")
+                .If(populated)
+                .ThenWhere(FullyQualifiedNameOf<&IfThenWhereTable::value>)
+                .All();
+        },
+        QueryExpectations::All(R"SQL(SELECT "a" FROM "IfThenWhereTable"
+                                     WHERE "IfThenWhereTable"."value" = 7)SQL"));
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.IfThenWhere with SqlDateTime", "[SqlQueryBuilder]")
+{
+    using namespace std::chrono_literals;
+
+    std::optional<SqlDateTime> const empty {};
+    std::optional<SqlDateTime> const populated { SqlDateTime {
+        std::chrono::year { 2026 }, std::chrono::month { 5 }, std::chrono::day { 18 }, 12h, 30min, 45s } };
+
+    // Empty optional => no WHERE
+    CheckSqlQueryBuilder(
+        [&](SqlQueryBuilder& q) {
+            return q.FromTable("Events").Select().Field("id").If(empty).ThenWhere("createdAt").All();
+        },
+        QueryExpectations::All(R"SQL(SELECT "id" FROM "Events")SQL"));
+
+    // Populated optional => WHERE with quoted ISO-8601 literal
+    CheckSqlQueryBuilder(
+        [&](SqlQueryBuilder& q) {
+            return q.FromTable("Events").Select().Field("id").If(populated).ThenWhere("createdAt").All();
+        },
+        QueryExpectations::All(R"SQL(SELECT "id" FROM "Events"
+                                     WHERE "createdAt" = '2026-05-18T12:30:45.000')SQL"));
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.IfThenWhere SqlDateTime range with operators", "[SqlQueryBuilder]")
+{
+    using namespace std::chrono_literals;
+
+    std::optional<SqlDateTime> const since { SqlDateTime {
+        std::chrono::year { 2026 }, std::chrono::month { 1 }, std::chrono::day { 1 }, 0h, 0min, 0s } };
+    std::optional<SqlDateTime> const until { SqlDateTime {
+        std::chrono::year { 2026 }, std::chrono::month { 5 }, std::chrono::day { 18 }, 12h, 30min, 45s } };
+    std::optional<SqlDateTime> const empty {};
+
+    // Both bounds present: combined `>=` and `<` filter (AND junctor between two If/ThenWhere)
+    CheckSqlQueryBuilder(
+        [&](SqlQueryBuilder& q) {
+            return q.FromTable("Events")
+                .Select()
+                .Field("id")
+                .If(since)
+                .ThenWhere("createdAt", ">=")
+                .If(until)
+                .ThenWhere("createdAt", "<")
+                .All();
+        },
+        QueryExpectations::All(R"SQL(SELECT "id" FROM "Events"
+                                     WHERE "createdAt" >= '2026-01-01T00:00:00.000' AND "createdAt" < '2026-05-18T12:30:45.000')SQL"));
+
+    // Only upper bound present: empty `since` is a no-op, only `<` filter is emitted
+    CheckSqlQueryBuilder(
+        [&](SqlQueryBuilder& q) {
+            return q.FromTable("Events")
+                .Select()
+                .Field("id")
+                .If(empty)
+                .ThenWhere("createdAt", ">=")
+                .If(until)
+                .ThenWhere("createdAt", "<")
+                .All();
+        },
+        QueryExpectations::All(R"SQL(SELECT "id" FROM "Events"
+                                     WHERE "createdAt" < '2026-05-18T12:30:45.000')SQL"));
+
+    // Both empty: no WHERE at all
+    CheckSqlQueryBuilder(
+        [&](SqlQueryBuilder& q) {
+            return q.FromTable("Events")
+                .Select()
+                .Field("id")
+                .If(empty)
+                .ThenWhere("createdAt", ">=")
+                .If(empty)
+                .ThenWhere("createdAt", "<")
+                .All();
+        },
+        QueryExpectations::All(R"SQL(SELECT "id" FROM "Events")SQL"));
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.IfThenWhere with std::string", "[SqlQueryBuilder]")
+{
+    std::optional<std::string> const empty {};
+    std::optional<std::string> const populated { "Alice" };
+
+    CheckSqlQueryBuilder(
+        [&](SqlQueryBuilder& q) { return q.FromTable("Users").Select().Field("id").If(empty).ThenWhere("name").All(); },
+        QueryExpectations::All(R"SQL(SELECT "id" FROM "Users")SQL"));
+
+    CheckSqlQueryBuilder(
+        [&](SqlQueryBuilder& q) { return q.FromTable("Users").Select().Field("id").If(populated).ThenWhere("name").All(); },
+        QueryExpectations::All(R"SQL(SELECT "id" FROM "Users"
+                                     WHERE "name" = 'Alice')SQL"));
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.IfThenWhere on Update and Delete", "[SqlQueryBuilder]")
+{
+    std::optional<int> const empty {};
+    std::optional<int> const populated { 5 };
+
+    CheckSqlQueryBuilder([&](SqlQueryBuilder& q) { return q.FromTable("T").Update().Set("a", 1).If(empty).ThenWhere("id"); },
+                         QueryExpectations::All(R"SQL(UPDATE "T" SET "a" = 1)SQL"));
+
+    CheckSqlQueryBuilder(
+        [&](SqlQueryBuilder& q) { return q.FromTable("T").Update().Set("a", 1).If(populated).ThenWhere("id"); },
+        QueryExpectations::All(R"SQL(UPDATE "T" SET "a" = 1
+                                     WHERE "id" = 5)SQL"));
+
+    CheckSqlQueryBuilder([&](SqlQueryBuilder& q) { return q.FromTable("T").Delete().If(empty).ThenWhere("id"); },
+                         QueryExpectations::All(R"SQL(DELETE FROM "T")SQL"));
+
+    CheckSqlQueryBuilder([&](SqlQueryBuilder& q) { return q.FromTable("T").Delete().If(populated).ThenWhere("id"); },
+                         QueryExpectations::All(R"SQL(DELETE FROM "T"
+                                                      WHERE "id" = 5)SQL"));
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.Junctors", "[SqlQueryBuilder]")
 {
     CheckSqlQueryBuilder(


### PR DESCRIPTION
Closes https://github.com/LASTRADA-Software/Lightweight/issues/493

Add a new API for the query builder with the sub builder to handle`optional<T>` values for the Where clause