### PR TITLE
Add headless CI tests for dbtool-gui

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -574,6 +574,67 @@ jobs:
               -f .github/Reflection.Dockerfile \
               --load . --no-cache
 
+  ubuntu_dbtool_gui:
+    # Headless CI coverage for the Qt 6 dbtool-gui binary. Runs three test
+    # layers under `QT_QPA_PLATFORM=offscreen` — Catch2 unit tests for
+    # AppController, qmltestrunner suites for the Lightweight.Migrations QML
+    # module, and a process smoke test against the real binary. No display
+    # server is required.
+    name: "dbtool-gui (Ubuntu, Qt 6.8, headless)"
+    # ubuntu-24.04 ships Catch2 v3 (the test sources include the v3-only
+    # `catch2/catch_session.hpp`); 22.04's `catch2` package is still v2.
+    runs-on: ubuntu-24.04
+    env:
+      QT_QPA_PLATFORM: offscreen
+    steps:
+      - uses: actions/checkout@v6
+      - name: Fetch tags
+        # cmake/Version.cmake derives the project version from the latest
+        # `v*` git tag; actions/checkout does a shallow clone without tags, so
+        # unshallow + fetch tags here (matching ubuntu_build_cc_matrix).
+        run: git fetch --prune --unshallow --tags
+      - name: "update APT database"
+        run: sudo apt -q update
+      - name: "install build + ODBC dependencies"
+        run: |
+          sudo apt install -y \
+            cmake ninja-build catch2 \
+            unixodbc-dev libsqliteodbc \
+            uuid-dev libyaml-cpp-dev libzip-dev \
+            python3-yaml \
+            libgl1-mesa-dev libegl1 libxkbcommon0 libfontconfig1
+      - name: "install Clang 20"
+        # clang-20 is not in the stock Ubuntu repositories — pull it from the
+        # official LLVM apt source.
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 20
+          sudo apt-get install -y clang-20
+      - name: Install Qt 6.8
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.8.0'
+          cache: true
+          # QtQml/QtQuick/QtQuickControls2 ship in the base desktop install —
+          # they are NOT aqtinstall add-on modules, so listing `qtdeclarative`
+          # here makes aqt fail its package-XML lookup. Only true add-ons go in
+          # `modules`; qtshadertools provides the build-time `qsb` tooling.
+          modules: 'qtshadertools'
+      - name: "configure"
+        run: |
+          cmake -S . -B out/build/ci-gui \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_COMPILER=clang++-20 \
+            -DLIGHTWEIGHT_BUILD_GUI=ON \
+            -DLIGHTWEIGHT_BUILD_TESTS=ON \
+            -DPEDANTIC_COMPILER_WERROR=OFF
+      - name: "build"
+        run: cmake --build out/build/ci-gui --target dbtool-gui dbtool-gui-tests dbtool-gui-qmltest -- -j3
+      - name: "ctest (Catch2 + qmltestrunner + smoke)"
+        run: ctest --test-dir out/build/ci-gui -L dbtool-gui --output-on-failure
+
   ddl2cpp:
     name: "ddl2cpp"
     runs-on: ubuntu-24.04

--- a/src/tests/test_dbtool_gui.py
+++ b/src/tests/test_dbtool_gui.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Headless process smoke test for dbtool-gui.
+
+Spawns the binary under ``QT_QPA_PLATFORM=offscreen``, lets the Qt event
+loop spin for a few seconds, asserts no fatal log lines appeared on stderr
+(``[FATAL]`` from ``qInstallMessageHandler``, ``QML_ERROR``, "Failed to
+create QML root object"), and then terminates the process cleanly.
+
+This catches the classes of regression an offscreen-only test can see:
+QML compile errors, missing resources / icons, plugin-loader crashes,
+windeployqt deploy mistakes, AppController constructor exceptions. It does
+*not* assert on the in-app startup banner — that text is routed only to
+the GUI's log pane (see ``AppController`` constructor), so it's invisible
+to a stderr probe.
+
+Companion to ``test_dbtool.py`` — same argparse/timeout style. Run locally
+with::
+
+    python src/tests/test_dbtool_gui.py \\
+        --dbtool-gui out/build/clangcl-debug/target/dbtool-gui.exe
+
+The CI job sets ``QT_QPA_PLATFORM=offscreen`` at job scope; we set it
+unconditionally here too so the test works in both contexts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+# Lines that indicate an unrecoverable failure during startup. The qInstall-
+# MessageHandler in main.cpp routes Qt log output to stderr with a `[LEVEL]`
+# prefix; the QML engine's `objectCreationFailed` lambda emits the "Failed to
+# create QML root object" line directly. If any of these appear we fail
+# loudly with the captured stderr so the CI log makes the cause obvious.
+FATAL_MARKERS = (
+    "[FATAL]",
+    "[ERROR]",
+    "QML_ERROR",
+    "Failed to create QML root object",
+    "No root objects were loaded",
+)
+
+# How long the binary must stay alive without producing a fatal marker
+# before we declare success and terminate it. Three seconds is plenty for
+# the QML engine to instantiate Main.qml, AppController to run its
+# constructor, and ReloadPlugins() to scan the (typically empty) plugin
+# directory — anything that crashes in startup does so within ~1 s.
+LIVENESS_PROBE_SECONDS = 3.0
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dbtool-gui",
+        required=True,
+        type=Path,
+        help="Path to the built dbtool-gui executable.",
+    )
+    parser.add_argument(
+        "--liveness-seconds",
+        type=float,
+        default=LIVENESS_PROBE_SECONDS,
+        help="How long the binary must stay alive without emitting a fatal marker before being terminated.",
+    )
+    parser.add_argument(
+        "--extra-arg",
+        action="append",
+        default=[],
+        help="Additional argv entries forwarded to dbtool-gui (repeatable).",
+    )
+    return parser.parse_args()
+
+
+def _ensure_executable(path: Path) -> None:
+    if not path.exists():
+        print(f"Error: dbtool-gui binary not found at {path}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _drain_stderr_until(proc: subprocess.Popen, deadline: float, fatal_markers):
+    """Read stderr line-by-line until the deadline elapses, a fatal marker
+    appears, or the process dies. Returns (fatal_seen, lines, process_died).
+
+    Uses a background reader thread because `pipe.readline()` blocks
+    indefinitely on Windows when no data is available — even after the
+    deadline — which would defeat the liveness probe."""
+    q: queue.Queue = queue.Queue()
+    stop = threading.Event()
+
+    def reader():
+        try:
+            for raw in iter(proc.stderr.readline, b""):
+                if stop.is_set():
+                    break
+                q.put(raw)
+        except (OSError, ValueError):
+            pass  # pipe closed during shutdown
+
+    reader_thread = threading.Thread(target=reader, name="stderr-reader", daemon=True)
+    reader_thread.start()
+
+    fatal: str | None = None
+    lines: list[str] = []
+    died = False
+    try:
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                died = True
+                break
+            try:
+                raw = q.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            decoded = raw.decode("utf-8", errors="replace").rstrip()
+            lines.append(decoded)
+            for marker in fatal_markers:
+                if marker in decoded:
+                    fatal = marker
+                    return fatal, lines, died
+    finally:
+        stop.set()
+    return fatal, lines, died
+
+
+def main() -> int:
+    args = _parse_args()
+    _ensure_executable(args.dbtool_gui)
+
+    env = os.environ.copy()
+    env["QT_QPA_PLATFORM"] = "offscreen"
+
+    cmd = [
+        str(args.dbtool_gui),
+        "--theme=light",
+        "--enable-backup-restore",
+        "--verbose",
+        *args.extra_arg,
+    ]
+    print(f"Launching: {' '.join(cmd)}")
+
+    proc = subprocess.Popen(
+        cmd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        bufsize=0,
+    )
+
+    try:
+        deadline = time.monotonic() + args.liveness_seconds
+        fatal, lines, died = _drain_stderr_until(proc, deadline, FATAL_MARKERS)
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+        # Close the pipes explicitly — on Windows, Popen does not always
+        # release them on terminate(), which would keep the Python process
+        # alive past the end of `main()` and look like a hang.
+        for stream in (proc.stdout, proc.stderr):
+            try:
+                if stream is not None:
+                    stream.close()
+            except OSError:
+                pass
+
+    print("--- captured stderr ---")
+    for line in lines:
+        print(line)
+    print("--- end stderr ---")
+
+    if fatal is not None:
+        print(f"FAIL: fatal marker '{fatal}' appeared during startup.", file=sys.stderr)
+        return 1
+
+    if died:
+        print(
+            f"FAIL: dbtool-gui exited (code {proc.returncode}) before liveness probe finished.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"OK: dbtool-gui stayed alive for {args.liveness_seconds}s under "
+        "QT_QPA_PLATFORM=offscreen with no fatal log lines."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tools/dbtool-gui/CMakeLists.txt
+++ b/src/tools/dbtool-gui/CMakeLists.txt
@@ -2,6 +2,11 @@
 #
 # Built only when LIGHTWEIGHT_BUILD_GUI is ON and Qt 6 was located by the
 # top-level LightweightFindQt probe. See docs/migrations-gui-plan.md for the design.
+#
+# The C++ view-model layer lives in a STATIC backing library
+# (`dbtool-gui-lib`) so the test binaries under `tests/` can link against
+# `AppController` & friends without duplicating sources. The executable
+# (`dbtool-gui`) reduces to a thin `main.cpp` wrapper around that library.
 
 # The top-level CMakeLists ran `lightweight_probe_qt6()` which extends
 # CMAKE_PREFIX_PATH, but did not call `find_package(Qt6)` itself because the
@@ -15,8 +20,6 @@ find_package(Qt6 6.8 REQUIRED COMPONENTS Core Gui Qml Quick QuickControls2 Concu
 qt_standard_project_setup(REQUIRES 6.8)
 
 set(MIGRATIONS_GUI_CXX_SOURCES
-    main.cpp
-
     AppController.hpp
     AppController.cpp
     BackupRunner.hpp
@@ -74,10 +77,6 @@ set(MIGRATIONS_GUI_QML_FILES
     qml/SettingsPage.qml
 )
 
-qt_add_executable(dbtool-gui
-    ${MIGRATIONS_GUI_CXX_SOURCES}
-)
-
 # A reusable QML module so the migrations view can be embedded by other Qt
 # applications later. URI is `Lightweight.Migrations` (version 1.0).
 # Theme.qml is a `pragma Singleton` and must be declared as such in the
@@ -88,14 +87,30 @@ set_source_files_properties(qml/Theme.qml PROPERTIES
     QT_QML_SINGLETON_TYPE TRUE
 )
 
-qt_add_qml_module(dbtool-gui
+# STATIC backing library. The QML module is attached to *this* target rather
+# than the executable so tests (and any future Qt host application) can link
+# `dbtool-gui-lib` and reach both the C++ view-models and the QML files
+# through a single dependency.
+qt_add_library(dbtool-gui-lib STATIC
+    ${MIGRATIONS_GUI_CXX_SOURCES}
+)
+
+qt_add_qml_module(dbtool-gui-lib
     URI Lightweight.Migrations
     VERSION 1.0
     QML_FILES ${MIGRATIONS_GUI_QML_FILES}
     RESOURCE_PREFIX /qt/qml
+    # Qt expects the module's OUTPUT_DIRECTORY to end with the URI's path
+    # (Lightweight/Migrations) so qmllint and related tooling resolve
+    # cross-imports without an explicit QML2_IMPORT_PATH. Setting it here
+    # silences the "should end in the same target path" warning the
+    # auto-derived directory would otherwise produce.
+    OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Lightweight/Migrations
 )
 
-target_link_libraries(dbtool-gui PRIVATE
+target_include_directories(dbtool-gui-lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(dbtool-gui-lib PUBLIC
     Lightweight
     dbtool_lib  # reuses Tools::PluginLoader for migration-plugin loading
     Qt6::Core
@@ -106,6 +121,23 @@ target_link_libraries(dbtool-gui PRIVATE
     Qt6::Concurrent
 )
 
+set_target_properties(dbtool-gui-lib PROPERTIES
+    # Qt's camelCase signal/slot convention, unscoped Q_ENUMs, and
+    # parent-based `new` ownership all clash with the project-wide
+    # clang-tidy policy — opt this target out of clang-tidy entirely.
+    CXX_CLANG_TIDY ""
+)
+
+# Thin executable: only main.cpp + wiring. All real logic lives in the lib.
+qt_add_executable(dbtool-gui
+    main.cpp
+)
+
+target_link_libraries(dbtool-gui PRIVATE
+    dbtool-gui-lib
+    dbtool-gui-libplugin
+)
+
 # On Windows release builds, mark as GUI-only (no console window). On debug
 # builds we keep a console so Qt warnings, QML error lines, and our own
 # stderr output land somewhere the developer can read — the GUI is useless
@@ -113,9 +145,6 @@ target_link_libraries(dbtool-gui PRIVATE
 set_target_properties(dbtool-gui PROPERTIES
     WIN32_EXECUTABLE $<NOT:$<CONFIG:Debug>>
     MACOSX_BUNDLE ON
-    # Qt's camelCase signal/slot convention, unscoped Q_ENUMs, and
-    # parent-based `new` ownership all clash with the project-wide
-    # clang-tidy policy — opt this target out of clang-tidy entirely.
     CXX_CLANG_TIDY ""
 )
 
@@ -190,4 +219,8 @@ elseif(APPLE)
     else()
         message(STATUS "macdeployqt not found — skipping Qt framework deployment for dbtool-gui")
     endif()
+endif()
+
+if(LIGHTWEIGHT_BUILD_TESTS)
+    add_subdirectory(tests)
 endif()

--- a/src/tools/dbtool-gui/README.md
+++ b/src/tools/dbtool-gui/README.md
@@ -31,12 +31,12 @@ plan and deferred work.
   Tracking as a phase-4 follow-up; the CLI-grade fallback chain
   (`env:` / `file:` / `stdin:`) is wired today and covers every headless / CI
   scenario.
-- Three new GitHub Actions matrix jobs (`ubuntu + Qt 6.7`, `windows + Qt 6.7`,
-  `macos + Qt 6.7`) — the plan's §8 CI section. Ready to add once the team
-  confirms the `jurplel/install-qt-action` caching strategy.
-- QML test-runner integration (`qmltestrunner`) — the C++ view-model is
-  covered by compilation + offscreen smoke runs; dedicated QML component
-  tests come in the CI follow-up.
+- Windows + macOS GitHub Actions runners for the GUI tests. The Linux job
+  (`ubuntu_dbtool_gui` in `.github/workflows/build.yml`) lands as the first
+  step; the same `jurplel/install-qt-action@v4` recipe drops onto the other
+  two platforms in a follow-up once the Linux job is stable.
+- Postgres / MSSQL fan-out for the GUI test job (the existing
+  `dbms_test_matrix` pattern reused with `LIGHTWEIGHT_BUILD_GUI=ON`).
 
 ## Building
 
@@ -58,6 +58,31 @@ cmake -S . -B build -DLIGHTWEIGHT_BUILD_GUI=ON -DQt6_DIR=C:/Qt/6.11.0/msvc2022_6
 # Headless smoke test (uses Qt's offscreen platform — no display needed):
 QT_QPA_PLATFORM=offscreen ./build/target/dbtool-gui &
 ```
+
+## Running the tests
+
+When the project is configured with `LIGHTWEIGHT_BUILD_GUI=ON` **and**
+`LIGHTWEIGHT_BUILD_TESTS=ON`, three CTest entries become available under the
+shared `dbtool-gui` label, all of which run under
+`QT_QPA_PLATFORM=offscreen`:
+
+| CTest entry          | Layer              | Runner                                  |
+|----------------------|--------------------|-----------------------------------------|
+| `dbtool-gui-tests`   | C++ view-model     | Catch2 (`AppControllerTests.cpp`)       |
+| `dbtool-gui-qmltest` | QML components     | Qt `qmltestrunner` (`tests/qml/*.qml`)  |
+| `dbtool-gui-smoke`   | Process startup    | `src/tests/test_dbtool_gui.py` (Python) |
+
+Run them all in one go:
+
+```bash
+ctest --preset clang-debug -L dbtool-gui --output-on-failure
+# or, against the Windows build:
+ctest --preset clangcl-debug -L dbtool-gui --output-on-failure
+```
+
+The same recipe runs on every push via the `dbtool-gui (Ubuntu, Qt 6.8,
+headless)` GitHub Actions job — see `ubuntu_dbtool_gui` in
+`.github/workflows/build.yml`.
 
 ## QML module
 
@@ -92,4 +117,7 @@ dbtool-gui/
                             MigrationRow, StatusCard, ReleasesSummary,
                             ActionsPanel, LogPanel, ConnectionPanel,
                             BackupRestoreDialog).
+  tests/                    Headless test suites. Built when
+                            LIGHTWEIGHT_BUILD_TESTS=ON; see "Running the
+                            tests" above.
 ```

--- a/src/tools/dbtool-gui/tests/AppControllerTests.cpp
+++ b/src/tools/dbtool-gui/tests/AppControllerTests.cpp
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Catch2 coverage for `DbtoolGui::AppController` — the C++ view-model that
+// holds every piece of long-lived state behind the dbtool-gui QML UI.
+// Tests drive the controller through its `Q_INVOKABLE` surface and observe
+// state changes via `QSignalSpy`, exactly the same way QML would, so a
+// regression here will also be a regression in the live app.
+//
+// No QML engine is instantiated; `tests/main.cpp` boots a single
+// `QGuiApplication` under `QT_QPA_PLATFORM=offscreen` and Catch2 owns the
+// rest of the process lifetime.
+
+#include "../AppController.hpp"
+#include "../LogLevel.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+
+#include <QtCore/QString>
+#include <QtCore/QStringList>
+#include <QtTest/QSignalSpy>
+
+namespace
+{
+
+/// Absolute path to the test-fixtures directory next to this source file.
+/// `__FILE__` resolves at compile time so the lookup works regardless of
+/// where the binary is invoked from (build tree, install tree, IDE).
+[[nodiscard]] std::filesystem::path FixturesDir()
+{
+    return std::filesystem::path(__FILE__).parent_path() / "fixtures";
+}
+
+/// Concatenates every captured `logLine` payload into a single newline-
+/// separated string for substring assertions. Catch2's spy stores each
+/// invocation as a `QList<QVariant>`; we only care about the first arg.
+[[nodiscard]] QString JoinLogLines(QSignalSpy const& spy)
+{
+    QStringList lines;
+    lines.reserve(static_cast<int>(spy.count()));
+    for (auto const& args: spy)
+        lines << args.value(0).toString();
+    return lines.join(QLatin1Char('\n'));
+}
+
+} // namespace
+
+TEST_CASE("AppController constructs in a disconnected state", "[dbtool-gui][AppController]")
+{
+    DbtoolGui::AppController controller;
+
+    CHECK_FALSE(controller.connected());
+    CHECK(controller.lastError().isEmpty());
+}
+
+TEST_CASE("AppController buffers a startup banner that replays on attachLogSink", "[dbtool-gui][AppController][startup]")
+{
+    DbtoolGui::AppController controller;
+    QSignalSpy spy(&controller, &DbtoolGui::AppController::logLine);
+    REQUIRE(spy.isValid());
+
+    // Before `attachLogSink`, the controller buffers everything — the spy
+    // sees nothing because no signal has been emitted yet.
+    CHECK(spy.count() == 0);
+
+    controller.attachLogSink();
+
+    // After flushing the buffer, every banner line emerges as a `logLine`
+    // signal. We assert on stable substrings rather than full text so the
+    // test does not break the next time a banner line is reworded.
+    auto const joined = JoinLogLines(spy);
+    CHECK(joined.contains(QStringLiteral("dbtool-gui starting")));
+    CHECK(joined.contains(QStringLiteral("Theme:")));
+    CHECK(joined.contains(QStringLiteral("View mode:")));
+    CHECK(joined.contains(QStringLiteral("Profile store:")));
+    CHECK(joined.contains(QStringLiteral("Ready")));
+}
+
+TEST_CASE("attachLogSink is idempotent — banner does not replay on a second call", "[dbtool-gui][AppController][startup]")
+{
+    DbtoolGui::AppController controller;
+    QSignalSpy spy(&controller, &DbtoolGui::AppController::logLine);
+
+    controller.attachLogSink();
+    auto const firstFlushCount = spy.count();
+    REQUIRE(firstFlushCount > 0);
+
+    controller.attachLogSink();
+    CHECK(spy.count() == firstFlushCount);
+}
+
+TEST_CASE("loadProfiles populates the profiles model from a fixture YAML", "[dbtool-gui][AppController][profiles]")
+{
+    auto const fixturePath = FixturesDir() / "dbtool.yml";
+    REQUIRE(std::filesystem::exists(fixturePath));
+
+    DbtoolGui::AppController controller;
+    auto const ok = controller.loadProfiles(QString::fromStdString(fixturePath.string()));
+
+    REQUIRE(ok);
+    CHECK(controller.profiles()->rowCount() >= 2);
+    CHECK(controller.profilePath().toStdString() == fixturePath.string());
+}
+
+TEST_CASE("setMigrationSelected on an unknown timestamp is a no-op", "[dbtool-gui][AppController][selection]")
+{
+    DbtoolGui::AppController controller;
+    REQUIRE(controller.selectedMigrationTimestamps().isEmpty());
+
+    controller.setMigrationSelected(QStringLiteral("99999999999999-ghost"), true);
+
+    CHECK(controller.selectedMigrationTimestamps().isEmpty());
+    CHECK(controller.selectionCount() == 0);
+}
+
+TEST_CASE("selectAllPending on an empty migration list is a no-op", "[dbtool-gui][AppController][selection]")
+{
+    DbtoolGui::AppController controller;
+
+    controller.selectAllPending(true);
+    CHECK(controller.selectionCount() == 0);
+
+    controller.selectAllPending(false);
+    CHECK(controller.selectionCount() == 0);
+}
+
+TEST_CASE("previewMigrationSql returns empty for an unknown timestamp", "[dbtool-gui][AppController]")
+{
+    DbtoolGui::AppController controller;
+    auto const sql = controller.previewMigrationSql(QStringLiteral("19700101000000-not-a-migration"));
+    CHECK(sql.isEmpty());
+}
+
+TEST_CASE("buildFailureReport returns a non-empty multi-line bundle even when disconnected",
+          "[dbtool-gui][AppController][failure-report]")
+{
+    DbtoolGui::AppController controller;
+    auto const report = controller.buildFailureReport();
+
+    REQUIRE_FALSE(report.isEmpty());
+    // The report is the diagnostic bundle the Failure card surfaces — it
+    // should always carry the connection summary so support tickets can be
+    // routed even when no profile has connected yet.
+    CHECK(report.contains(QStringLiteral("Connection")));
+}
+
+TEST_CASE("releaseHighestTimestamp returns empty for an unknown release", "[dbtool-gui][AppController]")
+{
+    DbtoolGui::AppController controller;
+    auto const ts = controller.releaseHighestTimestamp(QStringLiteral("v999.999.999"));
+    CHECK(ts.isEmpty());
+}

--- a/src/tools/dbtool-gui/tests/CMakeLists.txt
+++ b/src/tools/dbtool-gui/tests/CMakeLists.txt
@@ -1,0 +1,120 @@
+# dbtool-gui — Catch2 unit tests for the C++ view-model layer.
+#
+# Links against `dbtool-gui-lib` so the same `AppController`, `MigrationRunner`,
+# and list-model objects driven by the QML UI are exercised directly from
+# C++. The tests run under `QT_QPA_PLATFORM=offscreen` and do not require a
+# display server — see the parent `CMakeLists.txt` for the build gate.
+
+find_package(Catch2 REQUIRED)
+find_package(Qt6 REQUIRED COMPONENTS Test QuickTest)
+
+qt_add_executable(dbtool-gui-tests
+    main.cpp
+    AppControllerTests.cpp
+)
+
+target_link_libraries(dbtool-gui-tests PRIVATE
+    dbtool-gui-lib
+    dbtool-gui-libplugin
+    Catch2::Catch2
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Test
+)
+
+set_target_properties(dbtool-gui-tests PROPERTIES
+    # Qt's camelCase signal/slot convention clashes with the project-wide
+    # clang-tidy policy — opt out, like the executable does.
+    CXX_CLANG_TIDY ""
+)
+
+# Stage the Qt offscreen + minimal platform plugins next to the test binary
+# so `QT_QPA_PLATFORM=offscreen` resolves without a display server. The same
+# windeployqt invocation copies QML modules, image format plugins, etc.
+if(WIN32)
+    find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS ${Qt6_DIR}/../../../bin)
+    if(WINDEPLOYQT_EXECUTABLE)
+        add_custom_command(TARGET dbtool-gui-tests POST_BUILD
+            COMMAND "${WINDEPLOYQT_EXECUTABLE}"
+                    --no-translations
+                    --no-system-d3d-compiler
+                    --qmldir "${CMAKE_CURRENT_SOURCE_DIR}/../qml"
+                    "$<TARGET_FILE:dbtool-gui-tests>"
+            COMMENT "Running windeployqt for dbtool-gui-tests"
+            VERBATIM
+        )
+    endif()
+endif()
+
+add_test(NAME dbtool-gui-tests
+    COMMAND dbtool-gui-tests
+)
+
+set_tests_properties(dbtool-gui-tests PROPERTIES
+    LABELS "dbtool-gui"
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+# QML component layer. Drives the `Lightweight.Migrations` QML module through
+# Qt's `qmltestrunner`, executing every `tst_*.qml` file under `qml/` as a
+# separate test function. Catches binding / singleton-registration regressions
+# the C++ harness cannot reach.
+qt_add_executable(dbtool-gui-qmltest
+    qmltest_main.cpp
+)
+
+target_link_libraries(dbtool-gui-qmltest PRIVATE
+    Qt6::QuickTest
+    Qt6::Quick
+    Qt6::Qml
+    dbtool-gui-lib
+    dbtool-gui-libplugin
+)
+
+set_target_properties(dbtool-gui-qmltest PROPERTIES
+    CXX_CLANG_TIDY ""
+)
+
+# Stage the Qt platform plugins next to the qmltest binary so it can launch
+# under `QT_QPA_PLATFORM=offscreen` from a clean install.
+if(WIN32)
+    find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS ${Qt6_DIR}/../../../bin)
+    if(WINDEPLOYQT_EXECUTABLE)
+        add_custom_command(TARGET dbtool-gui-qmltest POST_BUILD
+            COMMAND "${WINDEPLOYQT_EXECUTABLE}"
+                    --no-translations
+                    --no-system-d3d-compiler
+                    --qmldir "${CMAKE_CURRENT_SOURCE_DIR}/../qml"
+                    "$<TARGET_FILE:dbtool-gui-qmltest>"
+            COMMENT "Running windeployqt for dbtool-gui-qmltest"
+            VERBATIM
+        )
+    endif()
+endif()
+
+add_test(NAME dbtool-gui-qmltest
+    COMMAND dbtool-gui-qmltest -input ${CMAKE_CURRENT_SOURCE_DIR}/qml
+)
+
+set_tests_properties(dbtool-gui-qmltest PROPERTIES
+    LABELS "dbtool-gui"
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+# Process-level smoke test driven from Python: launches the real `dbtool-gui`
+# binary under the offscreen platform plugin and asserts it stays alive
+# without any fatal log lines. This catches a class of failure the Catch2
+# and qmltestrunner suites cannot reach: a broken QML loader, missing
+# resources after windeployqt, or a regression in `main.cpp` itself.
+find_package(Python3 QUIET COMPONENTS Interpreter)
+if(Python3_FOUND)
+    add_test(NAME dbtool-gui-smoke
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_SOURCE_DIR}/src/tests/test_dbtool_gui.py
+                --dbtool-gui $<TARGET_FILE:dbtool-gui>
+    )
+    set_tests_properties(dbtool-gui-smoke PROPERTIES
+        LABELS "dbtool-gui"
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+    )
+endif()

--- a/src/tools/dbtool-gui/tests/fixtures/dbtool.yml
+++ b/src/tools/dbtool-gui/tests/fixtures/dbtool.yml
@@ -1,0 +1,18 @@
+# Profile store fixture for the dbtool-gui Catch2 tests.
+#
+# Two profiles so tests that exercise the profile model see a non-trivial
+# list. No `connectionString` is exercised at *load* time — the
+# `connectToProfile()` integration tests pick the right driver per platform
+# at runtime so this YAML stays portable across CI hosts.
+
+defaultProfile: sqlite-temp
+
+profiles:
+  sqlite-temp:
+    # Driver name varies (Linux: SQLite3, Windows: SQLite3 ODBC Driver) —
+    # individual tests assemble the live connection string instead of
+    # binding the fixture to one platform.
+    connectionString: "Driver=SQLite3;Database=:memory:"
+
+  sqlite-secondary:
+    connectionString: "Driver=SQLite3;Database=:memory:"

--- a/src/tools/dbtool-gui/tests/main.cpp
+++ b/src/tools/dbtool-gui/tests/main.cpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Custom Catch2 entry point that boots a single `QGuiApplication` before
+// any test runs. `AppController` and its child QObjects (MigrationRunner,
+// list models) assume a Qt event loop is reachable for queued signals,
+// `QThreadPool`, and Qt::QueuedConnection delivery — without `QGuiApplication`
+// even constructing them is unsafe.
+
+#define CATCH_CONFIG_RUNNER
+
+#include <catch2/catch_session.hpp>
+
+#include <cstdlib>
+
+#include <QtCore/QCoreApplication>
+#include <QtCore/QThreadPool>
+#include <QtGui/QGuiApplication>
+
+#ifdef _WIN32
+    #include <windows.h>
+#endif
+
+int main(int argc, char* argv[])
+{
+    // Heap-allocated and intentionally never deleted. Each test case
+    // constructs an `AppController` that owns a `QThreadPool`-driven
+    // `MigrationRunner` and a `QFileSystemWatcher`; both can have queued
+    // events in flight when the test cleans up its local controller.
+    // Letting the OS reap the QGuiApplication on process exit sidesteps
+    // the access violations a stack-allocated app raises during static
+    // tear-down on Windows + Qt 6.11 debug builds.
+    auto* app = new QGuiApplication(argc, argv);
+    QGuiApplication::setApplicationName(QStringLiteral("dbtool-gui-tests"));
+    QGuiApplication::setOrganizationName(QStringLiteral("JP-Software"));
+    QGuiApplication::setOrganizationDomain(QStringLiteral("lastrada.software"));
+
+    Catch::Session session;
+    auto const result = session.run(argc, argv);
+    QThreadPool::globalInstance()->waitForDone();
+    QCoreApplication::processEvents();
+    (void) app;
+
+    // Bypass C++ static destructors. Qt 6.11 debug builds + Catch2's own
+    // static fixtures + the Lightweight library's static caches don't tear
+    // down in a defined order on Windows, and the result is an access
+    // violation *after* every test has already passed. The OS reclaims
+    // every resource we hold; bypassing C++ tear-down skips the corruption
+    // path. `ExitProcess` is used on Windows because MSVC's `std::_Exit`
+    // still segfaults through some Qt/CRT cleanup path on debug builds.
+#ifdef _WIN32
+    // TerminateProcess is harsher than ExitProcess: it skips DLL_PROCESS_
+    // DETACH callbacks entirely. On Qt 6 debug builds (Windows + clang-cl)
+    // those callbacks segfault when QML resources, QtConcurrent worker
+    // threads, and AppController QObject lifetimes interact during
+    // shutdown — and we have already collected the test result here so
+    // there is nothing left to clean up gracefully.
+    TerminateProcess(GetCurrentProcess(), static_cast<UINT>(result));
+#endif
+    return result;
+}

--- a/src/tools/dbtool-gui/tests/qml/tst_module_loads.qml
+++ b/src/tools/dbtool-gui/tests/qml/tst_module_loads.qml
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Smoke test for the `Lightweight.Migrations` QML module. Verifies the
+// module imports without error and the `AppController` singleton exposes
+// the properties the rest of the UI binds against. A regression here means
+// the QML plugin registration broke — which would make the live UI fail to
+// load at all.
+
+import QtQuick
+import QtTest
+import Lightweight.Migrations
+
+TestCase {
+    name: "ModuleLoads"
+
+    function test_app_controller_singleton_is_reachable() {
+        verify(AppController !== null)
+    }
+
+    function test_app_controller_properties_have_expected_types() {
+        compare(typeof AppController.connected, "boolean")
+        compare(typeof AppController.viewMode, "string")
+        compare(typeof AppController.migrationCount, "number")
+        compare(typeof AppController.selectionCount, "number")
+    }
+
+    function test_disconnected_at_startup_in_test_runner() {
+        verify(!AppController.connected)
+    }
+
+    function test_models_are_exposed() {
+        verify(AppController.profiles !== null)
+        verify(AppController.migrations !== null)
+        verify(AppController.releases !== null)
+        verify(AppController.odbcDataSources !== null)
+    }
+}

--- a/src/tools/dbtool-gui/tests/qml/tst_theme_singleton.qml
+++ b/src/tools/dbtool-gui/tests/qml/tst_theme_singleton.qml
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Verifies the `Theme` singleton resolves and exposes the colour roles every
+// other QML component binds against. A regression here (e.g. Theme.qml not
+// flagged as a singleton in qmldir) would leave every component falling back
+// to red `undefined` palette values at runtime.
+
+import QtQuick
+import QtTest
+import Lightweight.Migrations
+
+TestCase {
+    name: "ThemeSingleton"
+
+    function test_theme_singleton_is_reachable() {
+        verify(typeof Theme !== "undefined")
+    }
+
+    function test_theme_exposes_core_palette_roles() {
+        verify(Theme.bgPage)
+        verify(Theme.bgWindow)
+        verify(Theme.bgPanel)
+        verify(Theme.bgTerminal)
+    }
+
+    function test_theme_dark_flag_is_boolean() {
+        compare(typeof Theme.dark, "boolean")
+    }
+}

--- a/src/tools/dbtool-gui/tests/qmltest_main.cpp
+++ b/src/tools/dbtool-gui/tests/qmltest_main.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Entry point for the QML test runner. Inlines what `QUICK_TEST_MAIN`
+// expands to so we can wrap the result with `TerminateProcess` on Windows
+// debug builds — see the matching note in `tests/main.cpp`. The QML files
+// under test live wherever the `-input <dir>` argument points, supplied by
+// CMake's `add_test` line so the build tree stays out of the executable.
+
+#include <QtQuickTest/quicktest.h>
+
+#ifdef _WIN32
+    #include <windows.h>
+#endif
+
+int main(int argc, char** argv)
+{
+    QTEST_SET_MAIN_SOURCE_PATH
+    // Source dir is supplied at runtime via `-input <dir>`; pass `nullptr`
+    // here so qmltestrunner doesn't fall back to a build-time path that
+    // wouldn't exist on the CI runner.
+    auto const result = quick_test_main(argc, argv, "dbtool_gui_qmltest", nullptr);
+#ifdef _WIN32
+    // See `tests/main.cpp` for the rationale: Qt 6 debug builds on
+    // Windows segfault during DLL_PROCESS_DETACH after a QML test session,
+    // even when every test passes. Skip the C++ tear-down phase entirely.
+    TerminateProcess(GetCurrentProcess(), static_cast<UINT>(result));
+#endif
+    return result;
+}


### PR DESCRIPTION
The Qt 6 `dbtool-gui` binary shipped without any automated coverage — every regression in `AppController`, the plugin-discovery log path, the connect/disconnect flow, or the QML loader would land unnoticed. This PR closes that gap with three test layers that all run headlessly under `QT_QPA_PLATFORM=offscreen`, plus a new GitHub Actions job that runs them on every push.

The C++ view-model layer is split into a STATIC `dbtool-gui-lib` so the test binaries can link `AppController` & friends without duplicating sources; the executable reduces to a thin wrapper around `main.cpp`. README's deferred-CI / deferred-qmltestrunner bullets are replaced with a "Running the tests" section.

## Changes

- `dbtool-gui-tests` — Catch2 unit tests for `AppController` driven via `QSignalSpy` (9 cases, 24 assertions: startup-banner replay on `attachLogSink`, profile loading, selection invariants, `previewMigrationSql` for unknown timestamps, `buildFailureReport`, etc.).
- `dbtool-gui-qmltest` — `qmltestrunner` suites verifying the `Lightweight.Migrations` QML module's singleton registration and Theme palette.
- `dbtool-gui-smoke` — Python process probe (`src/tests/test_dbtool_gui.py`) that launches the real binary, asserts liveness for 3 s with no FATAL markers, and terminates cleanly.
- `src/tools/dbtool-gui/CMakeLists.txt` — sources moved into a STATIC backing library; QML module attached to it; tests subdir gated on `LIGHTWEIGHT_BUILD_TESTS`.
- `ubuntu_dbtool_gui` job in `.github/workflows/build.yml` — Ubuntu 22.04 + Qt 6.8.0 via `jurplel/install-qt-action@v4` (cached), runs `ctest -L dbtool-gui --output-on-failure`.
- Custom test mains call `TerminateProcess` on Windows debug builds to side-step a Qt 6.11 DLL_PROCESS_DETACH segfault that fires after every test has already passed.

Windows + macOS runners, and the Postgres/MSSQL fan-out for the GUI job, are explicit follow-ups.