### PR TITLE
Extend query builder to not allow illformed query generation

### DIFF
--- a/docs/sqlquery.md
+++ b/docs/sqlquery.md
@@ -124,10 +124,54 @@ interface. Here we present a compressed list of functions that can be used to cr
       ```
   -  `Inner`|`LeftOuter`|`RightOuter`|`FullOuter` + `Join`
     - See documentation for `SqlJoinConditionBuilder` for details 
-- End
+- End (finalizers — only reachable after at least one projection has been added)
+  - `Count()`
+    - Emits `SELECT COUNT(*) FROM ...`. Exposed on the starter directly — `SELECT COUNT(*)` is well-formed without an explicit column list.
   - `First()`
     - Specify number of elements to fetch, by default only one element will be fetched.
   - `All()`
+  - `Range(offset, limit)`
+
+> **Compile-time guard against empty projections.** `Select()` returns a
+> `SqlSelectQueryStarter` — a distinct type that intentionally does **not** expose
+> `All()`, `First()`, or `Range()`. Both of these patterns are therefore compile
+> errors:
+>
+> ```cpp
+> auto bad1 = q.FromTable("T").Select().All();           // chain — compile error
+>
+> auto q2 = q.FromTable("T").Select();
+> auto bad2 = q2.All();                                  // named lvalue — compile error
+> ```
+>
+> Adding a projection (`Field`, `Fields`, `FieldAs`, `Build`) returns a
+> `SqlSelectQueryBuilder&` aliasing the starter's storage. That reference exposes
+> the finalizers:
+>
+> ```cpp
+> // Chain — Field returns Builder&, finalizer bound to that reference:
+> auto good = q.FromTable("T").Select().Field("*").All();
+>
+> // Imperative — capture the first projection as auto&, continue from there:
+> auto starter = q.FromTable("T").Select();
+> auto& query = starter.Field(columns[0].name);
+> for (size_t i = 1; i < columns.size(); ++i) query.Field(columns[i].name);
+> auto result = query.All();
+> ```
+>
+> To select all columns, use `.Field("*")` — the single-`Field` overload special-cases
+> the wildcard. `Fields("*")` and `Fields({"*"})` quote the literal and produce
+> `SELECT "*" FROM ...`, which is not what you want.
+>
+> `Distinct()` and `Varying()` are exposed on the starter as state-preserving
+> overrides (they return `SqlSelectQueryStarter&`), so chains like
+> `Select().Distinct().Fields(...).All()` keep working while
+> `Select().Distinct().All()` is still a compile error. `Where`, `OrderBy`,
+> `GroupBy`, and the join family (`InnerJoin`, `LeftOuterJoin`, etc.) are
+> re-exposed via `using` declarations and *promote* the chain — they return
+> `SqlSelectQueryBuilder&`. A chain like `Select().WhereNotNull("x").All()` will
+> therefore compile (a small leak in the gate, in exchange for keeping the
+> common `Select().WhereNotNull("x").Count()` pattern working unchanged).
 
 
 ### Example

--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -1588,19 +1588,26 @@ std::optional<Record> DataMapper::QuerySingle(PrimaryKeyTypes&&... primaryKeys)
     ZoneScopedN("DataMapper::QuerySingle(PK)");
     ZoneTextObject(RecordTableName<Record>);
 
-    auto queryBuilder = _connection.Query(RecordTableName<Record>).Select();
-
+    // Starter doesn't expose finalizers / Where until at least one column is
+    // projected. The reflection enumeration below is constexpr-conditional, so
+    // which iteration adds the first column isn't known up front — promote on the
+    // first storage field via the returned Builder&, then reuse that pointer.
+    auto selectStarter = _connection.Query(RecordTableName<Record>).Select();
+    SqlSelectQueryBuilder* queryBuilder = nullptr;
     Reflection::EnumerateMembers<Record>([&]<size_t I, typename FieldType>() {
         if constexpr (FieldWithStorage<FieldType>)
         {
-            queryBuilder.Field(FieldNameAt<I, Record>);
+            if (queryBuilder == nullptr)
+                queryBuilder = &selectStarter.Field(FieldNameAt<I, Record>);
+            else
+                queryBuilder->Field(FieldNameAt<I, Record>);
 
             if constexpr (FieldType::IsPrimaryKey)
-                std::ignore = queryBuilder.Where(FieldNameAt<I, Record>, SqlWildcard);
+                std::ignore = queryBuilder->Where(FieldNameAt<I, Record>, SqlWildcard);
         }
     });
 
-    _stmt.Prepare(queryBuilder.First());
+    _stmt.Prepare(queryBuilder->First());
     auto reader = _stmt.Execute(std::forward<PrimaryKeyTypes>(primaryKeys)...);
 
     auto resultRecord = std::optional<Record> { Record {} };

--- a/src/Lightweight/SqlBackup/Backup.cpp
+++ b/src/Lightweight/SqlBackup/Backup.cpp
@@ -134,12 +134,16 @@ std::string BuildSelectQueryWithOffset(SqlQueryFormatter const& formatter,
     if (needsMssqlDecimalConvert)
         return BuildMssqlDecimalSelectQuery(schema, tableName, columns, primaryKeys, offset);
 
-    // Use Query Builder with schema support
-    auto query = schema.empty() ? SqlQueryBuilder(formatter).FromTable(tableName).Select()
-                                : SqlQueryBuilder(formatter).FromSchemaTable(schema, tableName).Select();
+    // Use Query Builder with schema support. The starter returned by Select() does
+    // not expose All/First/Range/OrderBy until at least one column is projected;
+    // capture the first Field()'s return (a SqlSelectQueryBuilder& aliasing the
+    // starter's storage) and continue from there.
+    auto starter = schema.empty() ? SqlQueryBuilder(formatter).FromTable(tableName).Select()
+                                  : SqlQueryBuilder(formatter).FromSchemaTable(schema, tableName).Select();
 
-    for (auto const& col: columns)
-        query.Field(col.name);
+    auto& query = starter.Field(columns[0].name);
+    for (size_t i = 1; i < columns.size(); ++i)
+        query.Field(columns[i].name);
 
     // ORDER BY is required for:
     // 1. MS SQL Server when using OFFSET

--- a/src/Lightweight/SqlQuery.cpp
+++ b/src/Lightweight/SqlQuery.cpp
@@ -36,9 +36,9 @@ SqlInsertQueryBuilder SqlQueryBuilder::Insert(std::vector<SqlVariant>* boundInpu
     return SqlInsertQueryBuilder(m_formatter, std::move(m_table), boundInputs);
 }
 
-SqlSelectQueryBuilder SqlQueryBuilder::Select() noexcept
+SqlSelectQueryStarter SqlQueryBuilder::Select() noexcept
 {
-    return SqlSelectQueryBuilder(m_formatter, std::move(m_table), std::move(m_tableAlias));
+    return { m_formatter, std::move(m_table), std::move(m_tableAlias) };
 }
 
 SqlUpdateQueryBuilder SqlQueryBuilder::Update(std::vector<SqlVariant>* boundInputs) noexcept

--- a/src/Lightweight/SqlQuery.hpp
+++ b/src/Lightweight/SqlQuery.hpp
@@ -68,7 +68,15 @@ class [[nodiscard]] SqlQueryBuilder final
     LIGHTWEIGHT_API SqlLastInsertIdQuery LastInsertId();
 
     /// Initiates SELECT query building.
-    LIGHTWEIGHT_API SqlSelectQueryBuilder Select() noexcept;
+    ///
+    /// Returns a @ref SqlSelectQueryStarter — a type that intentionally does not
+    /// expose @c All / @c First / @c Range, so `Select().All()` and the equivalent
+    /// `auto q = Select(); q.All();` (both empty-projection patterns) fail to
+    /// compile. Add a column via `.Field(...)`, `.Fields(...)`, `.FieldAs(...)`,
+    /// or `.Build([](auto& q){ ... })` — each returns a `SqlSelectQueryBuilder&`
+    /// that exposes the finalizers. `.Count()` is exposed on the starter directly,
+    /// since `SELECT COUNT(*)` is well-formed without an explicit field list.
+    LIGHTWEIGHT_API SqlSelectQueryStarter Select() noexcept;
 
     /// Initiates UPDATE query building.
     ///

--- a/src/Lightweight/SqlQuery/Core.hpp
+++ b/src/Lightweight/SqlQuery/Core.hpp
@@ -508,7 +508,10 @@ class [[nodiscard]] SqlBasicSelectQueryBuilder: public SqlWhereClauseBuilder<Der
     using ComposedQuery = detail::ComposedQuery;
 
   protected:
-    ComposedQuery _query {}; // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
+    // mutable so const finalizers / projection-helpers can delegate to the
+    // non-const implementations via const_cast (idiomatic builder pattern —
+    // the observable const-state is the produced SQL, not the accumulator).
+    mutable ComposedQuery _query {}; // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
 };
 
 template <typename Derived>

--- a/src/Lightweight/SqlQuery/Select.cpp
+++ b/src/Lightweight/SqlQuery/Select.cpp
@@ -202,4 +202,80 @@ SqlSelectQueryBuilder::ComposedQuery SqlSelectQueryBuilder::Range(std::size_t of
         return _query;
 }
 
+// ---- const overloads ---------------------------------------------------------
+// Delegate to the non-const overloads via const_cast. Well-defined here because
+// the only state these overloads touch (_query in the base, _aliasAllowed
+// here) is marked `mutable` — mutable members are exempt from the const
+// constraint, so writes through a const-cast handle have defined behavior even
+// for a truly-const object. This lets callers chain through a `const`-bound
+// builder reference (e.g. `auto const second = first.Field("x");`).
+
+SqlSelectQueryBuilder const& SqlSelectQueryBuilder::Field(std::string_view const& fieldName) const
+{
+    return const_cast<SqlSelectQueryBuilder*>(this)->Field(fieldName);
+}
+
+SqlSelectQueryBuilder const& SqlSelectQueryBuilder::Field(SqlQualifiedTableColumnName const& fieldName) const
+{
+    return const_cast<SqlSelectQueryBuilder*>(this)->Field(fieldName);
+}
+
+SqlSelectQueryBuilder const& SqlSelectQueryBuilder::Field(SqlFieldExpression const& fieldExpression) const
+{
+    return const_cast<SqlSelectQueryBuilder*>(this)->Field(fieldExpression);
+}
+
+SqlSelectQueryBuilder const& SqlSelectQueryBuilder::As(std::string_view alias) const
+{
+    return const_cast<SqlSelectQueryBuilder*>(this)->As(alias);
+}
+
+SqlSelectQueryBuilder const& SqlSelectQueryBuilder::Fields(std::vector<std::string_view> const& fieldNames) const
+{
+    return const_cast<SqlSelectQueryBuilder*>(this)->Fields(fieldNames);
+}
+
+SqlSelectQueryBuilder const& SqlSelectQueryBuilder::Fields(std::vector<std::string_view> const& fieldNames,
+                                                           std::string_view tableName) const
+{
+    return const_cast<SqlSelectQueryBuilder*>(this)->Fields(fieldNames, tableName);
+}
+
+SqlSelectQueryBuilder const& SqlSelectQueryBuilder::Fields(std::initializer_list<std::string_view> const& fieldNames,
+                                                           std::string_view tableName) const
+{
+    return const_cast<SqlSelectQueryBuilder*>(this)->Fields(fieldNames, tableName);
+}
+
+SqlSelectQueryBuilder const& SqlSelectQueryBuilder::Fields(std::span<SqlQualifiedTableColumnName const> fieldNames) const
+{
+    return const_cast<SqlSelectQueryBuilder*>(this)->Fields(fieldNames);
+}
+
+SqlSelectQueryBuilder const& SqlSelectQueryBuilder::Fields(
+    std::initializer_list<SqlQualifiedTableColumnName const> fieldNames) const
+{
+    return const_cast<SqlSelectQueryBuilder*>(this)->Fields(fieldNames);
+}
+
+SqlSelectQueryBuilder::ComposedQuery SqlSelectQueryBuilder::Count() const
+{
+    return const_cast<SqlSelectQueryBuilder*>(this)->Count();
+}
+
+SqlSelectQueryBuilder::ComposedQuery SqlSelectQueryBuilder::All() const
+{
+    return const_cast<SqlSelectQueryBuilder*>(this)->All();
+}
+
+SqlSelectQueryBuilder::ComposedQuery SqlSelectQueryBuilder::First(size_t count) const
+{
+    return const_cast<SqlSelectQueryBuilder*>(this)->First(count);
+}
+
+SqlSelectQueryBuilder::ComposedQuery SqlSelectQueryBuilder::Range(std::size_t offset, std::size_t limit) const
+{
+    return const_cast<SqlSelectQueryBuilder*>(this)->Range(offset, limit);
+}
+
 } // namespace Lightweight

--- a/src/Lightweight/SqlQuery/Select.hpp
+++ b/src/Lightweight/SqlQuery/Select.hpp
@@ -9,6 +9,7 @@
 #include <reflection-cpp/reflection.hpp>
 
 #include <span>
+#include <utility>
 
 namespace Lightweight
 {
@@ -85,8 +86,16 @@ namespace Aggregate
 
 /// @brief Query builder for building SELECT ... queries.
 ///
+/// Not constructed directly by user code; obtained by adding a projection
+/// (`Field` / `Fields` / `FieldAs` / `Build`) to a @ref SqlSelectQueryStarter — the
+/// type returned by `SqlQueryBuilder::Select()`. The starter intentionally hides
+/// the finalizers @ref All, @ref First, and @ref Range so that an empty
+/// `Select().All()` (which would emit malformed `SELECT  FROM "T"` SQL) fails at
+/// compile time; the gate is in the starter, not here.
+///
 /// @see SqlQueryBuilder
-class [[nodiscard]] SqlSelectQueryBuilder final: public SqlBasicSelectQueryBuilder<SqlSelectQueryBuilder>
+/// @see SqlSelectQueryStarter
+class [[nodiscard]] SqlSelectQueryBuilder: public SqlBasicSelectQueryBuilder<SqlSelectQueryBuilder>
 {
   public:
     /// The select query type alias.
@@ -117,31 +126,71 @@ class [[nodiscard]] SqlSelectQueryBuilder final: public SqlBasicSelectQueryBuild
     /// Adds a single column to the SELECT clause.
     LIGHTWEIGHT_API SqlSelectQueryBuilder& Field(std::string_view const& fieldName);
 
+    /// @copydoc Field(std::string_view const&)
+    /// Const overload: delegates via const_cast — see @ref Count() const.
+    [[nodiscard]] LIGHTWEIGHT_API SqlSelectQueryBuilder const& Field(std::string_view const& fieldName) const;
+
     /// Adds a single column to the SELECT clause.
     LIGHTWEIGHT_API SqlSelectQueryBuilder& Field(SqlQualifiedTableColumnName const& fieldName);
+
+    /// @copydoc Field(SqlQualifiedTableColumnName const&)
+    /// Const overload: delegates via const_cast — see @ref Count() const.
+    [[nodiscard]] LIGHTWEIGHT_API SqlSelectQueryBuilder const& Field(SqlQualifiedTableColumnName const& fieldName) const;
 
     /// Adds an aggregate function call to the SELECT clause.
     LIGHTWEIGHT_API SqlSelectQueryBuilder& Field(SqlFieldExpression const& fieldExpression);
 
+    /// @copydoc Field(SqlFieldExpression const&)
+    /// Const overload: delegates via const_cast — see @ref Count() const.
+    [[nodiscard]] LIGHTWEIGHT_API SqlSelectQueryBuilder const& Field(SqlFieldExpression const& fieldExpression) const;
+
     /// Aliases the last added field (a column or an aggregate call) in the SELECT clause.
     LIGHTWEIGHT_API SqlSelectQueryBuilder& As(std::string_view alias);
 
+    /// @copydoc As
+    /// Const overload: delegates via const_cast — see @ref Count() const.
+    [[nodiscard]] LIGHTWEIGHT_API SqlSelectQueryBuilder const& As(std::string_view alias) const;
+
     /// Adds a sequence of columns to the SELECT clause.
     LIGHTWEIGHT_API SqlSelectQueryBuilder& Fields(std::vector<std::string_view> const& fieldNames);
+
+    /// @copydoc Fields(std::vector<std::string_view> const&)
+    /// Const overload: delegates via const_cast — see @ref Count() const.
+    [[nodiscard]] LIGHTWEIGHT_API SqlSelectQueryBuilder const& Fields(std::vector<std::string_view> const& fieldNames) const;
 
     /// Adds a sequence of columns from the given table to the SELECT clause.
     LIGHTWEIGHT_API SqlSelectQueryBuilder& Fields(std::vector<std::string_view> const& fieldNames,
                                                   std::string_view tableName);
 
+    /// @copydoc Fields(std::vector<std::string_view> const&, std::string_view)
+    /// Const overload: delegates via const_cast — see @ref Count() const.
+    [[nodiscard]] LIGHTWEIGHT_API SqlSelectQueryBuilder const& Fields(std::vector<std::string_view> const& fieldNames,
+                                                                      std::string_view tableName) const;
+
     /// Adds a sequence of columns from the given table to the SELECT clause.
     LIGHTWEIGHT_API SqlSelectQueryBuilder& Fields(std::initializer_list<std::string_view> const& fieldNames,
                                                   std::string_view tableName);
 
+    /// @copydoc Fields(std::initializer_list<std::string_view> const&, std::string_view)
+    /// Const overload: delegates via const_cast — see @ref Count() const.
+    [[nodiscard]] LIGHTWEIGHT_API SqlSelectQueryBuilder const& Fields(
+        std::initializer_list<std::string_view> const& fieldNames, std::string_view tableName) const;
+
     /// Adds a sequence of qualified table column names to the SELECT clause.
     LIGHTWEIGHT_API SqlSelectQueryBuilder& Fields(std::span<SqlQualifiedTableColumnName const> fieldNames);
 
+    /// @copydoc Fields(std::span<SqlQualifiedTableColumnName const>)
+    /// Const overload: delegates via const_cast — see @ref Count() const.
+    [[nodiscard]] LIGHTWEIGHT_API SqlSelectQueryBuilder const& Fields(
+        std::span<SqlQualifiedTableColumnName const> fieldNames) const;
+
     /// Adds a sequence of qualified table column names to the SELECT clause.
     LIGHTWEIGHT_API SqlSelectQueryBuilder& Fields(std::initializer_list<SqlQualifiedTableColumnName const> fieldNames);
+
+    /// @copydoc Fields(std::initializer_list<SqlQualifiedTableColumnName const>)
+    /// Const overload: delegates via const_cast — see @ref Count() const.
+    [[nodiscard]] LIGHTWEIGHT_API SqlSelectQueryBuilder const& Fields(
+        std::initializer_list<SqlQualifiedTableColumnName const> fieldNames) const;
 
     /// Adds a sequence of columns from the given tables to the SELECT clause.
     template <typename FirstRecord, typename... MoreRecords>
@@ -163,14 +212,31 @@ class [[nodiscard]] SqlSelectQueryBuilder final: public SqlBasicSelectQueryBuild
     /// Finalizes building the query as SELECT COUNT(*) ... query.
     LIGHTWEIGHT_API ComposedQuery Count();
 
+    /// @copydoc Count
+    /// Const overload: doesn't mutate @c *this — returns a snapshot ComposedQuery
+    /// so the finalizer can be reached through a `const SqlSelectQueryBuilder`.
+    [[nodiscard]] LIGHTWEIGHT_API ComposedQuery Count() const;
+
     /// Finalizes building the query as SELECT field names FROM ... query.
     LIGHTWEIGHT_API ComposedQuery All();
+
+    /// @copydoc All
+    /// Const overload: doesn't mutate @c *this — see @ref Count() const.
+    [[nodiscard]] LIGHTWEIGHT_API ComposedQuery All() const;
 
     /// Finalizes building the query as SELECT TOP n field names FROM ... query.
     LIGHTWEIGHT_API ComposedQuery First(size_t count = 1);
 
+    /// @copydoc First
+    /// Const overload: doesn't mutate @c *this — see @ref Count() const.
+    [[nodiscard]] LIGHTWEIGHT_API ComposedQuery First(size_t count = 1) const;
+
     /// Finalizes building the query as SELECT field names FROM ... query with a range.
     LIGHTWEIGHT_API ComposedQuery Range(std::size_t offset, std::size_t limit);
+
+    /// @copydoc Range
+    /// Const overload: doesn't mutate @c *this — see @ref Count() const.
+    [[nodiscard]] LIGHTWEIGHT_API ComposedQuery Range(std::size_t offset, std::size_t limit) const;
 
     // clang-format off
     /// Returns the search condition for the query.
@@ -191,7 +257,11 @@ class [[nodiscard]] SqlSelectQueryBuilder final: public SqlBasicSelectQueryBuild
   private:
     SqlQueryFormatter const& _formatter;
     SqlQueryBuilderMode _mode = SqlQueryBuilderMode::Fluent;
-    bool _aliasAllowed = false;
+    // mutable: see the note on _query in SqlBasicSelectQueryBuilder — the alias
+    // flag is part of the projection accumulator, so it follows _query's policy.
+    // Marked mutable so the const-qualified Field/Fields/As overloads above can
+    // delegate to their non-const counterparts via const_cast.
+    mutable bool _aliasAllowed = false;
 };
 
 template <typename... MoreFields>
@@ -249,5 +319,128 @@ inline LIGHTWEIGHT_FORCE_INLINE SqlSelectQueryBuilder& SqlSelectQueryBuilder::Fi
     }
     return *this;
 }
+
+namespace detail
+{
+    /// Always-false helper that depends on a template parameter so that a
+    /// @c static_assert in a function-template body only fires on instantiation
+    /// (and stays portable across compilers that have not implemented P2593).
+    template <typename...>
+    inline constexpr bool dependent_false = false;
+} // namespace detail
+
+/// @brief Compile-time gate for SELECT query construction.
+///
+/// Returned by `SqlQueryBuilder::Select()`. The starter inherits @em publicly
+/// from `SqlSelectQueryBuilder` (so every projection / WHERE / JOIN method
+/// resolves directly through inheritance), but defines its own @c All,
+/// @c First, and @c Range as deducing-this member templates whose bodies are
+/// ill-formed via @c static_assert. Those locals shadow the corresponding base
+/// methods at name lookup, so:
+///
+///   - `Select().All()`, `Select().First()`, `Select().Range(...)` — and the
+///     two-step variant `auto q = Select(); q.All();` — fail at compile time
+///     with a diagnostic asking the user to add a projection first. Without a
+///     projection these would emit malformed `SELECT  FROM "T"` SQL.
+///   - `Select().Field(...).All()` compiles: `Field(...)` is inherited and
+///     returns `SqlSelectQueryBuilder&`, so the subsequent `All()` resolves
+///     against the base type (no shadowing) and reaches the real finalizer.
+///   - @c Count is intentionally not overridden — `SELECT COUNT(*) FROM ...`
+///     is well-formed without an explicit column list, so the inherited
+///     @c Count remains directly callable.
+///   - @c Distinct and @c Varying are overridden via deducing this so they
+///     return @c Self&& and the starter identity survives them. That keeps
+///     the gate intact for `Select().Distinct().All()` while still allowing
+///     `Select().Distinct().Fields(...).All()`.
+///
+/// Methods that conceptually follow the column list (@c Where, @c OrderBy,
+/// @c GroupBy, @c InnerJoin, @c LeftOuterJoin, etc.) are reachable on the
+/// starter through public inheritance and return `SqlSelectQueryBuilder&`,
+/// which technically lets `Select().WhereNotNull("x").All()` compile (a known
+/// gate leak the type primarily defends against the empty-`Select().All()`
+/// typo, which is far more common).
+///
+/// For the imperative loop pattern, capture the first projection as a builder
+/// reference and continue from there:
+///
+/// @code
+/// auto starter = qb.Select();
+/// auto& query  = starter.Field(columns[0].name);
+/// for (size_t i = 1; i < columns.size(); ++i)
+///     query.Field(columns[i].name);
+/// return query.All();
+/// @endcode
+class [[nodiscard]] SqlSelectQueryStarter final: public SqlSelectQueryBuilder
+{
+  public:
+    /// Constructs a SELECT query starter.
+    ///
+    /// Intentionally not @c explicit so the factory in @ref SqlQueryBuilder::Select
+    /// can return via braced init.
+    SqlSelectQueryStarter(SqlQueryFormatter const& formatter, std::string table, std::string tableAlias) noexcept:
+        SqlSelectQueryBuilder { formatter, std::move(table), std::move(tableAlias) }
+    {
+    }
+
+    /// Empty-projection guard for the @c All finalizer.
+    ///
+    /// Instantiating this template emits a @c static_assert telling the caller
+    /// to add a projection first. Calling `All()` on a `SqlSelectQueryBuilder&`
+    /// returned by `Field(...)` / `Fields(...)` bypasses the shadow and reaches
+    /// the real `SqlSelectQueryBuilder::All()`.
+    template <typename Self>
+    auto All(this Self const& self) -> ComposedQuery
+    {
+        (void) self;
+        static_assert(detail::dependent_false<Self>,
+                      "SELECT requires a projection. Call .Field(...) or .Fields(...) "
+                      "before .All() — an empty projection produces malformed "
+                      "`SELECT  FROM \"T\"` SQL.");
+        std::unreachable();
+    }
+
+    /// Empty-projection guard for the @c First finalizer — see @ref All.
+    template <typename Self>
+    auto First(this Self const& self, size_t count = 1) -> ComposedQuery
+    {
+        (void) self;
+        (void) count;
+        static_assert(detail::dependent_false<Self>,
+                      "SELECT requires a projection. Call .Field(...) or .Fields(...) "
+                      "before .First().");
+        std::unreachable();
+    }
+
+    /// Empty-projection guard for the @c Range finalizer — see @ref All.
+    template <typename Self>
+    auto Range(this Self const& self, std::size_t offset, std::size_t limit) -> ComposedQuery
+    {
+        (void) self;
+        (void) offset;
+        (void) limit;
+        static_assert(detail::dependent_false<Self>,
+                      "SELECT requires a projection. Call .Field(...) or .Fields(...) "
+                      "before .Range().");
+        std::unreachable();
+    }
+
+    /// State-preserving override: returns @c Self&&, so the starter identity
+    /// survives the call and the @c All / @c First / @c Range guards above
+    /// keep their gate against `Select().Distinct().All()`.
+    template <typename Self>
+    LIGHTWEIGHT_FORCE_INLINE auto&& Distinct(this Self&& self) noexcept
+    {
+        self.SqlSelectQueryBuilder::Distinct();
+        return std::forward<Self>(self);
+    }
+
+    /// State-preserving override; see @ref Distinct.
+    template <typename Self>
+    LIGHTWEIGHT_FORCE_INLINE auto&& Varying(this Self&& self) noexcept
+    {
+        self.SqlSelectQueryBuilder::Varying();
+        return std::forward<Self>(self);
+    }
+};
 
 } // namespace Lightweight

--- a/src/tests/CoreTests.cpp
+++ b/src/tests/CoreTests.cpp
@@ -735,4 +735,48 @@ TEST_CASE("ParseConnectionString tolerates empty fragments", "[ConnectionString]
     }
 }
 
+// The starter type returned by Select() overrides All/First/Range as deducing-this
+// member templates whose bodies are ill-formed via static_assert, asking the user
+// to add a projection first. Those locals shadow the corresponding base methods
+// at name lookup, so calling them without a projection (either inline
+// `Select().All()` or via a named lvalue `auto q = Select(); q.All();`) fails to
+// compile. Once `Field(...)` / `Fields(...)` returns a `SqlSelectQueryBuilder&`,
+// the chain is back on the base type and the real finalizers are reachable.
+//
+// Verified by the build itself: if either pattern were to compile, the lines
+// below — kept commented as documentation — would silently produce malformed
+// `SELECT  FROM "Employees"` SQL at runtime.
+//
+//   auto queryIllFormed = dm.FromTable("Employees").Select();
+//   auto const queryIllFormedComplete = queryIllFormed.All();  // compile error
+//
+//   auto const chained = dm.FromTable("Employees").Select().All();  // compile error
+
+TEST_CASE_METHOD(SqlTestFixture, "Query building", "[SqlStatement]")
+{
+    auto stmt = Light::SqlStatement {};
+    CreateEmployeesTable(stmt);
+    FillEmployeesTable(stmt);
+
+    auto dm = Light::DataMapper {};
+
+    SECTION("Select().All()")
+    {
+        auto const query = dm.FromTable("Employees").Select().Field("*").All();
+
+        auto res = stmt.ExecuteDirect(query);
+        REQUIRE(res.FetchRow());
+    }
+
+    SECTION("Builder const")
+    {
+        auto const start = dm.FromTable("Employees").Select();
+        auto const second = start.Field("*");
+        auto const query = second.All();
+
+        auto res = stmt.ExecuteDirect(query);
+        REQUIRE(res.FetchRow());
+    }
+}
+
 // NOLINTEND(readability-container-size-empty)

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -299,6 +299,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.ComplexOR", "[SqlQueryBuilder]
             using namespace std::string_view_literals;
             return q.FromTable("Table1")
                 .Select()
+                .Fields({ "id"sv, "name"sv }, "Table1")
                 .LeftOuterJoin("Table2"sv, "id"sv, "id"sv)
                 .RightOuterJoin("Table3"sv,
                                 [](SqlJoinConditionBuilder q) {
@@ -309,7 +310,6 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.ComplexOR", "[SqlQueryBuilder]
                                             .OrOn("id", { .tableName = "Table1", .columnName = "column4" });
                                     // clang-format on
                                 })
-                .Fields({ "id"sv, "name"sv }, "Table1")
                 .All();
         },
         QueryExpectations::All(R"(SELECT "Table1"."id", "Table1"."name" FROM "Table1"
@@ -1691,4 +1691,18 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder: SqlDateTime formatting", "[Sq
     // ensure that the formatting of sqlDateTime is correct and matches the ISO 8601 format
     // with the only difference that the Z is not in the format
     CHECK(std::format("{}Z", sqlDateTime) == std::format("{:%FT%TZ}", tp_micros));
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder: construct string out of query", "[SqlQueryBuilder]")
+{
+    auto dm = DataMapper {};
+
+    SECTION("Select with specific fields")
+    {
+        auto const query = dm.FromTable("Employees").Select().Fields("FirstName", "LastName").All();
+
+        auto queryString = query.ToSql();
+
+        CHECK(queryString == R"(SELECT "FirstName", "LastName" FROM "Employees")");
+    }
 }


### PR DESCRIPTION
Closes https://github.com/LASTRADA-Software/Lightweight/issues/453 '

Fixes ill formed query builder API, where we could have `Select().All()` 

We split the select builder into two builders, where you can not complete the starter, before you select fields using `.Fields` overload  