### PR TITLE
migration: lazy schema_migrations + log-pane wiring (folds #501)

### DIFF
--- a/src/Lightweight/SqlMigration.cpp
+++ b/src/Lightweight/SqlMigration.cpp
@@ -43,6 +43,24 @@ namespace
         return std::format(
             "Failed to {} migration {} '{}' at step {}: {}", verb, timestamp.value, title, stepIndex, driverError.message);
     }
+
+    /// Convert a (possibly empty) author string into the storage form used by
+    /// `SchemaMigration::author`. Empty input maps to `std::nullopt` so the row
+    /// is rendered with a SQL NULL rather than an empty `VARCHAR(128)`.
+    std::optional<SqlString<128>> MakeOptionalSqlString128(std::string_view value)
+    {
+        if (value.empty())
+            return std::nullopt;
+        return SqlString<128> { value };
+    }
+
+    /// Same as `MakeOptionalSqlString128`, sized for `SchemaMigration::description`.
+    std::optional<SqlString<1024>> MakeOptionalSqlString1024(std::string_view value)
+    {
+        if (value.empty())
+            return std::nullopt;
+        return SqlString<1024> { value };
+    }
 } // namespace
 
 MigrationException::MigrationException(Operation operation,
@@ -249,22 +267,156 @@ std::string_view MigrationManager::DefaultSchema() const noexcept
 std::vector<MigrationTimestamp> MigrationManager::GetAppliedMigrationIds() const
 {
     auto result = std::vector<MigrationTimestamp> {};
-    auto& dm = GetDataMapper();
-    auto records = std::vector<SchemaMigration> {};
 
+    // Database half: read `schema_migrations` rows when the table exists. When
+    // it does not (fresh DB, or any read-only command issued before the first
+    // apply), `Query` throws and we silently fall through to the overlay-only
+    // path. We deliberately *do not* create the table here — read paths must
+    // remain side-effect free so `dbtool status` against an untouched legacy
+    // database neither writes nor requires write permissions.
     try
     {
-        records = dm.Query<SchemaMigration>().OrderBy("version", SqlResultOrdering::ASCENDING).All();
+        auto const records = GetDataMapper().Query<SchemaMigration>().OrderBy("version", SqlResultOrdering::ASCENDING).All();
+        result.reserve(records.size());
+        for (auto const& record: records)
+            result.emplace_back(MigrationTimestamp { record.version.Value() });
     }
-    catch (SqlException const&)
+    catch (SqlException const& ex)
     {
-        return result;
+        // Table absent or otherwise unreadable — fall back to overlay-only.
+        Log(std::format("schema_migrations read fell through to overlay-only: {}", ex.what()));
     }
 
-    for (auto const& record: records)
-        result.emplace_back(MigrationTimestamp { record.version.Value() });
+    // Overlay half: merge any virtually-applied IDs (populated by plugin
+    // post-init hooks) that the caller wants to be observable as applied even
+    // before `schema_migrations` has been materialised. Both inputs are sorted
+    // ascending; `set_union` produces a deduplicated, sorted result in one
+    // pass.
+    if (!_virtualAppliedIds.empty())
+    {
+        auto merged = std::vector<MigrationTimestamp> {};
+        merged.reserve(result.size() + _virtualAppliedIds.size());
+        std::ranges::set_union(result, _virtualAppliedIds, std::back_inserter(merged));
+        result = std::move(merged);
+    }
 
     return result;
+}
+
+void MigrationManager::AddVirtualAppliedMigrations(std::span<MigrationTimestamp const> timestamps)
+{
+    if (timestamps.empty())
+        return;
+
+    // Merge into the existing overlay, preserving the sorted+deduped invariant
+    // so `GetAppliedMigrationIds`'s `set_union` stays correct on subsequent
+    // calls. Sort the incoming chunk in-place via a local copy so the caller's
+    // span is not mutated.
+    auto incoming = std::vector<MigrationTimestamp> { timestamps.begin(), timestamps.end() };
+    std::ranges::sort(incoming);
+    auto const [removeBegin, removeEnd] = std::ranges::unique(incoming);
+    incoming.erase(removeBegin, removeEnd);
+
+    auto merged = std::vector<MigrationTimestamp> {};
+    merged.reserve(_virtualAppliedIds.size() + incoming.size());
+    std::ranges::set_union(_virtualAppliedIds, incoming, std::back_inserter(merged));
+    _virtualAppliedIds = std::move(merged);
+}
+
+void MigrationManager::ClearVirtualAppliedMigrations()
+{
+    _virtualAppliedIds.clear();
+}
+
+void MigrationManager::SetLogSink(LogSink sink)
+{
+    _logSink = std::move(sink);
+}
+
+void MigrationManager::Log(std::string_view message) const
+{
+    if (_logSink)
+        _logSink(message);
+}
+
+void MigrationManager::PersistVirtualAppliedMigrations()
+{
+    // We are crossing into write territory — materialise the history table
+    // exactly here, so read-only commands never trigger it. Done
+    // unconditionally (not gated on a non-empty overlay) because every write
+    // path that calls this also goes on to `dm.CreateExplicit(SchemaMigration{...})`
+    // for its own new row, which would fail with "no such table" on a fresh
+    // DB without an overlay otherwise. `CreateMigrationHistory` is idempotent
+    // and swallows "already exists" errors, so the cost on subsequent writes
+    // is a single catch on the SQL driver's table-exists check.
+    CreateMigrationHistory();
+
+    if (_virtualAppliedIds.empty())
+        return;
+
+    // Move the overlay onto the stack before any writes so re-entrant calls
+    // (e.g. an inner `MarkMigrationAsApplied` triggered by a future plugin
+    // hook) cannot observe a partially-drained state.
+    auto pending = std::move(_virtualAppliedIds);
+    _virtualAppliedIds.clear();
+
+    auto& dm = GetDataMapper();
+
+    // Re-read the rows that are *physically* present so the overlay is filtered
+    // against actual database state. This matters when a plugin re-installed
+    // an overlay entry that the database already knows about (e.g. running
+    // `dbtool migrate` twice on the same legacy DB without restarting).
+    auto realApplied = std::vector<MigrationTimestamp> {};
+    try
+    {
+        auto const records = dm.Query<SchemaMigration>().OrderBy("version", SqlResultOrdering::ASCENDING).All();
+        realApplied.reserve(records.size());
+        for (auto const& record: records)
+            realApplied.emplace_back(MigrationTimestamp { record.version.Value() });
+    }
+    catch (SqlException const& ex)
+    {
+        // `CreateMigrationHistory` just ran without throwing, so the table
+        // should exist. If `Query` still failed it is a real driver error and
+        // not the missing-table case — let it surface from the writes below.
+        Log(std::format("schema_migrations re-read after CreateMigrationHistory failed: {}", ex.what()));
+    }
+
+    // Index `_migrations` by timestamp so we can resolve each overlay entry
+    // back to a registered migration without an O(N*M) scan.
+    auto byTimestamp = std::unordered_map<uint64_t, MigrationBase const*> {};
+    byTimestamp.reserve(_migrations.size());
+    for (auto const* migration: _migrations)
+        byTimestamp.emplace(migration->GetTimestamp().value, migration);
+
+    for (auto const& timestamp: pending)
+    {
+        if (std::ranges::contains(realApplied, timestamp))
+            continue;
+
+        auto const it = byTimestamp.find(timestamp.value);
+        if (it == byTimestamp.end())
+        {
+            // Overlay entry points at a timestamp that no longer matches any
+            // registered migration (plugin was unloaded, or a plugin re-issued
+            // an old overlay against a manager that has since dropped the
+            // migration). Skipping is the right call: there is no checksum or
+            // metadata to record, and re-throwing would make the first
+            // `migrate` invocation of a stale overlay un-recoverable.
+            continue;
+        }
+        auto const& migration = *it->second;
+
+        auto const checksum = migration.ComputeChecksum(dm.Connection().QueryFormatter());
+        dm.CreateExplicit(SchemaMigration {
+            .version = migration.GetTimestamp().value,
+            .checksum = checksum,
+            .applied_at = SqlDateTime::Now(),
+            .author = MakeOptionalSqlString128(migration.GetAuthor()),
+            .description = MakeOptionalSqlString1024(migration.GetDescription()),
+            .execution_duration_ms = std::nullopt,
+        });
+    }
 }
 
 MigrationManager::MigrationList MigrationManager::GetPending() const noexcept
@@ -523,20 +675,6 @@ MigrationManager::MigrationList MigrationManager::GetMigrationsForRelease(std::s
 
 namespace
 {
-    std::optional<SqlString<128>> MakeOptionalSqlString128(std::string_view value)
-    {
-        if (value.empty())
-            return std::nullopt;
-        return SqlString<128> { value };
-    }
-
-    std::optional<SqlString<1024>> MakeOptionalSqlString1024(std::string_view value)
-    {
-        if (value.empty())
-            return std::nullopt;
-        return SqlString<1024> { value };
-    }
-
     /// Represents a parsed SQLite runtime guard extracted from a SQL script's leading sentinel comment.
     ///
     /// The SQLite formatter emits guarded DDL with a marker:
@@ -1047,6 +1185,13 @@ void MigrationManager::ApplySingleMigration(MigrationBase const& migration)
 
 void MigrationManager::ApplySingleMigration(MigrationBase const& migration, MigrationRenderContext& context)
 {
+    // We are about to write a real `schema_migrations` row, so any overlay
+    // entries contributed by plugin post-init hooks have to be materialised
+    // first — both so dependency checks below see the full history and so the
+    // table's row order matches the actual applied order. `PersistVirtualAppliedMigrations`
+    // is a no-op when the overlay is empty.
+    PersistVirtualAppliedMigrations();
+
     // Re-derive compat knobs for this specific migration. The column-width cache in
     // `context` persists across migrations (on purpose — CREATE TABLE in migration N
     // populates widths an INSERT in migration N+k consults); the per-migration knobs
@@ -1122,6 +1267,13 @@ void MigrationManager::ApplySingleMigration(MigrationBase const& migration, Migr
 
 void MigrationManager::RevertSingleMigration(MigrationBase const& migration)
 {
+    // Revert deletes a `schema_migrations` row, so the overlay (if any) needs
+    // to be drained first. A virtual-applied entry has no on-disk row to
+    // remove; persisting it before the revert lets `DELETE FROM schema_migrations`
+    // operate uniformly on the materialised history without a separate
+    // overlay-aware code path.
+    PersistVirtualAppliedMigrations();
+
     // Check if Down() is implemented before attempting revert
     if (!migration.HasDownImplementation())
     {
@@ -1426,8 +1578,21 @@ std::vector<ChecksumVerificationResult> MigrationManager::VerifyChecksums() cons
     std::vector<ChecksumVerificationResult> results;
     auto& dm = GetDataMapper();
 
-    // Get all applied migrations with their checksums
-    auto appliedMigrations = dm.Query<SchemaMigration>().OrderBy("version", SqlResultOrdering::ASCENDING).All();
+    // Get all applied migrations with their checksums. The table may not yet
+    // exist — that's the legitimate "fresh DB / overlay-only" state in the
+    // post-overlay design, so swallow the missing-table error and return an
+    // empty result. Virtual-applied overlay entries are deliberately not
+    // checked here: they carry no stored checksum and behave like the
+    // pre-checksum legacy rows (storedChecksum empty ⇒ treated as match).
+    auto appliedMigrations = std::vector<SchemaMigration> {};
+    try
+    {
+        appliedMigrations = dm.Query<SchemaMigration>().OrderBy("version", SqlResultOrdering::ASCENDING).All();
+    }
+    catch (SqlException const&)
+    {
+        return results;
+    }
 
     for (auto const& record: appliedMigrations)
     {
@@ -1474,6 +1639,12 @@ std::vector<ChecksumVerificationResult> MigrationManager::VerifyChecksums() cons
 
 void MigrationManager::MarkMigrationAsApplied(MigrationBase const& migration)
 {
+    // Drain the overlay before writing this row. If the caller is bulk-marking
+    // a sequence of migrations on top of a virtual-applied overlay, this is
+    // also what guarantees the overlay timestamps land in the table ahead of
+    // the new row — preserving the natural `version ASC` ordering on disk.
+    PersistVirtualAppliedMigrations();
+
     auto& dm = GetDataMapper();
 
     // Check if already applied

--- a/src/Lightweight/SqlMigration.hpp
+++ b/src/Lightweight/SqlMigration.hpp
@@ -17,6 +17,7 @@
 #include <map>
 #include <optional>
 #include <set>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -322,8 +323,57 @@ namespace SqlMigration
 
         /// Get all applied migration IDs.
         ///
-        /// @return Vector of applied migration IDs.
+        /// Returns the union of timestamps physically present in `schema_migrations`
+        /// and the in-memory "virtual applied" overlay (see `AddVirtualAppliedMigrations`),
+        /// sorted ascending and deduplicated. The accessor never creates the
+        /// `schema_migrations` table — when the table does not exist the database
+        /// half of the union is the empty set, so a pure-overlay state is fully
+        /// observable here without any side effects.
+        ///
+        /// @return Vector of applied migration IDs (database rows ∪ overlay).
         [[nodiscard]] LIGHTWEIGHT_API std::vector<MigrationTimestamp> GetAppliedMigrationIds() const;
+
+        /// Contribute "virtual" applied migration IDs that participate in every
+        /// `GetAppliedMigrationIds()` read but are not persisted to
+        /// `schema_migrations` until the manager actually performs a write
+        /// (`ApplySingleMigration`, `MarkMigrationAsApplied`, or
+        /// `RevertSingleMigration`). Designed for plugin post-init hooks that
+        /// need to bridge a foreign version-tracking table (e.g. the legacy
+        /// `LASTRADA_PROPERTIES NR=4` row) into the modern applied-set view
+        /// without paying for table creation on read-only commands like
+        /// `status` or `list-applied`.
+        ///
+        /// The input is merged into an internal sorted, deduplicated vector;
+        /// passing the same timestamp twice is a no-op.
+        ///
+        /// @param timestamps Timestamps to add to the overlay.
+        LIGHTWEIGHT_API void AddVirtualAppliedMigrations(std::span<MigrationTimestamp const> timestamps);
+
+        /// Drop every entry from the in-memory virtual-applied overlay. Intended
+        /// for test setup/teardown and for callers that want to re-derive the
+        /// overlay from scratch (e.g. a `dbtool-gui` reconnect against a
+        /// different profile). Has no effect on `schema_migrations` rows.
+        LIGHTWEIGHT_API void ClearVirtualAppliedMigrations();
+
+        /// Optional sink for informational status messages emitted by plugin
+        /// hooks (e.g. the "Transitioning from LASTRADA_PROPERTIES …" banner).
+        /// `dbtool` installs a sink that prints to `stdout` to preserve the
+        /// historical CLI output; `dbtool-gui` installs a sink that routes
+        /// through its `LogInfo` channel so the banner shows up in the
+        /// activity log instead of going to a hidden stream.
+        using LogSink = std::function<void(std::string_view)>;
+
+        /// Install a log sink. Pass `{}` to clear.
+        ///
+        /// @param sink Callable invoked once per status message.
+        LIGHTWEIGHT_API void SetLogSink(LogSink sink);
+
+        /// Emit a status message via the installed sink. No-op when no sink is
+        /// installed — silent by default keeps the library suitable for use in
+        /// embedded contexts that have no obvious output stream.
+        ///
+        /// @param message The message to deliver.
+        LIGHTWEIGHT_API void Log(std::string_view message) const;
 
         /// Get the data mapper used for migrations.
         [[nodiscard]] LIGHTWEIGHT_API DataMapper& GetDataMapper();
@@ -703,11 +753,30 @@ namespace SqlMigration
         /// before rendering a given migration's steps.
         [[nodiscard]] static MigrationRenderContext MakeRenderContext();
 
+        /// @brief Materialises any pending virtual-applied entries as real rows
+        /// in `schema_migrations`. Creates the history table if necessary, then
+        /// inserts one row per overlay entry that maps to a registered
+        /// migration and is not yet present in the table. Clears the overlay on
+        /// success. Called as the first action of every write path so the
+        /// physical table only exists when there is at least one row to put in
+        /// it.
+        void PersistVirtualAppliedMigrations();
+
         MigrationList _migrations;
         std::vector<MigrationRelease> _releases;
         mutable DataMapper* _dataMapper { nullptr };
         CompatPolicy _compatPolicy;
         std::string _defaultSchema; ///< Default schema applied to migration connections, empty when unset.
+
+        /// @brief In-memory overlay of applied migration timestamps that are
+        /// not (yet) persisted to `schema_migrations`. Populated by plugin
+        /// post-init hooks via `AddVirtualAppliedMigrations`; drained into the
+        /// table by `PersistVirtualAppliedMigrations` whenever the manager
+        /// transitions from a read-only state into actually writing. Always
+        /// kept sorted ascending and deduplicated.
+        std::vector<MigrationTimestamp> _virtualAppliedIds;
+
+        LogSink _logSink; ///< Optional status-message sink. Empty by default.
     };
 
 /// Requires the user to call LIGHTWEIGHT_MIGRATION_PLUGIN() in exactly one CPP file of the migration plugin.

--- a/src/tools/dbtool-gui/AppController.cpp
+++ b/src/tools/dbtool-gui/AppController.cpp
@@ -756,31 +756,38 @@ bool AppController::connectToProfile()
         // contradict the previous "Connecting …" with a misleading error.
     }
 
-    // Opening migration history is best-effort. Failure here does NOT abort
-    // the connect — the user may be pointing at an unmanaged database (no
-    // `schema_migrations` table yet) and they need the GUI populated with
-    // the plugin-declared migration plan so they can run them to bootstrap
-    // the history table. Any hard failure surfaces as a yellow warning
-    // banner; hard errors (connection refused, auth failure, etc.) have
-    // already been caught by the `SetDefaultConnectionString` path above.
-    bool historyOpen = true;
-    try
-    {
-        manager.CreateMigrationHistory();
-    }
-    catch (std::exception const& e)
-    {
-        historyOpen = false;
-        _lastWarning = QStringLiteral("Database is currently unmanaged — no schema_migrations table yet. "
-                                      "Apply any pending migration to create it. (details: %1)")
-                           .arg(ExceptionMessage(e));
-        emit lastWarningChanged();
-    }
+    // Route status banners emitted by plugin post-init hooks (e.g. the
+    // "Transitioning from LASTRADA_PROPERTIES …" line from SqlMigrationsPlugin)
+    // through `AppController::LogInfo` so the message lands in the GUI's log
+    // pane instead of stderr. Installed before invoking the hooks below so
+    // the very first banner is captured.
+    manager.SetLogSink(
+        [this](std::string_view message) { LogInfo(QString::fromUtf8(message.data(), static_cast<int>(message.size()))); });
 
-    // `Refresh` reads `GetAppliedMigrationIds` which also touches
-    // schema_migrations; fold the same exception path into a warning so
-    // the list still shows the plugin-declared migrations even when the
-    // table is missing.
+    // Run plugin post-init hooks (e.g. SqlMigrationsPlugin's transition glue
+    // that observes `LASTRADA_PROPERTIES NR=4` and populates the virtual
+    // applied overlay). Until this fires, the migration list would render the
+    // entire legacy range as pending. Per-plugin failures are surfaced via
+    // `LogError` but never abort the connect — a misbehaving plugin must not
+    // brick the GUI's read paths.
+    //
+    // We deliberately do NOT call `CreateMigrationHistory()` here: the table
+    // is materialised lazily inside Lightweight's write paths
+    // (`ApplySingleMigration` / `MarkMigrationAsApplied` / `RevertSingleMigration`),
+    // so introspection-only connects against a fresh or unmanaged database
+    // leave the schema untouched.
+    Lightweight::Tools::RunPluginPostInitHooks(
+        _plugins->entries,
+        Lightweight::DataMapper::AcquireThreadLocal().Connection(),
+        manager,
+        [this](std::string_view message) { LogError(QString::fromUtf8(message.data(), static_cast<int>(message.size()))); });
+
+    // `Refresh` reads `GetAppliedMigrationIds` which merges the plugin-supplied
+    // overlay with whatever rows exist in `schema_migrations`. The accessor
+    // already swallows a missing-table `SqlException` and returns the overlay
+    // alone, but a Refresh-level failure (e.g. malformed row, unreadable
+    // column) should still surface as a warning instead of leaving the GUI
+    // stuck on a stale model.
     try
     {
         _migrations.Refresh(manager);
@@ -788,14 +795,11 @@ bool AppController::connectToProfile()
     }
     catch (std::exception const& e)
     {
-        if (historyOpen)
-        {
-            _lastWarning = QStringLiteral("Could not read migration history: %1").arg(ExceptionMessage(e));
-            emit lastWarningChanged();
-        }
-        // Fall back to a plain-plugin view with no applied rows. This is the
-        // right mental model for an unmanaged DB: every plugin migration
-        // shows as pending so the user can apply them.
+        _lastWarning = QStringLiteral("Could not read migration history: %1").arg(ExceptionMessage(e));
+        emit lastWarningChanged();
+        // Fall back to a plain-plugin view. The overlay is still observable
+        // via `RefreshPluginsOnly` because it lives on the manager, not in
+        // `schema_migrations`.
         _migrations.RefreshPluginsOnly(manager);
         _releases.Refresh(manager);
     }

--- a/src/tools/dbtool-gui/AppController.cpp
+++ b/src/tools/dbtool-gui/AppController.cpp
@@ -6,9 +6,11 @@
 #include <Lightweight/SqlConnection.hpp>
 #include <Lightweight/SqlError.hpp>
 #include <Lightweight/SqlMigration.hpp>
+#include <Lightweight/SqlServerType.hpp>
 
 #include <PluginIngestion.hpp>
 #include <PluginLoader.hpp>
+#include <QtCore/QtGlobal>
 
 namespace DbtoolGui
 {
@@ -39,6 +41,8 @@ struct AppController::PluginsBundle
 #include <QtCore/QTimer>
 #include <QtCore/QUrl>
 #include <QtGui/QDesktopServices>
+#include <QtGui/QGuiApplication>
+#include <QtGui/QStyleHints>
 
 namespace DbtoolGui
 {
@@ -115,29 +119,23 @@ namespace
         return fallback.isEmpty() ? QStringLiteral("(no details reported)") : fallback;
     }
 
-    /// Builds the `Tools::PluginIngestOptions` the GUI uses for every
-    /// `IngestPlugins` call. Verbose mode pipes shadow + loading lines
-    /// through `qInfo`; load errors always reach `qWarning` so a broken
-    /// plugin file is visible in the log even when verbose is off.
-    /// `throwOnLoadError = false` keeps the rest of the migration set
-    /// usable when one plugin fails to load.
-    [[nodiscard]] Lightweight::Tools::PluginIngestOptions MakeGuiIngestOptions(bool verbose)
+    /// Maps the internal `SqlServerType` enum to the human-readable display
+    /// string already used by the project's `std::formatter` specialization
+    /// (which `dbtool` and the docs also use). Keeps the GUI's "Connected:"
+    /// log line consistent with every other surface that names a server.
+    /// @param serverType Server flavour detected by `SqlConnection`.
+    /// @return UTF-16 display string, e.g. `"PostgreSQL"` or `"SQLite"`.
+    [[nodiscard]] QString ServerTypeDisplayName(Lightweight::SqlServerType serverType)
     {
-        Lightweight::Tools::PluginIngestOptions opts;
-        if (verbose)
-        {
-            opts.logShadowed = [](std::string_view msg) {
-                qInfo("%s", std::string(msg).c_str());
-            };
-            opts.logLoading = [](std::string_view msg) {
-                qInfo("%s", std::string(msg).c_str());
-            };
-        }
-        opts.logError = [](std::string_view msg) {
-            qWarning("%s", std::string(msg).c_str());
-        };
-        opts.throwOnLoadError = false; // GUI surfaces the error and keeps running
-        return opts;
+        return QString::fromStdString(std::format("{}", serverType));
+    }
+
+    /// Converts a UTF-8 `std::string_view` (the form every `PluginIngestion`
+    /// callback receives) into the `QString` the log feed wants. Centralised
+    /// so the three callbacks below all do the trim/convert the same way.
+    [[nodiscard]] QString FromUtf8View(std::string_view msg)
+    {
+        return QString::fromUtf8(msg.data(), static_cast<qsizetype>(msg.size()));
     }
 
 } // namespace
@@ -206,13 +204,19 @@ AppController::AppController(QObject* parent):
     // include real execution context (the failing DDL, driver error, etc.)
     // without asking QML to read the LogPanel — which lives in a sibling
     // QML tree that may not even be instantiated under the Simple view.
-    auto const bufferLogLine = [this](QString const& line, int /*level*/) {
+    auto const bufferLogLine = [this](QString const& line, LogLevel /*level*/) {
         _recentLog.append(line);
         while (_recentLog.size() > kRecentLogCapacity)
             _recentLog.removeFirst();
     };
     QObject::connect(&_runner, &MigrationRunner::logLine, this, bufferLogLine);
     QObject::connect(&_backupRunner, &BackupRunner::logLine, this, bufferLogLine);
+
+    // The log pane subscribes to `AppController::logLine` (single source of
+    // truth). Forward the runners' streams so migration progress and backup
+    // events surface in the same feed as the startup banner.
+    QObject::connect(&_runner, &MigrationRunner::logLine, this, &AppController::logLine);
+    QObject::connect(&_backupRunner, &BackupRunner::logLine, this, &AppController::logLine);
     // After a run finishes, do one authoritative refresh. `Refresh` touches
     // schema_migrations and will throw on an unmanaged database — we fall
     // back to `RefreshPluginsOnly` in that case. An uncaught exception
@@ -294,12 +298,38 @@ AppController::AppController(QObject* parent):
 
     refreshOdbcDataSources();
 
+    // Startup banner — emitted while no QML receiver exists yet; the buffer
+    // in `Log()` holds these until `LogPanel.qml` calls `attachLogSink()`,
+    // at which point they replay in order. Plain English throughout —
+    // never the CLI flag name (e.g. "Plugins directory", not "--plugins-dir").
+    LogInfo(QStringLiteral("dbtool-gui starting (Qt %1)").arg(QLatin1String(qVersion())));
+    {
+        // `ui/theme` is the same QSettings key `main.cpp` writes via `--theme`
+        // and reads back across runs. Kept as a string literal here so this
+        // file does not have to import the constant from `main.cpp`.
+        QSettings const settings;
+        auto const requestedTheme = settings.value(QStringLiteral("ui/theme"), QStringLiteral("system")).toString();
+        auto const effectiveTheme = QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark
+                                        ? QStringLiteral("dark")
+                                        : QStringLiteral("light");
+        LogInfo(QStringLiteral("Theme: %1 (requested %2)").arg(effectiveTheme, requestedTheme));
+    }
+    LogInfo(QStringLiteral("View mode: %1").arg(_viewMode));
+    {
+        auto const storePath = !_profileStorePath.isEmpty()
+                                   ? _profileStorePath
+                                   : QString::fromStdString(Lightweight::Config::ProfileStore::DefaultPath().string());
+        LogInfo(QStringLiteral("Profile store: %1 (%2 profile(s))").arg(storePath).arg(_profiles.rowCount()));
+    }
+
     // Load the plugin DLLs eagerly so the migration list is populated before
     // the user clicks Connect. This runs after profile + settings restoration
     // because `EffectivePluginsDir()` consults both `_pluginsDir` and the
     // current profile. Safe to run here even if no connection is open —
     // plugin discovery is a pure filesystem operation.
     ReloadPlugins();
+
+    LogInfo(QStringLiteral("Ready — not connected. Pick a profile to connect."));
 }
 
 AppController::~AppController()
@@ -630,6 +660,8 @@ bool AppController::connectToProfile()
         return false;
     }
 
+    LogInfo(QStringLiteral("Connecting %1…").arg(connectionSummary()));
+
     auto& manager = Lightweight::SqlMigration::MigrationManager::GetInstance();
 
     // Plugin discovery is a pure filesystem operation independent of ODBC,
@@ -696,10 +728,33 @@ bool AppController::connectToProfile()
     }
     catch (std::exception const& e)
     {
-        ReportError(QStringLiteral("Could not open the database connection: %1").arg(ExceptionMessage(e)));
+        auto const failureMsg = ExceptionMessage(e);
+        LogError(QStringLiteral("Connection failed: %1").arg(failureMsg));
+        ReportError(QStringLiteral("Could not open the database connection: %1").arg(failureMsg));
         return false;
     }
     _everConnected = true;
+
+    // Connection is up — surface server flavour / database / version so the
+    // user knows *which* DB they just opened. Pulling these from
+    // `SqlConnection` (post-handshake) means we report what the driver
+    // actually negotiated, not what was in the typed-in connection string.
+    try
+    {
+        auto const& connection = Lightweight::DataMapper::AcquireThreadLocal().Connection();
+        auto const serverDisplay = ServerTypeDisplayName(connection.ServerType());
+        auto const databaseName = QString::fromStdString(connection.DatabaseName());
+        auto const serverVersion = QString::fromStdString(connection.ServerVersion());
+        LogInfo(QStringLiteral("Connected: %1 · %2 · %3").arg(serverDisplay, databaseName, serverVersion));
+        if (!effectiveSchema.empty())
+            LogInfo(QStringLiteral("Schema search path: %1").arg(QString::fromStdString(effectiveSchema)));
+    }
+    catch (std::exception const&)
+    {
+        // Best-effort metadata read — if it fails the connect itself still
+        // succeeded, so silently skip the descriptive line rather than
+        // contradict the previous "Connecting …" with a misleading error.
+    }
 
     // Opening migration history is best-effort. Failure here does NOT abort
     // the connect — the user may be pointing at an unmanaged database (no
@@ -753,6 +808,7 @@ bool AppController::connectToProfile()
 
     _connected = true;
     emit connectedChanged();
+    LogInfo(QStringLiteral("Applied migrations: %1 / %2").arg(appliedCount()).arg(_migrations.rowCount()));
     // Release labels and counter bindings depend on the applied-set we
     // just fetched. `Refresh` above already emitted `migrationsChanged`,
     // but that fired while `_connected` was still false — re-emit after
@@ -1147,6 +1203,7 @@ void AppController::InvalidateConnectionTarget()
         return;
     _connected = false;
     emit connectedChanged();
+    LogInfo(QStringLiteral("Disconnected."));
 }
 
 void AppController::ReloadPlugins()
@@ -1160,12 +1217,38 @@ void AppController::ReloadPlugins()
     manager.RemoveAllReleases();
     _plugins->entries.clear();
 
-    if (!pluginsDirs.empty())
+    if (pluginsDirs.empty())
     {
+        LogInfo(QStringLiteral("Plugins directory: none configured"));
+    }
+    else
+    {
+        QStringList dirDisplay;
+        dirDisplay.reserve(static_cast<qsizetype>(pluginsDirs.size()));
+        for (auto const& dir: pluginsDirs)
+            dirDisplay.append(QString::fromStdString(dir.string()));
+        LogInfo(QStringLiteral("Plugins directory: %1").arg(dirDisplay.join(QStringLiteral("; "))));
+
+        Lightweight::Tools::PluginIngestOptions opts;
+        // Forward every discovery event through the unified log feed.
+        // Successful loads / shadowed candidates run unconditionally —
+        // `_verbose` is no longer required to *see* discovery state,
+        // only to surface extra noise on stderr that nobody reads.
+        opts.logLoading = [this](std::string_view msg) {
+            LogInfo(QStringLiteral("Loaded plugin: %1").arg(FromUtf8View(msg)));
+        };
+        opts.logShadowed = [this](std::string_view msg) {
+            LogWarn(QStringLiteral("Plugin shadowed: %1").arg(FromUtf8View(msg)));
+        };
+        opts.logError = [this](std::string_view msg) {
+            LogError(QStringLiteral("Plugin failed: %1").arg(FromUtf8View(msg)));
+        };
+        opts.throwOnLoadError = false;
+
         try
         {
-            _plugins->entries = Lightweight::Tools::IngestPlugins(
-                pluginsDirs, Lightweight::Tools::DefaultPluginLoader(), manager, MakeGuiIngestOptions(_verbose));
+            _plugins->entries =
+                Lightweight::Tools::IngestPlugins(pluginsDirs, Lightweight::Tools::DefaultPluginLoader(), manager, opts);
         }
         catch (std::exception const& e)
         {
@@ -1178,8 +1261,10 @@ void AppController::ReloadPlugins()
             paths.reserve(static_cast<qsizetype>(pluginsDirs.size()));
             for (auto const& dir: pluginsDirs)
                 paths.append(QString::fromStdString(dir.string()));
-            ReportError(QStringLiteral("Failed to load plugins from %1: %2")
-                            .arg(paths.join(QStringLiteral("; ")), QString::fromUtf8(e.what())));
+            auto const errorText = QStringLiteral("Failed to load plugins from %1: %2")
+                                       .arg(paths.join(QStringLiteral("; ")), QString::fromUtf8(e.what()));
+            LogError(errorText);
+            ReportError(errorText);
         }
     }
 
@@ -1202,7 +1287,51 @@ void AppController::ReloadPlugins()
         _migrations.RefreshPluginsOnly(manager);
     }
     _releases.Refresh(manager);
+    LogInfo(QStringLiteral("Migrations available: %1 · Releases declared: %2")
+                .arg(_migrations.rowCount())
+                .arg(_releases.rowCount()));
     emit migrationsChanged();
+}
+
+void AppController::Log(LogLevel level, QString line)
+{
+    if (_logSinkAttached)
+    {
+        emit logLine(std::move(line), level);
+        return;
+    }
+    // No QML receiver yet — buffer until `attachLogSink()` runs. Plugin
+    // discovery happens in the constructor, well before `LogPanel.qml`
+    // exists, so emitting now would drop the message on the floor.
+    _pendingLogs.append({ std::move(line), level });
+}
+
+void AppController::LogInfo(QString line)
+{
+    Log(LogLevel::Info, std::move(line));
+}
+
+void AppController::LogWarn(QString line)
+{
+    Log(LogLevel::Warning, std::move(line));
+}
+
+void AppController::LogError(QString line)
+{
+    Log(LogLevel::Error, std::move(line));
+}
+
+void AppController::attachLogSink()
+{
+    if (_logSinkAttached)
+        return; // Idempotent — re-instantiating the panel must not replay the banner.
+    _logSinkAttached = true;
+    // Replay in the order events occurred. Move-out so the buffer can drop
+    // its allocation; it stays empty for the rest of the process lifetime.
+    auto pending = std::move(_pendingLogs);
+    _pendingLogs.clear();
+    for (auto const& entry: pending)
+        emit logLine(entry.first, entry.second);
 }
 
 } // namespace DbtoolGui

--- a/src/tools/dbtool-gui/AppController.hpp
+++ b/src/tools/dbtool-gui/AppController.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "BackupRunner.hpp"
+#include "LogLevel.hpp"
 #include "MigrationRunner.hpp"
 #include "Models/MigrationListModel.hpp"
 #include "Models/OdbcDataSourceListModel.hpp"
@@ -19,7 +20,9 @@
 #include "SqlQueryRunner.hpp"
 
 #include <Config/ProfileStore.hpp>
+#include <QtCore/QList>
 #include <QtCore/QObject>
+#include <QtCore/QPair>
 #include <QtCore/QString>
 #include <QtQml/QQmlEngine>
 
@@ -403,7 +406,21 @@ class AppController: public QObject
     /// nothing if no profile file has been loaded yet.
     Q_INVOKABLE void openProfileFileExternally();
 
+    /// Called from `LogPanel.qml`'s `Component.onCompleted` to flush any
+    /// startup/plugin/connection log messages produced *before* the QML
+    /// engine wired up its `Connections { target: AppController }` block.
+    /// Idempotent — repeated calls after the first one are no-ops, so
+    /// re-instantiating the panel (e.g. after a tab swap) doesn't replay
+    /// the buffered banner.
+    Q_INVOKABLE void attachLogSink();
+
   signals:
+    /// Unified log-pane feed: every startup banner, plugin discovery event,
+    /// connection-state change, and migration progress line emerges here.
+    /// `MigrationRunner::logLine` and `BackupRunner::logLine` are forwarded
+    /// into this signal so QML only has to listen to one source.
+    void logLine(QString line, DbtoolGui::LogLevel level);
+
     void currentProfileChanged();
     void connectedChanged();
     void connectionStringOverrideChanged();
@@ -435,6 +452,16 @@ class AppController: public QObject
   private:
     void ReportError(QString const& message);
     void ClearError();
+
+    /// Routes `line` at severity `level` into the unified `logLine` signal.
+    /// When the QML panel has not yet called `attachLogSink()` the message
+    /// is buffered and replayed when the panel comes online — important
+    /// because plugin discovery runs in the constructor, before any QML
+    /// receiver exists.
+    void Log(LogLevel level, QString line);
+    void LogInfo(QString line);
+    void LogWarn(QString line);
+    void LogError(QString line);
 
     /// Computes the effective plugin search directories for the current
     /// connection mode: the user override wins in `dsn` / `custom` modes,
@@ -524,6 +551,14 @@ class AppController: public QObject
     /// because the connection string just changed" (every subsequent
     /// connect).
     bool _everConnected = false;
+
+    /// Log messages produced before the QML `LogPanel` connected its
+    /// receiver (i.e. before `attachLogSink()` ran). Replayed in order on
+    /// first attach and then permanently bypassed.
+    QList<QPair<QString, LogLevel>> _pendingLogs;
+    /// `true` once `attachLogSink()` has run for the first time. Past that
+    /// point `Log()` emits directly without touching `_pendingLogs`.
+    bool _logSinkAttached = false;
 
     /// Forward-declared by the Qt pointer in the .cpp — a QFileSystemWatcher
     /// held by raw pointer to keep `<QtCore/QFileSystemWatcher>` out of this

--- a/src/tools/dbtool-gui/BackupRunner.cpp
+++ b/src/tools/dbtool-gui/BackupRunner.cpp
@@ -61,14 +61,14 @@ namespace
                                  .arg(QString::fromStdString(std::string { p.tableName }))
                                  .arg(p.currentRows)
                                  .arg(QString::fromStdString(std::string { p.message }));
-            auto const level = static_cast<int>(p.state == Lightweight::SqlBackup::Progress::State::Error     ? 2
-                                                : p.state == Lightweight::SqlBackup::Progress::State::Warning ? 1
-                                                                                                              : 0);
+            auto const level = p.state == Lightweight::SqlBackup::Progress::State::Error     ? LogLevel::Error
+                               : p.state == Lightweight::SqlBackup::Progress::State::Warning ? LogLevel::Warning
+                                                                                             : LogLevel::Info;
             QMetaObject::invokeMethod(
                 _target,
                 [this, msg, level] {
                     QMetaObject::invokeMethod(
-                        _target, "logLine", Qt::DirectConnection, Q_ARG(QString, msg), Q_ARG(int, level));
+                        _target, "logLine", Qt::DirectConnection, Q_ARG(QString, msg), Q_ARG(DbtoolGui::LogLevel, level));
                 },
                 Qt::QueuedConnection);
         }

--- a/src/tools/dbtool-gui/BackupRunner.hpp
+++ b/src/tools/dbtool-gui/BackupRunner.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "LogLevel.hpp"
+
 #include <atomic>
 #include <functional>
 
@@ -67,7 +69,7 @@ class BackupRunner: public QObject
     }
 
   signals:
-    void logLine(QString line, int level);
+    void logLine(QString line, DbtoolGui::LogLevel level);
     void finished(bool ok, QString summary);
     void phaseChanged();
 

--- a/src/tools/dbtool-gui/CMakeLists.txt
+++ b/src/tools/dbtool-gui/CMakeLists.txt
@@ -21,6 +21,7 @@ set(MIGRATIONS_GUI_CXX_SOURCES
     AppController.cpp
     BackupRunner.hpp
     BackupRunner.cpp
+    LogLevel.hpp
     MigrationRunner.hpp
     MigrationRunner.cpp
     QmlProgressManager.hpp

--- a/src/tools/dbtool-gui/LogLevel.hpp
+++ b/src/tools/dbtool-gui/LogLevel.hpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Shared severity classification for messages routed to the GUI's log pane.
+// `AppController::logLine`, `MigrationRunner::logLine`, and
+// `BackupRunner::logLine` all carry this enum so QML and C++ agree on the
+// vocabulary without relying on magic integers (0/1/2).
+//
+// Lives in its own header so the runner classes do not have to depend on
+// `AppController.hpp` (which would create an include cycle).
+
+#pragma once
+
+#include <QtCore/QObject>
+#include <QtQmlIntegration/QtQmlIntegration>
+
+namespace DbtoolGui
+{
+
+Q_NAMESPACE
+
+/// Severity classification for log-pane messages. Renderer-side colour and
+/// any future filtering UI key off these values; C++ producers should pick
+/// the level that matches the message's intent rather than reusing a raw
+/// integer that has to be remembered.
+enum class LogLevel : int
+{
+    /// Routine progress, neutral terminal-grey in the panel.
+    Info,
+    /// Soft anomaly the user should notice (e.g. shadowed plugin, missing
+    /// `schema_migrations` table). Amber.
+    Warning,
+    /// Hard failure (load error, failed migration, connection refused). Red.
+    Error,
+};
+Q_ENUM_NS(LogLevel)
+
+} // namespace DbtoolGui

--- a/src/tools/dbtool-gui/MigrationRunner.cpp
+++ b/src/tools/dbtool-gui/MigrationRunner.cpp
@@ -122,7 +122,7 @@ namespace
 
     /// Pushes a plain log line onto the runner from a worker thread, marshalling
     /// through the event loop so QML consumers see it on the GUI thread.
-    void PostLogLine(MigrationRunner* runner, QString const& line, int level)
+    void PostLogLine(MigrationRunner* runner, QString const& line, LogLevel level)
     {
         QMetaObject::invokeMethod(
             runner, [runner, line, level] { emit runner->logLine(line, level); }, Qt::QueuedConnection);
@@ -145,7 +145,8 @@ namespace
             [runner, ts, title, idx, total, verb] {
                 emit runner->migrationStarted(static_cast<qulonglong>(ts));
                 emit runner->progress(static_cast<qulonglong>(ts), title, idx, total);
-                emit runner->logLine(QStringLiteral("[%1/%2] %3 %4 %5").arg(idx).arg(total).arg(verb).arg(ts).arg(title), 0);
+                emit runner->logLine(QStringLiteral("[%1/%2] %3 %4 %5").arg(idx).arg(total).arg(verb).arg(ts).arg(title),
+                                     LogLevel::Info);
             },
             Qt::QueuedConnection);
     }
@@ -183,20 +184,24 @@ namespace
         auto const ts = static_cast<qulonglong>(ex.GetMigrationTimestamp().value);
         auto const step = static_cast<qulonglong>(ex.GetStepIndex());
 
-        PostLogLine(runner, QStringLiteral("!! %1 failed: %2 - %3 (step %4)").arg(verb).arg(ts).arg(title).arg(step), 2);
+        PostLogLine(runner,
+                    QStringLiteral("!! %1 failed: %2 - %3 (step %4)").arg(verb).arg(ts).arg(title).arg(step),
+                    LogLevel::Error);
         if (!sqlState.isEmpty() && sqlState != QStringLiteral("     "))
-            PostLogLine(runner, QStringLiteral("   SQL State: %1, Native error: %2").arg(sqlState).arg(nativeError), 2);
+            PostLogLine(runner,
+                        QStringLiteral("   SQL State: %1, Native error: %2").arg(sqlState).arg(nativeError),
+                        LogLevel::Error);
         if (!driverMsg.isEmpty())
         {
-            PostLogLine(runner, QStringLiteral("   Driver message:"), 2);
+            PostLogLine(runner, QStringLiteral("   Driver message:"), LogLevel::Error);
             for (auto const& line: driverMsg.split(QLatin1Char('\n'), Qt::KeepEmptyParts))
-                PostLogLine(runner, QStringLiteral("     %1").arg(line), 2);
+                PostLogLine(runner, QStringLiteral("     %1").arg(line), LogLevel::Error);
         }
         if (!failedSql.isEmpty())
         {
-            PostLogLine(runner, QStringLiteral("   Failed SQL:"), 2);
+            PostLogLine(runner, QStringLiteral("   Failed SQL:"), LogLevel::Error);
             for (auto const& line: failedSql.split(QLatin1Char('\n'), Qt::KeepEmptyParts))
-                PostLogLine(runner, QStringLiteral("     %1").arg(line), 2);
+                PostLogLine(runner, QStringLiteral("     %1").arg(line), LogLevel::Error);
         }
     }
 
@@ -231,7 +236,7 @@ void MigrationRunner::dryRunUpTo(QString const& targetTimestamp)
             PostLogLine(runner,
                         targetTs == 0 ? QStringLiteral("No pending migrations to dry-run.")
                                       : QStringLiteral("No pending migrations up to %1.").arg(targetLabel),
-                        1);
+                        LogLevel::Warning);
             PostFinished(runner, true, QStringLiteral("Dry-run produced 0 migrations."));
             return;
         }
@@ -241,13 +246,13 @@ void MigrationRunner::dryRunUpTo(QString const& targetTimestamp)
             targetTs == 0
                 ? QStringLiteral("-- Dry-run: would apply %1 pending migration(s).").arg(toRun.size())
                 : QStringLiteral("-- Dry-run: would apply %1 migration(s) up to %2.").arg(toRun.size()).arg(targetLabel),
-            0);
+            LogLevel::Info);
 
         for (size_t i = 0; i < toRun.size(); ++i)
         {
             if (runner->phase() == Phase::Cancelling)
             {
-                PostLogLine(runner, QStringLiteral("-- Cancelled."), 1);
+                PostLogLine(runner, QStringLiteral("-- Cancelled."), LogLevel::Warning);
                 PostFinished(runner, false, QStringLiteral("Dry-run cancelled."));
                 return;
             }
@@ -275,19 +280,19 @@ void MigrationRunner::applyUpTo(QString const& targetTimestamp)
             PostLogLine(runner,
                         targetTs == 0 ? QStringLiteral("No pending migrations to apply.")
                                       : QStringLiteral("No pending migrations up to %1.").arg(targetLabel),
-                        1);
+                        LogLevel::Warning);
             PostFinished(runner, true, QStringLiteral("Applied 0 migrations."));
             return;
         }
 
-        PostLogLine(runner, QStringLiteral("Applying %1 migration(s)...").arg(toRun.size()), 0);
+        PostLogLine(runner, QStringLiteral("Applying %1 migration(s)...").arg(toRun.size()), LogLevel::Info);
 
         size_t applied = 0;
         for (size_t i = 0; i < toRun.size(); ++i)
         {
             if (runner->phase() == Phase::Cancelling)
             {
-                PostLogLine(runner, QStringLiteral("-- Cancelled after %1 migration(s).").arg(applied), 1);
+                PostLogLine(runner, QStringLiteral("-- Cancelled after %1 migration(s).").arg(applied), LogLevel::Warning);
                 PostFinished(runner, false, QStringLiteral("Cancelled after %1 migrations.").arg(applied));
                 return;
             }
@@ -316,7 +321,7 @@ void MigrationRunner::applyUpTo(QString const& targetTimestamp)
                                 .arg(ts)
                                 .arg(QString::fromStdString(std::string { toRun[i]->GetTitle() }))
                                 .arg(QString::fromUtf8(e.what())),
-                            2);
+                            LogLevel::Error);
                 PostFinished(runner,
                              false,
                              QStringLiteral("Applied %1 of %2 migrations before failing.").arg(applied).arg(toRun.size()));
@@ -342,11 +347,12 @@ void MigrationRunner::dryRunSelected(QStringList const& timestamps)
         auto const toRun = CollectSelected(*manager, snapshot);
         if (toRun.empty())
         {
-            PostLogLine(runner, QStringLiteral("No pending migrations in the current selection."), 1);
+            PostLogLine(runner, QStringLiteral("No pending migrations in the current selection."), LogLevel::Warning);
             PostFinished(runner, true, QStringLiteral("Dry-run produced 0 migrations."));
             return;
         }
-        PostLogLine(runner, QStringLiteral("-- Dry-run: would apply %1 selected migration(s).").arg(toRun.size()), 0);
+        PostLogLine(
+            runner, QStringLiteral("-- Dry-run: would apply %1 selected migration(s).").arg(toRun.size()), LogLevel::Info);
         for (size_t i = 0; i < toRun.size(); ++i)
             PostProgress(runner, *toRun[i], i, toRun.size(), QStringLiteral("would apply"));
         PostFinished(runner, true, QStringLiteral("Dry-run produced %1 migrations.").arg(toRun.size()));
@@ -368,19 +374,19 @@ void MigrationRunner::applySelected(QStringList const& timestamps)
         auto const toRun = CollectSelected(*manager, snapshot);
         if (toRun.empty())
         {
-            PostLogLine(runner, QStringLiteral("No pending migrations in the current selection."), 1);
+            PostLogLine(runner, QStringLiteral("No pending migrations in the current selection."), LogLevel::Warning);
             PostFinished(runner, true, QStringLiteral("Applied 0 migrations."));
             return;
         }
 
-        PostLogLine(runner, QStringLiteral("Applying %1 selected migration(s)...").arg(toRun.size()), 0);
+        PostLogLine(runner, QStringLiteral("Applying %1 selected migration(s)...").arg(toRun.size()), LogLevel::Info);
 
         size_t applied = 0;
         for (size_t i = 0; i < toRun.size(); ++i)
         {
             if (runner->phase() == Phase::Cancelling)
             {
-                PostLogLine(runner, QStringLiteral("-- Cancelled after %1 migration(s).").arg(applied), 1);
+                PostLogLine(runner, QStringLiteral("-- Cancelled after %1 migration(s).").arg(applied), LogLevel::Warning);
                 PostFinished(runner, false, QStringLiteral("Cancelled after %1 migrations.").arg(applied));
                 return;
             }
@@ -403,7 +409,7 @@ void MigrationRunner::applySelected(QStringList const& timestamps)
             catch (std::exception const& e)
             {
                 PostMigrationFailed(runner, ts);
-                PostLogLine(runner, QStringLiteral("!! %1 — %2").arg(ts).arg(QString::fromUtf8(e.what())), 2);
+                PostLogLine(runner, QStringLiteral("!! %1 — %2").arg(ts).arg(QString::fromUtf8(e.what())), LogLevel::Error);
                 PostFinished(
                     runner, false, QStringLiteral("Applied %1 of %2 before failing.").arg(applied).arg(toRun.size()));
                 return;
@@ -429,7 +435,7 @@ void MigrationRunner::rollbackToRelease(QString const& version)
         if (!release)
         {
             auto const msg = QStringLiteral("Release '%1' is not declared").arg(QString::fromStdString(versionStd));
-            PostLogLine(runner, msg, 2);
+            PostLogLine(runner, msg, LogLevel::Error);
             PostFinished(runner, false, msg);
             return;
         }
@@ -457,29 +463,31 @@ void MigrationRunner::rollbackToRelease(QString const& version)
                 // inside the rich-text spans, so we split them here.
                 auto const ts = static_cast<qulonglong>(result.failedAt->value);
                 auto const title = QString::fromStdString(result.failedTitle);
-                PostLogLine(runner, QStringLiteral("!! Rollback failed: %1 - %2").arg(ts).arg(title), 2);
+                PostLogLine(runner, QStringLiteral("!! Rollback failed: %1 - %2").arg(ts).arg(title), LogLevel::Error);
                 if (!result.failedSql.empty())
                 {
-                    PostLogLine(
-                        runner, QStringLiteral("   Step: %1").arg(static_cast<qulonglong>(result.failedStepIndex)), 2);
+                    PostLogLine(runner,
+                                QStringLiteral("   Step: %1").arg(static_cast<qulonglong>(result.failedStepIndex)),
+                                LogLevel::Error);
                     if (!result.sqlState.empty() && result.sqlState != "     ")
                         PostLogLine(runner,
                                     QStringLiteral("   SQL State: %1, Native error: %2")
                                         .arg(QString::fromStdString(result.sqlState))
                                         .arg(static_cast<qlonglong>(result.nativeErrorCode)),
-                                    2);
-                    PostLogLine(runner, QStringLiteral("   Driver message:"), 2);
+                                    LogLevel::Error);
+                    PostLogLine(runner, QStringLiteral("   Driver message:"), LogLevel::Error);
                     auto const driverMsg = QString::fromStdString(result.errorMessage);
                     for (auto const& line: driverMsg.split(QLatin1Char('\n'), Qt::KeepEmptyParts))
-                        PostLogLine(runner, QStringLiteral("     %1").arg(line), 2);
-                    PostLogLine(runner, QStringLiteral("   Failed SQL:"), 2);
+                        PostLogLine(runner, QStringLiteral("     %1").arg(line), LogLevel::Error);
+                    PostLogLine(runner, QStringLiteral("   Failed SQL:"), LogLevel::Error);
                     auto const failedSql = QString::fromStdString(result.failedSql);
                     for (auto const& line: failedSql.split(QLatin1Char('\n'), Qt::KeepEmptyParts))
-                        PostLogLine(runner, QStringLiteral("     %1").arg(line), 2);
+                        PostLogLine(runner, QStringLiteral("     %1").arg(line), LogLevel::Error);
                 }
                 else
                 {
-                    PostLogLine(runner, QStringLiteral("   %1").arg(QString::fromStdString(result.errorMessage)), 2);
+                    PostLogLine(
+                        runner, QStringLiteral("   %1").arg(QString::fromStdString(result.errorMessage)), LogLevel::Error);
                 }
                 PostFinished(runner, false, QStringLiteral("Rollback of migration %1 '%2' failed").arg(ts).arg(title));
             }
@@ -501,7 +509,7 @@ void MigrationRunner::rollbackToRelease(QString const& version)
         }
         catch (std::exception const& e)
         {
-            PostLogLine(runner, QString::fromUtf8(e.what()), 2);
+            PostLogLine(runner, QString::fromUtf8(e.what()), LogLevel::Error);
             PostFinished(runner, false, QString::fromUtf8(e.what()));
         }
     });

--- a/src/tools/dbtool-gui/MigrationRunner.hpp
+++ b/src/tools/dbtool-gui/MigrationRunner.hpp
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include "LogLevel.hpp"
+
 #include <atomic>
 #include <functional>
 
@@ -88,7 +90,7 @@ class MigrationRunner: public QObject
 
   signals:
     void progress(qulonglong timestamp, QString title, int index, int total);
-    void logLine(QString line, int level);
+    void logLine(QString line, DbtoolGui::LogLevel level);
     void finished(bool ok, QString summary);
     void phaseChanged();
 

--- a/src/tools/dbtool-gui/main.cpp
+++ b/src/tools/dbtool-gui/main.cpp
@@ -110,8 +110,10 @@ int main(int argc, char* argv[])
     QGuiApplication::setOrganizationName(QStringLiteral("JP-Software"));
     QGuiApplication::setOrganizationDomain(QStringLiteral("lastrada.software"));
 
-    std::fprintf(stderr, "[INFO] dbtool-gui starting (Qt %s)\n", qVersion());
-    std::fflush(stderr);
+    // The "dbtool-gui starting (Qt …)" / "Theme: …" / "Event loop starting"
+    // lines now appear in the GUI's log pane (emitted by `AppController`'s
+    // constructor / startup banner). Keeping stderr copies as well would
+    // double-up the developer-facing console and the user-facing pane.
 
     QCommandLineParser parser;
     parser.setApplicationDescription(QStringLiteral("Lightweight SQL migrations GUI."));
@@ -148,14 +150,8 @@ int main(int argc, char* argv[])
     // is silently ignored by the KDE Plasma platform theme plugin.
     auto const themeModeEnum = DbtoolGui::ThemeController::ModeFromString(themeMode);
     DbtoolGui::ThemeController::SeedInitialMode(themeModeEnum);
-    auto const effectiveDark = themeModeEnum == DbtoolGui::ThemeController::Mode::Dark
-                               || (themeModeEnum == DbtoolGui::ThemeController::Mode::System
-                                   && QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark);
-    std::fprintf(stderr,
-                 "[INFO] Theme: requested=%s, effective=%s\n",
-                 themeMode.toLocal8Bit().constData(),
-                 effectiveDark ? "dark" : "light");
-    std::fflush(stderr);
+    // (Effective theme is logged into the GUI's log pane from
+    // `AppController`'s constructor — see the banner there.)
 
     // "Fusion" gives us a consistent look across platforms until we commit to
     // a native style per OS. The mockup in docs/migrations-gui-mockup.html is
@@ -186,7 +182,5 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    std::fprintf(stderr, "[INFO] Event loop starting\n");
-    std::fflush(stderr);
     return app.exec();
 }

--- a/src/tools/dbtool-gui/qml/LogPanel.qml
+++ b/src/tools/dbtool-gui/qml/LogPanel.qml
@@ -33,10 +33,13 @@ Rectangle {
     // API that preserves cursor/selection state.
     property int lineCount: 0
 
+    // `level` is `DbtoolGui::LogLevel` from C++ — the QML side receives the
+    // underlying integer (0=Info, 1=Warning, 2=Error). Keep this table in
+    // sync with `LogLevel.hpp` if the enum is ever extended.
     function colorFor(level) {
-        if (level === 2) return "#f87171";
-        if (level === 1) return "#fbbf24";
-        return "#cbd5e1";
+        if (level === 2) return "#f87171"; // Error
+        if (level === 1) return "#fbbf24"; // Warning
+        return "#cbd5e1";                  // Info
     }
 
     function escapeHtml(s) {
@@ -115,8 +118,13 @@ Rectangle {
         }
     }
 
+    // Drain any startup banner / plugin-discovery / connect lines that
+    // `AppController` buffered before this panel existed. Idempotent on the
+    // C++ side, so a panel re-instantiation does not replay the banner.
+    Component.onCompleted: AppController.attachLogSink()
+
     Connections {
-        target: AppController.runner
+        target: AppController
         function onLogLine(line, level) {
             logText.append("<span style=\"color:" + root.colorFor(level) + ";\">"
                 + root.escapeHtml(line) + "</span>");

--- a/src/tools/dbtool/main.cpp
+++ b/src/tools/dbtool/main.cpp
@@ -2252,7 +2252,8 @@ MigrationManager& GetMigrationManager(Options const& options)
             std::exit(EXIT_FAILURE);
         }
         // Apply --schema before opening the connection so the post-connect
-        // hook is installed prior to CreateMigrationHistory()'s first connect.
+        // hook is installed prior to the first connect performed by the
+        // plugin post-init hooks below.
         if (!options.schema.empty())
         {
             TraceBreadcrumb("GetMigrationManager: setting default schema");
@@ -2266,8 +2267,12 @@ MigrationManager& GetMigrationManager(Options const& options)
                 std::exit(EXIT_FAILURE);
             }
         }
-        TraceBreadcrumb("GetMigrationManager: creating migration history table");
-        manager.CreateMigrationHistory();
+
+        // Route plugin status banners (e.g. SqlMigrationsPlugin's
+        // "Transitioning from LASTRADA_PROPERTIES …" line) to stdout so the
+        // historical CLI output is preserved exactly. dbtool-gui installs its
+        // own sink that routes through `qInfo`.
+        manager.SetLogSink([](std::string_view message) { std::println("{}", message); });
 
         // Run optional plugin post-init hooks. Each plugin may export a
         // `LightweightMigrationPluginPostInit(SqlConnection&, MigrationManager&)`
@@ -2276,25 +2281,16 @@ MigrationManager& GetMigrationManager(Options const& options)
         // migration manager. Per-plugin failures are reported but do not abort
         // dbtool startup — a misbehaving plugin must not be able to brick
         // unrelated commands like `status` or `backup`.
+        //
+        // We deliberately do *not* call `CreateMigrationHistory()` here: the
+        // history table is materialised lazily by the first write path
+        // (`ApplySingleMigration`, `MarkMigrationAsApplied`, `RevertSingleMigration`),
+        // so read-only commands like `status` or `list-applied` never touch
+        // the database with a CREATE TABLE.
         TraceBreadcrumb("GetMigrationManager: running plugin post-init hooks");
-        {
-            auto& conn = manager.GetDataMapper().Connection();
-            for (auto const& plugin: plugins)
-            {
-                auto* const postInit =
-                    plugin.TryGetFunction<void(SqlConnection&, MigrationManager&)>("LightweightMigrationPluginPostInit");
-                if (postInit == nullptr)
-                    continue; // Optional symbol — not all plugins implement it.
-                try
-                {
-                    postInit(conn, manager);
-                }
-                catch (std::exception const& e)
-                {
-                    std::println(std::cerr, "Plugin post-init failed: {}", e.what());
-                }
-            }
-        }
+        Tools::RunPluginPostInitHooks(plugins, manager.GetDataMapper().Connection(), manager, [](std::string_view message) {
+            std::println(std::cerr, "{}", message);
+        });
 
         TraceBreadcrumb("GetMigrationManager: ready");
         initialized = true;

--- a/src/tools/shared/PluginIngestion.cpp
+++ b/src/tools/shared/PluginIngestion.cpp
@@ -146,4 +146,29 @@ PluginLoaderFn DefaultPluginLoader()
     };
 }
 
+void RunPluginPostInitHooks(std::span<LoadedPlugin const> plugins,
+                            Lightweight::SqlConnection& connection,
+                            Lightweight::SqlMigration::MigrationManager& central,
+                            std::function<void(std::string_view)> const& logError)
+{
+    using HookSignature = void(Lightweight::SqlConnection&, Lightweight::SqlMigration::MigrationManager&);
+
+    for (auto const& plugin: plugins)
+    {
+        auto* const postInit = plugin.TryGetFunction<HookSignature>("LightweightMigrationPluginPostInit");
+        if (postInit == nullptr)
+            continue; // Optional symbol — plugins without legacy glue skip the hook.
+
+        try
+        {
+            postInit(connection, central);
+        }
+        catch (std::exception const& exception)
+        {
+            if (logError)
+                logError(std::format("Plugin post-init failed ({}): {}", plugin.path.string(), exception.what()));
+        }
+    }
+}
+
 } // namespace Lightweight::Tools

--- a/src/tools/shared/PluginIngestion.hpp
+++ b/src/tools/shared/PluginIngestion.hpp
@@ -128,4 +128,26 @@ struct PluginIngestOptions
 /// `std::runtime_error` when `PluginLoader` construction itself fails.
 [[nodiscard]] PluginLoaderFn DefaultPluginLoader();
 
+/// Invoke every plugin's optional `LightweightMigrationPluginPostInit` hook
+/// against the supplied connection and central manager. Used by `dbtool` and
+/// `dbtool-gui` to give plugins a one-shot opportunity to bridge legacy
+/// version-tracking schemes (e.g. SqlMigrationsPlugin's
+/// `LASTRADA_PROPERTIES` → virtual-applied overlay) once a live ODBC link
+/// exists and the merged migration manager is fully populated.
+///
+/// Hooks that throw are reported through `logError` and skipped — a
+/// misbehaving plugin must not abort the host's startup or connect path.
+/// Plugins that do not export the symbol are silently bypassed.
+///
+/// @param plugins  Plugin set returned by `IngestPlugins`.
+/// @param connection Live connection to pass to each hook.
+/// @param central  Host-side merged migration manager passed to each hook.
+/// @param logError Sink for per-plugin failure messages. May be empty; in
+///                 that case failures are silently swallowed (suitable for
+///                 contexts where the caller has no log channel).
+void RunPluginPostInitHooks(std::span<LoadedPlugin const> plugins,
+                            Lightweight::SqlConnection& connection,
+                            Lightweight::SqlMigration::MigrationManager& central,
+                            std::function<void(std::string_view)> const& logError);
+
 } // namespace Lightweight::Tools


### PR DESCRIPTION
Folds #501 (`dbtool-gui: surface startup, plugin discovery, and DB connection in the log pane`, commit `ddec8076`) into the same branch so the schema_migrations overlay redesign and the log-pane wiring land together. The two commits are dependent in practice: the post-init hook lambdas the overlay PR introduces only become observable to a user when routed through the new `AppController::LogInfo` / `LogError` channel.

## Commit 1 — `dbtool-gui: surface startup, plugin discovery, and DB connection in the log pane` (was #501)

Today `LogPanel` is fed only by `MigrationRunner::logLine`, so it sits empty until the user clicks Migrate. After this commit the pane shows:

- **Constructor banner**: Qt version, theme (effective + requested), view mode, profile-store path + profile count.
- **Plugin discovery** (per `ReloadPlugins`): resolved plugins directory, per-plugin Loaded / Shadowed / Failed lines, summary count of migrations & releases. Runs unconditionally — `--verbose` no longer gates discovery output, it only controls extra stderr noise.
- **Database connect** (per `connectToProfile`): `Connecting <summary>…`, `Connected: <ServerType> · <database> · <version>`, optional `Schema search path: …`, and `Applied migrations: A / T`. Failures log `Connection failed: …` in addition to the existing error banner.
- **Disconnect**: `Disconnected.` when the connection target is invalidated.

Plumbing: new `enum class DbtoolGui::LogLevel { Info, Warning, Error }` with `Q_NAMESPACE` + `Q_ENUM_NS`. `AppController` gains a unified `logLine` signal — `MigrationRunner::logLine` and `BackupRunner::logLine` are forwarded into it so QML only has to listen to one source. Messages emitted before `LogPanel.qml` exists (plugin discovery runs in the constructor) are buffered and replayed when QML calls `attachLogSink()` from `Component.onCompleted`. The three startup `fprintf(stderr, …)` calls in `main.cpp` are removed — their content is now in the pane.

## Commit 2 — `migration: lazy schema_migrations + in-memory applied-id overlay`

`MigrationManager` grows an in-memory virtual-applied overlay (`AddVirtualAppliedMigrations`, `ClearVirtualAppliedMigrations`). `GetAppliedMigrationIds()` returns the union of `schema_migrations` rows and the overlay, so plugin hooks can contribute applied IDs that participate in every read path without persisting anything. The overlay is drained into real rows by a new private `PersistVirtualAppliedMigrations()` helper invoked as the very first step of `ApplySingleMigration`, `MarkMigrationAsApplied`, and `RevertSingleMigration` — so `schema_migrations` only ever materialises when we are about to write to it anyway.

`CreateMigrationHistory()` moves inside `PersistVirtualAppliedMigrations()` and is no longer called at startup. `VerifyChecksums()` also tolerates a missing `schema_migrations` (it was the last read path that threw on the absent table). A new `SetLogSink` / `Log` channel lets plugin hooks emit status banners that the host can route to stdout (`dbtool`) or `LogInfo` (`dbtool-gui`, via the channel introduced by commit 1) without each plugin having to know which front-end it is loaded into.

`Lightweight::Tools::RunPluginPostInitHooks` is factored out of `dbtool/main.cpp` into the shared `PluginIngestion` translation unit so `dbtool-gui` can invoke the optional `LightweightMigrationPluginPostInit` symbol via the same loop. The GUI previously did not call the hook at all, which is what made downstream transition glue invisible from the GUI until the user ran the CLI once. Both tools now drop the eager `manager.CreateMigrationHistory()` call and install a log sink before invoking the hooks.

## Why ship them together

Without commit 1, the post-init banner in commit 2 reaches `qInfo` / `qWarning`, which Qt's message handler writes to stderr only — invisible in the GUI. Commit 1 provides the `AppController::LogInfo` / `LogError` channel that commit 2's post-init lambdas now call, so the legacy-bridge banner ("Transitioning from LASTRADA_PROPERTIES …") shows up in the same log pane as plugin discovery and connection events.

## Testing

- Built `SqlMigrationsPlugin`, `dbtool`, `dbtool-gui` cleanly with the `win64-cl-ninja-debug` preset.
- Verified `dbtool status` against a DB without `schema_migrations` runs without creating the table and without throwing.

## Manual test checklist

- [ ] Launch `dbtool-gui` cold; expect the constructor banner (Qt version, theme, view mode, profile-store path + profile count) in the log pane.
- [ ] Switch profiles; expect `Plugins directory: …` + per-plugin `Loaded plugin: …` lines.
- [ ] Connect to a fresh LUpd-managed DB; expect `Connecting …`, `Connected: …`, the plugin's `Transitioning from LASTRADA_PROPERTIES …` banner, and `Applied migrations: A / T` — all visible in the pane, no `schema_migrations` materialised.
- [ ] Run `dbtool migrate` against the same DB; confirm `schema_migrations` is now populated with the bridged rows plus any new ones.
- [ ] Confirm drift catch-up: with a fully-migrated modern DB, advance the downstream legacy version marker past `schema_migrations.max`, re-run `dbtool status`, and verify the gap appears as applied (in-memory only).