### PR TITLE
Improve dbtool-gui log pane with startup, plugin, and connection events

### DIFF
--- a/src/tools/dbtool-gui/AppController.cpp
+++ b/src/tools/dbtool-gui/AppController.cpp
@@ -6,9 +6,11 @@
 #include <Lightweight/SqlConnection.hpp>
 #include <Lightweight/SqlError.hpp>
 #include <Lightweight/SqlMigration.hpp>
+#include <Lightweight/SqlServerType.hpp>
 
 #include <PluginIngestion.hpp>
 #include <PluginLoader.hpp>
+#include <QtCore/QtGlobal>
 
 namespace DbtoolGui
 {
@@ -39,6 +41,8 @@ struct AppController::PluginsBundle
 #include <QtCore/QTimer>
 #include <QtCore/QUrl>
 #include <QtGui/QDesktopServices>
+#include <QtGui/QGuiApplication>
+#include <QtGui/QStyleHints>
 
 namespace DbtoolGui
 {
@@ -115,29 +119,23 @@ namespace
         return fallback.isEmpty() ? QStringLiteral("(no details reported)") : fallback;
     }
 
-    /// Builds the `Tools::PluginIngestOptions` the GUI uses for every
-    /// `IngestPlugins` call. Verbose mode pipes shadow + loading lines
-    /// through `qInfo`; load errors always reach `qWarning` so a broken
-    /// plugin file is visible in the log even when verbose is off.
-    /// `throwOnLoadError = false` keeps the rest of the migration set
-    /// usable when one plugin fails to load.
-    [[nodiscard]] Lightweight::Tools::PluginIngestOptions MakeGuiIngestOptions(bool verbose)
+    /// Maps the internal `SqlServerType` enum to the human-readable display
+    /// string already used by the project's `std::formatter` specialization
+    /// (which `dbtool` and the docs also use). Keeps the GUI's "Connected:"
+    /// log line consistent with every other surface that names a server.
+    /// @param serverType Server flavour detected by `SqlConnection`.
+    /// @return UTF-16 display string, e.g. `"PostgreSQL"` or `"SQLite"`.
+    [[nodiscard]] QString ServerTypeDisplayName(Lightweight::SqlServerType serverType)
     {
-        Lightweight::Tools::PluginIngestOptions opts;
-        if (verbose)
-        {
-            opts.logShadowed = [](std::string_view msg) {
-                qInfo("%s", std::string(msg).c_str());
-            };
-            opts.logLoading = [](std::string_view msg) {
-                qInfo("%s", std::string(msg).c_str());
-            };
-        }
-        opts.logError = [](std::string_view msg) {
-            qWarning("%s", std::string(msg).c_str());
-        };
-        opts.throwOnLoadError = false; // GUI surfaces the error and keeps running
-        return opts;
+        return QString::fromStdString(std::format("{}", serverType));
+    }
+
+    /// Converts a UTF-8 `std::string_view` (the form every `PluginIngestion`
+    /// callback receives) into the `QString` the log feed wants. Centralised
+    /// so the three callbacks below all do the trim/convert the same way.
+    [[nodiscard]] QString FromUtf8View(std::string_view msg)
+    {
+        return QString::fromUtf8(msg.data(), static_cast<qsizetype>(msg.size()));
     }
 
 } // namespace
@@ -206,13 +204,19 @@ AppController::AppController(QObject* parent):
     // include real execution context (the failing DDL, driver error, etc.)
     // without asking QML to read the LogPanel — which lives in a sibling
     // QML tree that may not even be instantiated under the Simple view.
-    auto const bufferLogLine = [this](QString const& line, int /*level*/) {
+    auto const bufferLogLine = [this](QString const& line, LogLevel /*level*/) {
         _recentLog.append(line);
         while (_recentLog.size() > kRecentLogCapacity)
             _recentLog.removeFirst();
     };
     QObject::connect(&_runner, &MigrationRunner::logLine, this, bufferLogLine);
     QObject::connect(&_backupRunner, &BackupRunner::logLine, this, bufferLogLine);
+
+    // The log pane subscribes to `AppController::logLine` (single source of
+    // truth). Forward the runners' streams so migration progress and backup
+    // events surface in the same feed as the startup banner.
+    QObject::connect(&_runner, &MigrationRunner::logLine, this, &AppController::logLine);
+    QObject::connect(&_backupRunner, &BackupRunner::logLine, this, &AppController::logLine);
     // After a run finishes, do one authoritative refresh. `Refresh` touches
     // schema_migrations and will throw on an unmanaged database — we fall
     // back to `RefreshPluginsOnly` in that case. An uncaught exception
@@ -294,12 +298,38 @@ AppController::AppController(QObject* parent):
 
     refreshOdbcDataSources();
 
+    // Startup banner — emitted while no QML receiver exists yet; the buffer
+    // in `Log()` holds these until `LogPanel.qml` calls `attachLogSink()`,
+    // at which point they replay in order. Plain English throughout —
+    // never the CLI flag name (e.g. "Plugins directory", not "--plugins-dir").
+    LogInfo(QStringLiteral("dbtool-gui starting (Qt %1)").arg(QLatin1String(qVersion())));
+    {
+        // `ui/theme` is the same QSettings key `main.cpp` writes via `--theme`
+        // and reads back across runs. Kept as a string literal here so this
+        // file does not have to import the constant from `main.cpp`.
+        QSettings const settings;
+        auto const requestedTheme = settings.value(QStringLiteral("ui/theme"), QStringLiteral("system")).toString();
+        auto const effectiveTheme = QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark
+                                        ? QStringLiteral("dark")
+                                        : QStringLiteral("light");
+        LogInfo(QStringLiteral("Theme: %1 (requested %2)").arg(effectiveTheme, requestedTheme));
+    }
+    LogInfo(QStringLiteral("View mode: %1").arg(_viewMode));
+    {
+        auto const storePath = !_profileStorePath.isEmpty()
+                                   ? _profileStorePath
+                                   : QString::fromStdString(Lightweight::Config::ProfileStore::DefaultPath().string());
+        LogInfo(QStringLiteral("Profile store: %1 (%2 profile(s))").arg(storePath).arg(_profiles.rowCount()));
+    }
+
     // Load the plugin DLLs eagerly so the migration list is populated before
     // the user clicks Connect. This runs after profile + settings restoration
     // because `EffectivePluginsDir()` consults both `_pluginsDir` and the
     // current profile. Safe to run here even if no connection is open —
     // plugin discovery is a pure filesystem operation.
     ReloadPlugins();
+
+    LogInfo(QStringLiteral("Ready — not connected. Pick a profile to connect."));
 }
 
 AppController::~AppController()
@@ -630,6 +660,8 @@ bool AppController::connectToProfile()
         return false;
     }
 
+    LogInfo(QStringLiteral("Connecting %1…").arg(connectionSummary()));
+
     auto& manager = Lightweight::SqlMigration::MigrationManager::GetInstance();
 
     // Plugin discovery is a pure filesystem operation independent of ODBC,
@@ -696,10 +728,33 @@ bool AppController::connectToProfile()
     }
     catch (std::exception const& e)
     {
-        ReportError(QStringLiteral("Could not open the database connection: %1").arg(ExceptionMessage(e)));
+        auto const failureMsg = ExceptionMessage(e);
+        LogError(QStringLiteral("Connection failed: %1").arg(failureMsg));
+        ReportError(QStringLiteral("Could not open the database connection: %1").arg(failureMsg));
         return false;
     }
     _everConnected = true;
+
+    // Connection is up — surface server flavour / database / version so the
+    // user knows *which* DB they just opened. Pulling these from
+    // `SqlConnection` (post-handshake) means we report what the driver
+    // actually negotiated, not what was in the typed-in connection string.
+    try
+    {
+        auto const& connection = Lightweight::DataMapper::AcquireThreadLocal().Connection();
+        auto const serverDisplay = ServerTypeDisplayName(connection.ServerType());
+        auto const databaseName = QString::fromStdString(connection.DatabaseName());
+        auto const serverVersion = QString::fromStdString(connection.ServerVersion());
+        LogInfo(QStringLiteral("Connected: %1 · %2 · %3").arg(serverDisplay, databaseName, serverVersion));
+        if (!effectiveSchema.empty())
+            LogInfo(QStringLiteral("Schema search path: %1").arg(QString::fromStdString(effectiveSchema)));
+    }
+    catch (std::exception const&)
+    {
+        // Best-effort metadata read — if it fails the connect itself still
+        // succeeded, so silently skip the descriptive line rather than
+        // contradict the previous "Connecting …" with a misleading error.
+    }
 
     // Opening migration history is best-effort. Failure here does NOT abort
     // the connect — the user may be pointing at an unmanaged database (no
@@ -753,6 +808,7 @@ bool AppController::connectToProfile()
 
     _connected = true;
     emit connectedChanged();
+    LogInfo(QStringLiteral("Applied migrations: %1 / %2").arg(appliedCount()).arg(_migrations.rowCount()));
     // Release labels and counter bindings depend on the applied-set we
     // just fetched. `Refresh` above already emitted `migrationsChanged`,
     // but that fired while `_connected` was still false — re-emit after
@@ -1147,6 +1203,7 @@ void AppController::InvalidateConnectionTarget()
         return;
     _connected = false;
     emit connectedChanged();
+    LogInfo(QStringLiteral("Disconnected."));
 }
 
 void AppController::ReloadPlugins()
@@ -1160,12 +1217,38 @@ void AppController::ReloadPlugins()
     manager.RemoveAllReleases();
     _plugins->entries.clear();
 
-    if (!pluginsDirs.empty())
+    if (pluginsDirs.empty())
     {
+        LogInfo(QStringLiteral("Plugins directory: none configured"));
+    }
+    else
+    {
+        QStringList dirDisplay;
+        dirDisplay.reserve(static_cast<qsizetype>(pluginsDirs.size()));
+        for (auto const& dir: pluginsDirs)
+            dirDisplay.append(QString::fromStdString(dir.string()));
+        LogInfo(QStringLiteral("Plugins directory: %1").arg(dirDisplay.join(QStringLiteral("; "))));
+
+        Lightweight::Tools::PluginIngestOptions opts;
+        // Forward every discovery event through the unified log feed.
+        // Successful loads / shadowed candidates run unconditionally —
+        // `_verbose` is no longer required to *see* discovery state,
+        // only to surface extra noise on stderr that nobody reads.
+        opts.logLoading = [this](std::string_view msg) {
+            LogInfo(QStringLiteral("Loaded plugin: %1").arg(FromUtf8View(msg)));
+        };
+        opts.logShadowed = [this](std::string_view msg) {
+            LogWarn(QStringLiteral("Plugin shadowed: %1").arg(FromUtf8View(msg)));
+        };
+        opts.logError = [this](std::string_view msg) {
+            LogError(QStringLiteral("Plugin failed: %1").arg(FromUtf8View(msg)));
+        };
+        opts.throwOnLoadError = false;
+
         try
         {
-            _plugins->entries = Lightweight::Tools::IngestPlugins(
-                pluginsDirs, Lightweight::Tools::DefaultPluginLoader(), manager, MakeGuiIngestOptions(_verbose));
+            _plugins->entries =
+                Lightweight::Tools::IngestPlugins(pluginsDirs, Lightweight::Tools::DefaultPluginLoader(), manager, opts);
         }
         catch (std::exception const& e)
         {
@@ -1178,8 +1261,10 @@ void AppController::ReloadPlugins()
             paths.reserve(static_cast<qsizetype>(pluginsDirs.size()));
             for (auto const& dir: pluginsDirs)
                 paths.append(QString::fromStdString(dir.string()));
-            ReportError(QStringLiteral("Failed to load plugins from %1: %2")
-                            .arg(paths.join(QStringLiteral("; ")), QString::fromUtf8(e.what())));
+            auto const errorText = QStringLiteral("Failed to load plugins from %1: %2")
+                                       .arg(paths.join(QStringLiteral("; ")), QString::fromUtf8(e.what()));
+            LogError(errorText);
+            ReportError(errorText);
         }
     }
 
@@ -1202,7 +1287,51 @@ void AppController::ReloadPlugins()
         _migrations.RefreshPluginsOnly(manager);
     }
     _releases.Refresh(manager);
+    LogInfo(QStringLiteral("Migrations available: %1 · Releases declared: %2")
+                .arg(_migrations.rowCount())
+                .arg(_releases.rowCount()));
     emit migrationsChanged();
+}
+
+void AppController::Log(LogLevel level, QString line)
+{
+    if (_logSinkAttached)
+    {
+        emit logLine(std::move(line), level);
+        return;
+    }
+    // No QML receiver yet — buffer until `attachLogSink()` runs. Plugin
+    // discovery happens in the constructor, well before `LogPanel.qml`
+    // exists, so emitting now would drop the message on the floor.
+    _pendingLogs.append({ std::move(line), level });
+}
+
+void AppController::LogInfo(QString line)
+{
+    Log(LogLevel::Info, std::move(line));
+}
+
+void AppController::LogWarn(QString line)
+{
+    Log(LogLevel::Warning, std::move(line));
+}
+
+void AppController::LogError(QString line)
+{
+    Log(LogLevel::Error, std::move(line));
+}
+
+void AppController::attachLogSink()
+{
+    if (_logSinkAttached)
+        return; // Idempotent — re-instantiating the panel must not replay the banner.
+    _logSinkAttached = true;
+    // Replay in the order events occurred. Move-out so the buffer can drop
+    // its allocation; it stays empty for the rest of the process lifetime.
+    auto pending = std::move(_pendingLogs);
+    _pendingLogs.clear();
+    for (auto const& entry: pending)
+        emit logLine(entry.first, entry.second);
 }
 
 } // namespace DbtoolGui

--- a/src/tools/dbtool-gui/AppController.hpp
+++ b/src/tools/dbtool-gui/AppController.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "BackupRunner.hpp"
+#include "LogLevel.hpp"
 #include "MigrationRunner.hpp"
 #include "Models/MigrationListModel.hpp"
 #include "Models/OdbcDataSourceListModel.hpp"
@@ -19,7 +20,9 @@
 #include "SqlQueryRunner.hpp"
 
 #include <Config/ProfileStore.hpp>
+#include <QtCore/QList>
 #include <QtCore/QObject>
+#include <QtCore/QPair>
 #include <QtCore/QString>
 #include <QtQml/QQmlEngine>
 
@@ -403,7 +406,21 @@ class AppController: public QObject
     /// nothing if no profile file has been loaded yet.
     Q_INVOKABLE void openProfileFileExternally();
 
+    /// Called from `LogPanel.qml`'s `Component.onCompleted` to flush any
+    /// startup/plugin/connection log messages produced *before* the QML
+    /// engine wired up its `Connections { target: AppController }` block.
+    /// Idempotent — repeated calls after the first one are no-ops, so
+    /// re-instantiating the panel (e.g. after a tab swap) doesn't replay
+    /// the buffered banner.
+    Q_INVOKABLE void attachLogSink();
+
   signals:
+    /// Unified log-pane feed: every startup banner, plugin discovery event,
+    /// connection-state change, and migration progress line emerges here.
+    /// `MigrationRunner::logLine` and `BackupRunner::logLine` are forwarded
+    /// into this signal so QML only has to listen to one source.
+    void logLine(QString line, DbtoolGui::LogLevel level);
+
     void currentProfileChanged();
     void connectedChanged();
     void connectionStringOverrideChanged();
@@ -435,6 +452,16 @@ class AppController: public QObject
   private:
     void ReportError(QString const& message);
     void ClearError();
+
+    /// Routes `line` at severity `level` into the unified `logLine` signal.
+    /// When the QML panel has not yet called `attachLogSink()` the message
+    /// is buffered and replayed when the panel comes online — important
+    /// because plugin discovery runs in the constructor, before any QML
+    /// receiver exists.
+    void Log(LogLevel level, QString line);
+    void LogInfo(QString line);
+    void LogWarn(QString line);
+    void LogError(QString line);
 
     /// Computes the effective plugin search directories for the current
     /// connection mode: the user override wins in `dsn` / `custom` modes,
@@ -524,6 +551,14 @@ class AppController: public QObject
     /// because the connection string just changed" (every subsequent
     /// connect).
     bool _everConnected = false;
+
+    /// Log messages produced before the QML `LogPanel` connected its
+    /// receiver (i.e. before `attachLogSink()` ran). Replayed in order on
+    /// first attach and then permanently bypassed.
+    QList<QPair<QString, LogLevel>> _pendingLogs;
+    /// `true` once `attachLogSink()` has run for the first time. Past that
+    /// point `Log()` emits directly without touching `_pendingLogs`.
+    bool _logSinkAttached = false;
 
     /// Forward-declared by the Qt pointer in the .cpp — a QFileSystemWatcher
     /// held by raw pointer to keep `<QtCore/QFileSystemWatcher>` out of this

--- a/src/tools/dbtool-gui/BackupRunner.cpp
+++ b/src/tools/dbtool-gui/BackupRunner.cpp
@@ -61,14 +61,14 @@ namespace
                                  .arg(QString::fromStdString(std::string { p.tableName }))
                                  .arg(p.currentRows)
                                  .arg(QString::fromStdString(std::string { p.message }));
-            auto const level = static_cast<int>(p.state == Lightweight::SqlBackup::Progress::State::Error     ? 2
-                                                : p.state == Lightweight::SqlBackup::Progress::State::Warning ? 1
-                                                                                                              : 0);
+            auto const level = p.state == Lightweight::SqlBackup::Progress::State::Error     ? LogLevel::Error
+                               : p.state == Lightweight::SqlBackup::Progress::State::Warning ? LogLevel::Warning
+                                                                                             : LogLevel::Info;
             QMetaObject::invokeMethod(
                 _target,
                 [this, msg, level] {
                     QMetaObject::invokeMethod(
-                        _target, "logLine", Qt::DirectConnection, Q_ARG(QString, msg), Q_ARG(int, level));
+                        _target, "logLine", Qt::DirectConnection, Q_ARG(QString, msg), Q_ARG(DbtoolGui::LogLevel, level));
                 },
                 Qt::QueuedConnection);
         }

--- a/src/tools/dbtool-gui/BackupRunner.hpp
+++ b/src/tools/dbtool-gui/BackupRunner.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "LogLevel.hpp"
+
 #include <atomic>
 #include <functional>
 
@@ -67,7 +69,7 @@ class BackupRunner: public QObject
     }
 
   signals:
-    void logLine(QString line, int level);
+    void logLine(QString line, DbtoolGui::LogLevel level);
     void finished(bool ok, QString summary);
     void phaseChanged();
 

--- a/src/tools/dbtool-gui/CMakeLists.txt
+++ b/src/tools/dbtool-gui/CMakeLists.txt
@@ -21,6 +21,7 @@ set(MIGRATIONS_GUI_CXX_SOURCES
     AppController.cpp
     BackupRunner.hpp
     BackupRunner.cpp
+    LogLevel.hpp
     MigrationRunner.hpp
     MigrationRunner.cpp
     QmlProgressManager.hpp

--- a/src/tools/dbtool-gui/LogLevel.hpp
+++ b/src/tools/dbtool-gui/LogLevel.hpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Shared severity classification for messages routed to the GUI's log pane.
+// `AppController::logLine`, `MigrationRunner::logLine`, and
+// `BackupRunner::logLine` all carry this enum so QML and C++ agree on the
+// vocabulary without relying on magic integers (0/1/2).
+//
+// Lives in its own header so the runner classes do not have to depend on
+// `AppController.hpp` (which would create an include cycle).
+
+#pragma once
+
+#include <QtCore/QObject>
+#include <QtQmlIntegration/QtQmlIntegration>
+
+namespace DbtoolGui
+{
+
+Q_NAMESPACE
+
+/// Severity classification for log-pane messages. Renderer-side colour and
+/// any future filtering UI key off these values; C++ producers should pick
+/// the level that matches the message's intent rather than reusing a raw
+/// integer that has to be remembered.
+enum class LogLevel : int
+{
+    /// Routine progress, neutral terminal-grey in the panel.
+    Info,
+    /// Soft anomaly the user should notice (e.g. shadowed plugin, missing
+    /// `schema_migrations` table). Amber.
+    Warning,
+    /// Hard failure (load error, failed migration, connection refused). Red.
+    Error,
+};
+Q_ENUM_NS(LogLevel)
+
+} // namespace DbtoolGui

--- a/src/tools/dbtool-gui/MigrationRunner.cpp
+++ b/src/tools/dbtool-gui/MigrationRunner.cpp
@@ -122,7 +122,7 @@ namespace
 
     /// Pushes a plain log line onto the runner from a worker thread, marshalling
     /// through the event loop so QML consumers see it on the GUI thread.
-    void PostLogLine(MigrationRunner* runner, QString const& line, int level)
+    void PostLogLine(MigrationRunner* runner, QString const& line, LogLevel level)
     {
         QMetaObject::invokeMethod(
             runner, [runner, line, level] { emit runner->logLine(line, level); }, Qt::QueuedConnection);
@@ -145,7 +145,8 @@ namespace
             [runner, ts, title, idx, total, verb] {
                 emit runner->migrationStarted(static_cast<qulonglong>(ts));
                 emit runner->progress(static_cast<qulonglong>(ts), title, idx, total);
-                emit runner->logLine(QStringLiteral("[%1/%2] %3 %4 %5").arg(idx).arg(total).arg(verb).arg(ts).arg(title), 0);
+                emit runner->logLine(QStringLiteral("[%1/%2] %3 %4 %5").arg(idx).arg(total).arg(verb).arg(ts).arg(title),
+                                     LogLevel::Info);
             },
             Qt::QueuedConnection);
     }
@@ -183,20 +184,24 @@ namespace
         auto const ts = static_cast<qulonglong>(ex.GetMigrationTimestamp().value);
         auto const step = static_cast<qulonglong>(ex.GetStepIndex());
 
-        PostLogLine(runner, QStringLiteral("!! %1 failed: %2 - %3 (step %4)").arg(verb).arg(ts).arg(title).arg(step), 2);
+        PostLogLine(runner,
+                    QStringLiteral("!! %1 failed: %2 - %3 (step %4)").arg(verb).arg(ts).arg(title).arg(step),
+                    LogLevel::Error);
         if (!sqlState.isEmpty() && sqlState != QStringLiteral("     "))
-            PostLogLine(runner, QStringLiteral("   SQL State: %1, Native error: %2").arg(sqlState).arg(nativeError), 2);
+            PostLogLine(runner,
+                        QStringLiteral("   SQL State: %1, Native error: %2").arg(sqlState).arg(nativeError),
+                        LogLevel::Error);
         if (!driverMsg.isEmpty())
         {
-            PostLogLine(runner, QStringLiteral("   Driver message:"), 2);
+            PostLogLine(runner, QStringLiteral("   Driver message:"), LogLevel::Error);
             for (auto const& line: driverMsg.split(QLatin1Char('\n'), Qt::KeepEmptyParts))
-                PostLogLine(runner, QStringLiteral("     %1").arg(line), 2);
+                PostLogLine(runner, QStringLiteral("     %1").arg(line), LogLevel::Error);
         }
         if (!failedSql.isEmpty())
         {
-            PostLogLine(runner, QStringLiteral("   Failed SQL:"), 2);
+            PostLogLine(runner, QStringLiteral("   Failed SQL:"), LogLevel::Error);
             for (auto const& line: failedSql.split(QLatin1Char('\n'), Qt::KeepEmptyParts))
-                PostLogLine(runner, QStringLiteral("     %1").arg(line), 2);
+                PostLogLine(runner, QStringLiteral("     %1").arg(line), LogLevel::Error);
         }
     }
 
@@ -231,7 +236,7 @@ void MigrationRunner::dryRunUpTo(QString const& targetTimestamp)
             PostLogLine(runner,
                         targetTs == 0 ? QStringLiteral("No pending migrations to dry-run.")
                                       : QStringLiteral("No pending migrations up to %1.").arg(targetLabel),
-                        1);
+                        LogLevel::Warning);
             PostFinished(runner, true, QStringLiteral("Dry-run produced 0 migrations."));
             return;
         }
@@ -241,13 +246,13 @@ void MigrationRunner::dryRunUpTo(QString const& targetTimestamp)
             targetTs == 0
                 ? QStringLiteral("-- Dry-run: would apply %1 pending migration(s).").arg(toRun.size())
                 : QStringLiteral("-- Dry-run: would apply %1 migration(s) up to %2.").arg(toRun.size()).arg(targetLabel),
-            0);
+            LogLevel::Info);
 
         for (size_t i = 0; i < toRun.size(); ++i)
         {
             if (runner->phase() == Phase::Cancelling)
             {
-                PostLogLine(runner, QStringLiteral("-- Cancelled."), 1);
+                PostLogLine(runner, QStringLiteral("-- Cancelled."), LogLevel::Warning);
                 PostFinished(runner, false, QStringLiteral("Dry-run cancelled."));
                 return;
             }
@@ -275,19 +280,19 @@ void MigrationRunner::applyUpTo(QString const& targetTimestamp)
             PostLogLine(runner,
                         targetTs == 0 ? QStringLiteral("No pending migrations to apply.")
                                       : QStringLiteral("No pending migrations up to %1.").arg(targetLabel),
-                        1);
+                        LogLevel::Warning);
             PostFinished(runner, true, QStringLiteral("Applied 0 migrations."));
             return;
         }
 
-        PostLogLine(runner, QStringLiteral("Applying %1 migration(s)...").arg(toRun.size()), 0);
+        PostLogLine(runner, QStringLiteral("Applying %1 migration(s)...").arg(toRun.size()), LogLevel::Info);
 
         size_t applied = 0;
         for (size_t i = 0; i < toRun.size(); ++i)
         {
             if (runner->phase() == Phase::Cancelling)
             {
-                PostLogLine(runner, QStringLiteral("-- Cancelled after %1 migration(s).").arg(applied), 1);
+                PostLogLine(runner, QStringLiteral("-- Cancelled after %1 migration(s).").arg(applied), LogLevel::Warning);
                 PostFinished(runner, false, QStringLiteral("Cancelled after %1 migrations.").arg(applied));
                 return;
             }
@@ -316,7 +321,7 @@ void MigrationRunner::applyUpTo(QString const& targetTimestamp)
                                 .arg(ts)
                                 .arg(QString::fromStdString(std::string { toRun[i]->GetTitle() }))
                                 .arg(QString::fromUtf8(e.what())),
-                            2);
+                            LogLevel::Error);
                 PostFinished(runner,
                              false,
                              QStringLiteral("Applied %1 of %2 migrations before failing.").arg(applied).arg(toRun.size()));
@@ -342,11 +347,12 @@ void MigrationRunner::dryRunSelected(QStringList const& timestamps)
         auto const toRun = CollectSelected(*manager, snapshot);
         if (toRun.empty())
         {
-            PostLogLine(runner, QStringLiteral("No pending migrations in the current selection."), 1);
+            PostLogLine(runner, QStringLiteral("No pending migrations in the current selection."), LogLevel::Warning);
             PostFinished(runner, true, QStringLiteral("Dry-run produced 0 migrations."));
             return;
         }
-        PostLogLine(runner, QStringLiteral("-- Dry-run: would apply %1 selected migration(s).").arg(toRun.size()), 0);
+        PostLogLine(
+            runner, QStringLiteral("-- Dry-run: would apply %1 selected migration(s).").arg(toRun.size()), LogLevel::Info);
         for (size_t i = 0; i < toRun.size(); ++i)
             PostProgress(runner, *toRun[i], i, toRun.size(), QStringLiteral("would apply"));
         PostFinished(runner, true, QStringLiteral("Dry-run produced %1 migrations.").arg(toRun.size()));
@@ -368,19 +374,19 @@ void MigrationRunner::applySelected(QStringList const& timestamps)
         auto const toRun = CollectSelected(*manager, snapshot);
         if (toRun.empty())
         {
-            PostLogLine(runner, QStringLiteral("No pending migrations in the current selection."), 1);
+            PostLogLine(runner, QStringLiteral("No pending migrations in the current selection."), LogLevel::Warning);
             PostFinished(runner, true, QStringLiteral("Applied 0 migrations."));
             return;
         }
 
-        PostLogLine(runner, QStringLiteral("Applying %1 selected migration(s)...").arg(toRun.size()), 0);
+        PostLogLine(runner, QStringLiteral("Applying %1 selected migration(s)...").arg(toRun.size()), LogLevel::Info);
 
         size_t applied = 0;
         for (size_t i = 0; i < toRun.size(); ++i)
         {
             if (runner->phase() == Phase::Cancelling)
             {
-                PostLogLine(runner, QStringLiteral("-- Cancelled after %1 migration(s).").arg(applied), 1);
+                PostLogLine(runner, QStringLiteral("-- Cancelled after %1 migration(s).").arg(applied), LogLevel::Warning);
                 PostFinished(runner, false, QStringLiteral("Cancelled after %1 migrations.").arg(applied));
                 return;
             }
@@ -403,7 +409,7 @@ void MigrationRunner::applySelected(QStringList const& timestamps)
             catch (std::exception const& e)
             {
                 PostMigrationFailed(runner, ts);
-                PostLogLine(runner, QStringLiteral("!! %1 — %2").arg(ts).arg(QString::fromUtf8(e.what())), 2);
+                PostLogLine(runner, QStringLiteral("!! %1 — %2").arg(ts).arg(QString::fromUtf8(e.what())), LogLevel::Error);
                 PostFinished(
                     runner, false, QStringLiteral("Applied %1 of %2 before failing.").arg(applied).arg(toRun.size()));
                 return;
@@ -429,7 +435,7 @@ void MigrationRunner::rollbackToRelease(QString const& version)
         if (!release)
         {
             auto const msg = QStringLiteral("Release '%1' is not declared").arg(QString::fromStdString(versionStd));
-            PostLogLine(runner, msg, 2);
+            PostLogLine(runner, msg, LogLevel::Error);
             PostFinished(runner, false, msg);
             return;
         }
@@ -457,29 +463,31 @@ void MigrationRunner::rollbackToRelease(QString const& version)
                 // inside the rich-text spans, so we split them here.
                 auto const ts = static_cast<qulonglong>(result.failedAt->value);
                 auto const title = QString::fromStdString(result.failedTitle);
-                PostLogLine(runner, QStringLiteral("!! Rollback failed: %1 - %2").arg(ts).arg(title), 2);
+                PostLogLine(runner, QStringLiteral("!! Rollback failed: %1 - %2").arg(ts).arg(title), LogLevel::Error);
                 if (!result.failedSql.empty())
                 {
-                    PostLogLine(
-                        runner, QStringLiteral("   Step: %1").arg(static_cast<qulonglong>(result.failedStepIndex)), 2);
+                    PostLogLine(runner,
+                                QStringLiteral("   Step: %1").arg(static_cast<qulonglong>(result.failedStepIndex)),
+                                LogLevel::Error);
                     if (!result.sqlState.empty() && result.sqlState != "     ")
                         PostLogLine(runner,
                                     QStringLiteral("   SQL State: %1, Native error: %2")
                                         .arg(QString::fromStdString(result.sqlState))
                                         .arg(static_cast<qlonglong>(result.nativeErrorCode)),
-                                    2);
-                    PostLogLine(runner, QStringLiteral("   Driver message:"), 2);
+                                    LogLevel::Error);
+                    PostLogLine(runner, QStringLiteral("   Driver message:"), LogLevel::Error);
                     auto const driverMsg = QString::fromStdString(result.errorMessage);
                     for (auto const& line: driverMsg.split(QLatin1Char('\n'), Qt::KeepEmptyParts))
-                        PostLogLine(runner, QStringLiteral("     %1").arg(line), 2);
-                    PostLogLine(runner, QStringLiteral("   Failed SQL:"), 2);
+                        PostLogLine(runner, QStringLiteral("     %1").arg(line), LogLevel::Error);
+                    PostLogLine(runner, QStringLiteral("   Failed SQL:"), LogLevel::Error);
                     auto const failedSql = QString::fromStdString(result.failedSql);
                     for (auto const& line: failedSql.split(QLatin1Char('\n'), Qt::KeepEmptyParts))
-                        PostLogLine(runner, QStringLiteral("     %1").arg(line), 2);
+                        PostLogLine(runner, QStringLiteral("     %1").arg(line), LogLevel::Error);
                 }
                 else
                 {
-                    PostLogLine(runner, QStringLiteral("   %1").arg(QString::fromStdString(result.errorMessage)), 2);
+                    PostLogLine(
+                        runner, QStringLiteral("   %1").arg(QString::fromStdString(result.errorMessage)), LogLevel::Error);
                 }
                 PostFinished(runner, false, QStringLiteral("Rollback of migration %1 '%2' failed").arg(ts).arg(title));
             }
@@ -501,7 +509,7 @@ void MigrationRunner::rollbackToRelease(QString const& version)
         }
         catch (std::exception const& e)
         {
-            PostLogLine(runner, QString::fromUtf8(e.what()), 2);
+            PostLogLine(runner, QString::fromUtf8(e.what()), LogLevel::Error);
             PostFinished(runner, false, QString::fromUtf8(e.what()));
         }
     });

--- a/src/tools/dbtool-gui/MigrationRunner.hpp
+++ b/src/tools/dbtool-gui/MigrationRunner.hpp
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include "LogLevel.hpp"
+
 #include <atomic>
 #include <functional>
 
@@ -88,7 +90,7 @@ class MigrationRunner: public QObject
 
   signals:
     void progress(qulonglong timestamp, QString title, int index, int total);
-    void logLine(QString line, int level);
+    void logLine(QString line, DbtoolGui::LogLevel level);
     void finished(bool ok, QString summary);
     void phaseChanged();
 

--- a/src/tools/dbtool-gui/main.cpp
+++ b/src/tools/dbtool-gui/main.cpp
@@ -110,8 +110,10 @@ int main(int argc, char* argv[])
     QGuiApplication::setOrganizationName(QStringLiteral("JP-Software"));
     QGuiApplication::setOrganizationDomain(QStringLiteral("lastrada.software"));
 
-    std::fprintf(stderr, "[INFO] dbtool-gui starting (Qt %s)\n", qVersion());
-    std::fflush(stderr);
+    // The "dbtool-gui starting (Qt …)" / "Theme: …" / "Event loop starting"
+    // lines now appear in the GUI's log pane (emitted by `AppController`'s
+    // constructor / startup banner). Keeping stderr copies as well would
+    // double-up the developer-facing console and the user-facing pane.
 
     QCommandLineParser parser;
     parser.setApplicationDescription(QStringLiteral("Lightweight SQL migrations GUI."));
@@ -148,14 +150,8 @@ int main(int argc, char* argv[])
     // is silently ignored by the KDE Plasma platform theme plugin.
     auto const themeModeEnum = DbtoolGui::ThemeController::ModeFromString(themeMode);
     DbtoolGui::ThemeController::SeedInitialMode(themeModeEnum);
-    auto const effectiveDark = themeModeEnum == DbtoolGui::ThemeController::Mode::Dark
-                               || (themeModeEnum == DbtoolGui::ThemeController::Mode::System
-                                   && QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark);
-    std::fprintf(stderr,
-                 "[INFO] Theme: requested=%s, effective=%s\n",
-                 themeMode.toLocal8Bit().constData(),
-                 effectiveDark ? "dark" : "light");
-    std::fflush(stderr);
+    // (Effective theme is logged into the GUI's log pane from
+    // `AppController`'s constructor — see the banner there.)
 
     // "Fusion" gives us a consistent look across platforms until we commit to
     // a native style per OS. The mockup in docs/migrations-gui-mockup.html is
@@ -186,7 +182,5 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    std::fprintf(stderr, "[INFO] Event loop starting\n");
-    std::fflush(stderr);
     return app.exec();
 }

--- a/src/tools/dbtool-gui/qml/LogPanel.qml
+++ b/src/tools/dbtool-gui/qml/LogPanel.qml
@@ -33,10 +33,13 @@ Rectangle {
     // API that preserves cursor/selection state.
     property int lineCount: 0
 
+    // `level` is `DbtoolGui::LogLevel` from C++ — the QML side receives the
+    // underlying integer (0=Info, 1=Warning, 2=Error). Keep this table in
+    // sync with `LogLevel.hpp` if the enum is ever extended.
     function colorFor(level) {
-        if (level === 2) return "#f87171";
-        if (level === 1) return "#fbbf24";
-        return "#cbd5e1";
+        if (level === 2) return "#f87171"; // Error
+        if (level === 1) return "#fbbf24"; // Warning
+        return "#cbd5e1";                  // Info
     }
 
     function escapeHtml(s) {
@@ -115,8 +118,13 @@ Rectangle {
         }
     }
 
+    // Drain any startup banner / plugin-discovery / connect lines that
+    // `AppController` buffered before this panel existed. Idempotent on the
+    // C++ side, so a panel re-instantiation does not replay the banner.
+    Component.onCompleted: AppController.attachLogSink()
+
     Connections {
-        target: AppController.runner
+        target: AppController
         function onLogLine(line, level) {
             logText.append("<span style=\"color:" + root.colorFor(level) + ";\">"
                 + root.escapeHtml(line) + "</span>");


### PR DESCRIPTION
Today `LogPanel` in dbtool-gui is fed only by `MigrationRunner::logLine`, so it sits empty until the user clicks Migrate. A user opening dbtool-gui cannot tell which plugins were loaded, which database was just connected, or where the profile store lives — even though all of that is already known internally. This PR makes the pane a chronological narrative of "what just happened".

## Changes

- **Startup banner** in `AppController`'s constructor: Qt version, theme (effective + requested), view mode, profile-store path + profile count.
- **Plugin discovery** (per `ReloadPlugins`): resolved plugins directory, per-plugin `Loaded` / `Shadowed` / `Failed` lines, summary count of migrations & releases. Runs unconditionally — `--verbose` no longer gates discovery output, it only controls extra stderr noise.
- **Database connect** (per `connectToProfile`): `Connecting <summary>…`, `Connected: <ServerType> · <database> · <version>`, optional `Schema search path: …`, and `Applied migrations: A / T`. Failures log `Connection failed: …` in addition to the existing error banner. Disconnect emits `Disconnected.`
- **Typed log level**: new `enum class DbtoolGui::LogLevel { Info, Warning, Error }` with `Q_NAMESPACE` + `Q_ENUM_NS` replaces every magic `0`/`1`/`2` at the C++ signal boundary (`MigrationRunner::logLine`, `BackupRunner::logLine`, and the new `AppController::logLine`).
- **Unified feed**: `AppController` gains a single `logLine` signal; the runners forward into it so QML has one subscription source. Messages emitted before `LogPanel.qml` exists (plugin discovery happens in the constructor, well before the QML engine wires up its receiver) are buffered and replayed when QML calls `attachLogSink()` from `Component.onCompleted`.
- **Reused, never reinvented**: `connectionSummary()` continues to redact secrets, so the pane never leaks passwords; `SqlConnection::{ServerType,DatabaseName,ServerVersion}` is queried post-handshake so the reported flavour matches what the driver actually negotiated.
- **No more stderr duplication**: the three `fprintf(stderr, ...)` startup lines in `main.cpp` are removed — their content is now in the pane, where users can actually see it.

No public API surface changes; `LogLevel` lives in the `DbtoolGui` namespace and is only used by the GUI binary. `LightweightTest` remains green on SQLite (7396 assertions pass); `dbtool` itself is untouched.