### PR TITLE
tools: filter plugin candidates by '*Plugin' filename suffix

### DIFF
--- a/src/tests/PluginDiscoveryTests.cpp
+++ b/src/tests/PluginDiscoveryTests.cpp
@@ -90,8 +90,8 @@ TEST_CASE("DiscoverPlugins — distinct filenames across directories all survive
     auto const dirA = tree.Dir("a");
     auto const dirB = tree.Dir("b");
 
-    Touch(dirA / "alpha.dll", BaseTime());
-    Touch(dirB / "beta.dll", BaseTime());
+    Touch(dirA / "AlphaPlugin.dll", BaseTime());
+    Touch(dirB / "BetaPlugin.dll", BaseTime());
 
     std::vector<std::filesystem::path> dirs { dirA, dirB };
     auto const resolved = Lightweight::Tools::DiscoverPlugins(dirs);
@@ -100,7 +100,7 @@ TEST_CASE("DiscoverPlugins — distinct filenames across directories all survive
     auto const names = resolved | std::views::transform([](auto const& r) { return r.path.filename().string(); });
     std::vector<std::string> sortedNames(names.begin(), names.end());
     std::ranges::sort(sortedNames);
-    CHECK(sortedNames == std::vector<std::string> { "alpha.dll", "beta.dll" });
+    CHECK(sortedNames == std::vector<std::string> { "AlphaPlugin.dll", "BetaPlugin.dll" });
 }
 
 TEST_CASE("DiscoverPlugins — same filename: newer mtime wins", "[PluginDiscovery]")
@@ -110,8 +110,8 @@ TEST_CASE("DiscoverPlugins — same filename: newer mtime wins", "[PluginDiscove
     auto const dirNew = tree.Dir("new");
 
     auto const base = BaseTime();
-    Touch(dirOld / "plugin.so", base);
-    Touch(dirNew / "plugin.so", base + std::chrono::seconds(30));
+    Touch(dirOld / "MyPlugin.so", base);
+    Touch(dirNew / "MyPlugin.so", base + std::chrono::seconds(30));
 
     std::vector<std::filesystem::path> dirs { dirOld, dirNew };
     std::vector<std::string> shadows;
@@ -119,9 +119,9 @@ TEST_CASE("DiscoverPlugins — same filename: newer mtime wins", "[PluginDiscove
 
     REQUIRE(resolved.size() == 1);
     CHECK(resolved.front().path.parent_path() == dirNew);
-    CHECK(resolved.front().path.filename() == std::filesystem::path("plugin.so"));
+    CHECK(resolved.front().path.filename() == std::filesystem::path("MyPlugin.so"));
     REQUIRE(shadows.size() == 1);
-    CHECK(shadows.front().contains("plugin.so"));
+    CHECK(shadows.front().contains("MyPlugin.so"));
     CHECK(shadows.front().contains("newer mtime"));
 }
 
@@ -132,8 +132,8 @@ TEST_CASE("DiscoverPlugins — mtime tie: earlier-listed dir wins", "[PluginDisc
     auto const dirSecond = tree.Dir("second");
 
     auto const same = BaseTime();
-    Touch(dirFirst / "plugin.dylib", same);
-    Touch(dirSecond / "plugin.dylib", same);
+    Touch(dirFirst / "MyPlugin.dylib", same);
+    Touch(dirSecond / "MyPlugin.dylib", same);
 
     std::vector<std::filesystem::path> dirs { dirFirst, dirSecond };
     auto const resolved = Lightweight::Tools::DiscoverPlugins(dirs);
@@ -148,7 +148,7 @@ TEST_CASE("DiscoverPlugins — non-plugin extensions are skipped", "[PluginDisco
     ScopedTempTree const tree;
     auto const dir = tree.Dir("mixed");
 
-    Touch(dir / "real.dll", BaseTime());
+    Touch(dir / "RealPlugin.dll", BaseTime());
     Touch(dir / "notes.txt", BaseTime());
     Touch(dir / "data.json", BaseTime());
 
@@ -156,7 +156,27 @@ TEST_CASE("DiscoverPlugins — non-plugin extensions are skipped", "[PluginDisco
     auto const resolved = Lightweight::Tools::DiscoverPlugins(dirs);
 
     REQUIRE(resolved.size() == 1);
-    CHECK(resolved.front().path.filename() == std::filesystem::path("real.dll"));
+    CHECK(resolved.front().path.filename() == std::filesystem::path("RealPlugin.dll"));
+}
+
+TEST_CASE("DiscoverPlugins — DLLs whose stem does not end in 'Plugin' are skipped", "[PluginDiscovery]")
+{
+    // Mirrors the real-world clutter in `out/build/.../plugins/` after vcpkg's
+    // applocal step copies a plugin's dependency closure next to it: only the
+    // actual plugin (stem ending in "Plugin") should be picked up by discovery.
+    ScopedTempTree const tree;
+    auto const dir = tree.Dir("applocal-like");
+
+    Touch(dir / "SqlMigrationsPlugin.dll", BaseTime());
+    Touch(dir / "Lightweight.dll", BaseTime());
+    Touch(dir / "zlibd1.dll", BaseTime());
+    Touch(dir / "bz2d.dll", BaseTime());
+
+    std::vector<std::filesystem::path> dirs { dir };
+    auto const resolved = Lightweight::Tools::DiscoverPlugins(dirs);
+
+    REQUIRE(resolved.size() == 1);
+    CHECK(resolved.front().path.filename() == std::filesystem::path("SqlMigrationsPlugin.dll"));
 }
 
 TEST_CASE("DiscoverPlugins — missing directories are skipped without crashing", "[PluginDiscovery]")
@@ -166,25 +186,27 @@ TEST_CASE("DiscoverPlugins — missing directories are skipped without crashing"
     auto const ghost = tree.Dir("ghost");
     std::filesystem::remove_all(ghost);
 
-    Touch(dir / "p.dll", BaseTime());
+    Touch(dir / "MyPlugin.dll", BaseTime());
 
     std::vector<std::filesystem::path> dirs { ghost, dir };
     auto const resolved = Lightweight::Tools::DiscoverPlugins(dirs);
 
     REQUIRE(resolved.size() == 1);
-    CHECK(resolved.front().path.filename() == std::filesystem::path("p.dll"));
+    CHECK(resolved.front().path.filename() == std::filesystem::path("MyPlugin.dll"));
 }
 
 #ifdef _WIN32
 TEST_CASE("DiscoverPlugins — filename comparison is case-insensitive on Windows", "[PluginDiscovery]")
 {
+    // Both names pass the case-insensitive `*Plugin` suffix filter, and the
+    // dedup key collapses `FooPlugin.dll` and `fooplugin.dll` to one entry.
     ScopedTempTree const tree;
     auto const dirA = tree.Dir("a");
     auto const dirB = tree.Dir("b");
 
     auto const base = BaseTime();
-    Touch(dirA / "Plugin.dll", base);
-    Touch(dirB / "plugin.dll", base + std::chrono::seconds(10));
+    Touch(dirA / "FooPlugin.dll", base);
+    Touch(dirB / "fooplugin.dll", base + std::chrono::seconds(10));
 
     std::vector<std::filesystem::path> dirs { dirA, dirB };
     auto const resolved = Lightweight::Tools::DiscoverPlugins(dirs);
@@ -195,19 +217,20 @@ TEST_CASE("DiscoverPlugins — filename comparison is case-insensitive on Window
 #else
 TEST_CASE("DiscoverPlugins — filename comparison is case-sensitive on POSIX", "[PluginDiscovery]")
 {
+    // Both stems end in the exact token `Plugin` (case-sensitive), so both
+    // pass the suffix filter; on a case-sensitive filesystem they're two
+    // distinct plugins, not a duplicate.
     ScopedTempTree const tree;
     auto const dirA = tree.Dir("a");
     auto const dirB = tree.Dir("b");
 
     auto const base = BaseTime();
-    Touch(dirA / "Plugin.so", base);
-    Touch(dirB / "plugin.so", base + std::chrono::seconds(10));
+    Touch(dirA / "FooPlugin.so", base);
+    Touch(dirB / "fooPlugin.so", base + std::chrono::seconds(10));
 
     std::vector<std::filesystem::path> dirs { dirA, dirB };
     auto const resolved = Lightweight::Tools::DiscoverPlugins(dirs);
 
-    // On case-sensitive filesystems these are two distinct plugins, not a
-    // duplicate — both should survive.
     REQUIRE(resolved.size() == 2);
 }
 #endif

--- a/src/tests/PluginIngestionTests.cpp
+++ b/src/tests/PluginIngestionTests.cpp
@@ -126,8 +126,8 @@ TEST_CASE("IngestPlugins — loader invoked once per resolved plugin", "[PluginI
     auto const dirNew = tree.Dir("new");
 
     auto const base = Baseline();
-    TouchPluginFile(dirOld / "p.dll", base);
-    TouchPluginFile(dirNew / "p.dll", base + std::chrono::seconds(60));
+    TouchPluginFile(dirOld / "MyPlugin.dll", base);
+    TouchPluginFile(dirNew / "MyPlugin.dll", base + std::chrono::seconds(60));
 
     Lightweight::SqlMigration::MigrationManager central;
     std::vector<std::filesystem::path> callPaths;
@@ -153,14 +153,14 @@ TEST_CASE("IngestPlugins — nullopt from loader is a silent skip", "[PluginInge
 {
     ScopedTempTree const tree;
     auto const dir = tree.Dir("plugins");
-    TouchPluginFile(dir / "real.dll", Baseline());
-    TouchPluginFile(dir / "passthrough.dll", Baseline());
+    TouchPluginFile(dir / "RealPlugin.dll", Baseline());
+    TouchPluginFile(dir / "PassthroughPlugin.dll", Baseline());
 
     Lightweight::SqlMigration::MigrationManager central;
     std::vector<std::string> errors;
 
     auto loader = [&](std::filesystem::path const& path) -> std::optional<Lightweight::Tools::LoadedPlugin> {
-        if (path.filename() == "passthrough.dll")
+        if (path.filename() == "PassthroughPlugin.dll")
             return std::nullopt;
         return Lightweight::Tools::LoadedPlugin {
             .path = path,
@@ -178,7 +178,7 @@ TEST_CASE("IngestPlugins — nullopt from loader is a silent skip", "[PluginInge
     auto const loaded = Lightweight::Tools::IngestPlugins(dirs, loader, central, opts);
 
     REQUIRE(loaded.size() == 1);
-    CHECK(loaded.front().path.filename() == std::filesystem::path("real.dll"));
+    CHECK(loaded.front().path.filename() == std::filesystem::path("RealPlugin.dll"));
     CHECK(errors.empty());
 }
 
@@ -186,7 +186,7 @@ TEST_CASE("IngestPlugins — loader exception rethrows when throwOnLoadError is 
 {
     ScopedTempTree const tree;
     auto const dir = tree.Dir("plugins");
-    TouchPluginFile(dir / "bad.dll", Baseline());
+    TouchPluginFile(dir / "BadPlugin.dll", Baseline());
 
     Lightweight::SqlMigration::MigrationManager central;
     std::string errorLine;
@@ -203,7 +203,7 @@ TEST_CASE("IngestPlugins — loader exception rethrows when throwOnLoadError is 
 
     std::vector<std::filesystem::path> dirs { dir };
     REQUIRE_THROWS_AS(Lightweight::Tools::IngestPlugins(dirs, loader, central, opts), std::runtime_error);
-    CHECK(errorLine.contains("bad.dll"));
+    CHECK(errorLine.contains("BadPlugin.dll"));
     CHECK(errorLine.contains("boom"));
 }
 
@@ -211,15 +211,15 @@ TEST_CASE("IngestPlugins — loader exception is swallowed when throwOnLoadError
 {
     ScopedTempTree const tree;
     auto const dir = tree.Dir("plugins");
-    TouchPluginFile(dir / "a.dll", Baseline());
-    TouchPluginFile(dir / "b.dll", Baseline() + std::chrono::seconds(5));
+    TouchPluginFile(dir / "APlugin.dll", Baseline());
+    TouchPluginFile(dir / "BPlugin.dll", Baseline() + std::chrono::seconds(5));
 
     Lightweight::SqlMigration::MigrationManager central;
     int errorCount = 0;
 
     auto loader = [](std::filesystem::path const& path) -> std::optional<Lightweight::Tools::LoadedPlugin> {
-        if (path.filename() == "a.dll")
-            throw std::runtime_error("a.dll is poisoned");
+        if (path.filename() == "APlugin.dll")
+            throw std::runtime_error("APlugin.dll is poisoned");
         return Lightweight::Tools::LoadedPlugin {
             .path = path,
             .handle = std::make_shared<int>(0),
@@ -237,7 +237,7 @@ TEST_CASE("IngestPlugins — loader exception is swallowed when throwOnLoadError
     auto const loaded = Lightweight::Tools::IngestPlugins(dirs, loader, central, opts);
 
     REQUIRE(loaded.size() == 1);
-    CHECK(loaded.front().path.filename() == std::filesystem::path("b.dll"));
+    CHECK(loaded.front().path.filename() == std::filesystem::path("BPlugin.dll"));
     CHECK(errorCount == 1);
 }
 
@@ -245,8 +245,8 @@ TEST_CASE("IngestPlugins — duplicate handle is rejected", "[PluginIngestion]")
 {
     ScopedTempTree const tree;
     auto const dir = tree.Dir("plugins");
-    TouchPluginFile(dir / "first.dll", Baseline());
-    TouchPluginFile(dir / "second.dll", Baseline() + std::chrono::seconds(5));
+    TouchPluginFile(dir / "FirstPlugin.dll", Baseline());
+    TouchPluginFile(dir / "SecondPlugin.dll", Baseline() + std::chrono::seconds(5));
 
     Lightweight::SqlMigration::MigrationManager central;
     // Both calls hand back the *same* shared_ptr — simulating an OS-level
@@ -279,7 +279,7 @@ TEST_CASE("IngestPlugins — releases and migrations propagate to central", "[Pl
 {
     ScopedTempTree const tree;
     auto const dir = tree.Dir("plugins");
-    TouchPluginFile(dir / "plugin.dll", Baseline());
+    TouchPluginFile(dir / "MainPlugin.dll", Baseline());
 
     Lightweight::SqlMigration::MigrationManager central;
 
@@ -316,7 +316,7 @@ TEST_CASE("IngestPlugins — pluginManager == &central is a no-op merge", "[Plug
 {
     ScopedTempTree const tree;
     auto const dir = tree.Dir("plugins");
-    TouchPluginFile(dir / "self.dll", Baseline());
+    TouchPluginFile(dir / "SelfPlugin.dll", Baseline());
 
     Lightweight::SqlMigration::MigrationManager central;
     FakeMigration preexisting { Lightweight::SqlMigration::MigrationTimestamp { 20260201000000ULL }, "pre" };
@@ -344,8 +344,8 @@ TEST_CASE("IngestPlugins — logShadowed wired through to DiscoverPlugins", "[Pl
     auto const dirOld = tree.Dir("old");
     auto const dirNew = tree.Dir("new");
     auto const base = Baseline();
-    TouchPluginFile(dirOld / "twin.dll", base);
-    TouchPluginFile(dirNew / "twin.dll", base + std::chrono::seconds(30));
+    TouchPluginFile(dirOld / "TwinPlugin.dll", base);
+    TouchPluginFile(dirNew / "TwinPlugin.dll", base + std::chrono::seconds(30));
 
     Lightweight::SqlMigration::MigrationManager central;
     int shadowedCount = 0;
@@ -374,9 +374,9 @@ TEST_CASE("IngestPlugins — logLoading fires per successfully-loaded plugin", "
 {
     ScopedTempTree const tree;
     auto const dir = tree.Dir("plugins");
-    TouchPluginFile(dir / "a.dll", Baseline());
-    TouchPluginFile(dir / "b.dll", Baseline() + std::chrono::seconds(1));
-    TouchPluginFile(dir / "c.dll", Baseline() + std::chrono::seconds(2));
+    TouchPluginFile(dir / "APlugin.dll", Baseline());
+    TouchPluginFile(dir / "BPlugin.dll", Baseline() + std::chrono::seconds(1));
+    TouchPluginFile(dir / "CPlugin.dll", Baseline() + std::chrono::seconds(2));
 
     Lightweight::SqlMigration::MigrationManager central;
     int loadingCount = 0;

--- a/src/tests/dummy_migration_plugin/CMakeLists.txt
+++ b/src/tests/dummy_migration_plugin/CMakeLists.txt
@@ -4,10 +4,16 @@ add_library(dummy_migration_plugin MODULE
 
 target_link_libraries(dummy_migration_plugin PRIVATE Lightweight)
 
-# Ensure the library is put in a known location for testing
+# Ensure the library is put in a known location for testing.
+# OUTPUT_NAME aligns the built filename with the `*Plugin` suffix that
+# `Lightweight::Tools::DiscoverPlugins` requires — without this the file
+# would be called `dummy_migration_plugin.{dll,so,dylib}` and discovery
+# would silently skip it.
 set_target_properties(dummy_migration_plugin PROPERTIES
+    OUTPUT_NAME "DummyMigrationPlugin"
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/plugins"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/plugins"
+    PREFIX ""
 )
 
 install(TARGETS dummy_migration_plugin DESTINATION ${CMAKE_INSTALL_DATADIR}/Lightweight/tests/plugins)

--- a/src/tests/dummy_migration_plugin_2/CMakeLists.txt
+++ b/src/tests/dummy_migration_plugin_2/CMakeLists.txt
@@ -4,10 +4,16 @@ add_library(dummy_migration_plugin_2 MODULE
 
 target_link_libraries(dummy_migration_plugin_2 PRIVATE Lightweight)
 
-# Ensure the library is put in a known location for testing
+# Ensure the library is put in a known location for testing.
+# OUTPUT_NAME aligns the built filename with the `*Plugin` suffix that
+# `Lightweight::Tools::DiscoverPlugins` requires — without this the file
+# would be called `dummy_migration_plugin_2.{dll,so,dylib}` and discovery
+# would silently skip it.
 set_target_properties(dummy_migration_plugin_2 PROPERTIES
+    OUTPUT_NAME "DummyMigration2Plugin"
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/plugins"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/plugins"
+    PREFIX ""
 )
 
 install(TARGETS dummy_migration_plugin_2 DESTINATION ${CMAKE_INSTALL_DATADIR}/Lightweight/tests/plugins)

--- a/src/tools/shared/PluginDiscovery.cpp
+++ b/src/tools/shared/PluginDiscovery.cpp
@@ -47,6 +47,38 @@ namespace
         return ext == ".so" || ext == ".dll" || ext == ".dylib";
     }
 
+    /// True when `p`'s file stem ends with the literal token "Plugin" (e.g.
+    /// `FooPlugin.dll`, `SqlMigrationsPlugin.so`). Filtering before
+    /// `LoadLibrary`/`dlopen` is what keeps neighbouring runtime DLLs out of
+    /// the loader: a vcpkg-applocal deposit (`zlib1.dll`, `bz2d.dll`, ...) or
+    /// a Qt frontend's Qt6*.dll has no business being mapped into dbtool just
+    /// to be skipped at the symbol-lookup step. Match the case-sensitivity
+    /// policy already used by `FilenameKeyFromPath` so a user's mental model
+    /// of "what counts as the same filename" stays consistent across both
+    /// stages of discovery.
+    [[nodiscard]] bool HasPluginStemSuffix(std::filesystem::path const& p) noexcept
+    {
+#ifdef _WIN32
+        constexpr std::wstring_view requiredSuffix { L"Plugin" };
+        auto const stem = p.stem().wstring();
+        if (stem.size() < requiredSuffix.size())
+            return false;
+        auto const tail = std::wstring_view(stem).substr(stem.size() - requiredSuffix.size());
+        // Case-insensitive on Windows: NTFS/refs and `LoadLibraryW` both
+        // ignore case, so `myplugin.dll` and `MyPlugin.dll` mean the same
+        // thing to the loader and should mean the same thing here.
+        return std::ranges::equal(tail, requiredSuffix, [](wchar_t a, wchar_t b) {
+            return std::towlower(static_cast<wint_t>(a)) == std::towlower(static_cast<wint_t>(b));
+        });
+#else
+        constexpr std::string_view requiredSuffix { "Plugin" };
+        auto const stem = p.stem().string();
+        if (stem.size() < requiredSuffix.size())
+            return false;
+        return std::string_view(stem).substr(stem.size() - requiredSuffix.size()) == requiredSuffix;
+#endif
+    }
+
     struct Candidate
     {
         std::filesystem::path path;
@@ -166,7 +198,7 @@ namespace
         {
             if (ec)
                 break;
-            if (!entry.is_regular_file(ec) || !IsPluginExtension(entry.path()))
+            if (!entry.is_regular_file(ec) || !IsPluginExtension(entry.path()) || !HasPluginStemSuffix(entry.path()))
                 continue;
             IngestCandidate(winners, MakeCandidate(entry.path(), dirIndex, encounter++), emit);
         }

--- a/src/tools/shared/PluginDiscovery.hpp
+++ b/src/tools/shared/PluginDiscovery.hpp
@@ -36,8 +36,19 @@ struct ResolvedPlugin
 };
 
 /// Scans every directory in `dirs` for shared libraries (`.so` / `.dll` /
-/// `.dylib`), deduplicates by filename, and returns the surviving entries
-/// in directory-listing order.
+/// `.dylib`) **whose file stem ends with the literal token `Plugin`** (e.g.
+/// `FooPlugin.dll`, `SqlMigrationsPlugin.so`), deduplicates by filename, and
+/// returns the surviving entries in directory-listing order.
+///
+/// Naming requirement:
+///   - A file is only considered a plugin candidate when its stem ends in
+///     `Plugin`. This is enforced **before** `LoadLibrary`/`dlopen`, so
+///     neighbouring runtime DLLs (vcpkg-applocal deposits like `zlib1.dll`
+///     or `bz2d.dll`, Qt6*.dll dropped next to a GUI tool, the C/C++
+///     runtimes, ...) are never mapped into the host process just to be
+///     skipped at the symbol-lookup step.
+///   - The suffix check is **case-insensitive on Windows** (matching the
+///     filesystem and `LoadLibraryW`) and **case-sensitive elsewhere**.
 ///
 /// Deduplication rules:
 ///   - The filename (basename, including extension) is the dedup key. Two


### PR DESCRIPTION
## Summary

- `Lightweight::Tools::DiscoverPlugins` now rejects shared libraries whose file stem does not end in the literal token `Plugin` (e.g. `FooPlugin.dll`, `SqlMigrationsPlugin.so`). The filter runs **before** `LoadLibrary` / `dlopen`, so neighbouring runtime DLLs (vcpkg-applocal deposits like `Lightweight.dll` / `zlibd1.dll` / `bz2d.dll`, Qt6*.dll dropped next to a GUI tool, MSVC runtimes, …) are never mapped into the host process and never run their `DllMain`.
- Case-insensitive on Windows (matching the filesystem and `LoadLibraryW`); case-sensitive on POSIX. Mirrors the existing `FilenameKeyFromPath` policy.
- The `TryGetFunction("AcquireMigrationManager")` null-skip in `DefaultPluginLoader` is kept as defence-in-depth: a `*Plugin.dll` without the entry point is still silently skipped rather than aborting dbtool.

## Motivation

A debug build of a downstream project (Lastrada) puts the migration plugin DLL in `<build>/plugins/`. After link, vcpkg's applocal deployment step (`VCPKG_APPLOCAL_DEPS=ON`) copies the plugin's transitive runtime DLL closure into the same directory. Result: dbtool would `LoadLibrary` `Lightweight.dll` / `zlibd1.dll` / `bz2d.dll` / etc. on every startup, run their DllMain, walk their import tables, only to discard them seconds later for missing the plugin entry point. With the filter, only `SqlMigrationsPlugin.dll` is loaded.

## Knock-on changes

- The two dummy migration plugin targets (`src/tests/dummy_migration_plugin{,_2}/CMakeLists.txt`) set `OUTPUT_NAME` to `DummyMigrationPlugin` / `DummyMigrationPlugin2` and `PREFIX ""` so the built artefacts conform to the new convention on both Windows and POSIX. Source folders and CMake target names are unchanged.
- `PluginDiscoveryTests.cpp` / `PluginIngestionTests.cpp` fixture filenames renamed to conforming names.
- New `TEST_CASE("DiscoverPlugins — DLLs whose stem does not end in 'Plugin' are skipped")` mirrors the applocal-style clutter and asserts only the plugin survives discovery.

## Documentation

The naming requirement is spelled out in the leading doc block of `DiscoverPlugins` in `PluginDiscovery.hpp`, with a "why" pointing at the applocal scenario above.

## Test plan

- [x] Unit tests: `LightweightTest` (Catch2) — existing tests pass after fixture rename, new `applocal-like` test asserts the filter rejects the four neighbours.
- [x] dbtool integration test (`test_dbtool.py`) — enumerates the test plugins dir by extension; the `OUTPUT_NAME` rename is transparent. No script change needed.
- [x] Manual: smoke-test `dbtool list-pending` against a `plugins/` directory that contains `SqlMigrationsPlugin.dll` + `Lightweight.dll` + `zlibd1.dll` and confirm only the plugin is loaded.