### PR TITLE
Add native batched INSERT/UPDATE for DataMapper

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,7 +32,7 @@
             "name": "windows-cl-common",
             "hidden": true,
             "inherits": ["windows-common"],
-            "generator": "Visual Studio 17 2022",
+            "generator": "Visual Studio 18 2026",
             "cacheVariables": {
                 "CMAKE_CXX_COMPILER": "cl"
             }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -131,10 +131,11 @@ void CRUD(DataMapper& dm)
 To insert or update many records efficiently, use `CreateAll` and `UpdateAll`. They prepare a single
 statement once and submit the whole batch, preferring native ODBC row-wise array binding (one
 `SQLExecute`, zero-copy) when every column is a fixed-width type — primitives, `SqlDate`/`SqlTime`/
-`SqlDateTime`, `SqlNumeric`, or `std::optional` of a fixed non-numeric type — and the driver supports
-parameter arrays. Records with variable-length columns (e.g. `std::string`) transparently fall back to
-a prepare-once + per-row execute, which is still far cheaper than calling `Create`/`CreateExplicit` in
-a loop (those re-prepare per row).
+`SqlDateTime`, `SqlNumeric`, inline fixed-capacity strings (`SqlAnsiString`/`SqlFixedString`), or
+`std::optional` of a fixed non-numeric type (including nullable fixed-capacity strings) — and the driver
+supports parameter arrays. Records with variable-length columns (e.g. `std::string`) transparently fall
+back to a prepare-once + per-row execute, which is still far cheaper than calling `Create`/`CreateExplicit`
+in a loop (those re-prepare per row).
 
 ```cpp
 void BulkInsert(DataMapper& dm, std::vector<Person> const& people)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -126,6 +126,33 @@ void CRUD(DataMapper& dm)
 }
 ```
 
+### Batched insert and update
+
+To insert or update many records efficiently, use `CreateAll` and `UpdateAll`. They prepare a single
+statement once and submit the whole batch, preferring native ODBC row-wise array binding (one
+`SQLExecute`, zero-copy) when every column is a fixed-width type — primitives, `SqlDate`/`SqlTime`/
+`SqlDateTime`, `SqlNumeric`, or `std::optional` of a fixed non-numeric type — and the driver supports
+parameter arrays. Records with variable-length columns (e.g. `std::string`) transparently fall back to
+a prepare-once + per-row execute, which is still far cheaper than calling `Create`/`CreateExplicit` in
+a loop (those re-prepare per row).
+
+```cpp
+void BulkInsert(DataMapper& dm, std::vector<Person> const& people)
+{
+    dm.CreateTable<Person>();
+
+    // Inserts all records with a single prepared statement (native batch when possible).
+    dm.CreateAll(people); // accepts any contiguous range: std::vector, std::array, std::span, C array
+
+    // UpdateAll writes all storable non-primary-key columns, matched on the primary key.
+    dm.UpdateAll(people);
+}
+```
+
+> Note: `CreateAll`/`UpdateAll` do not write primary keys, relations, or modified-state back onto the
+> records (treat them as write-only inputs), and `UpdateAll` writes a uniform set of columns for every
+> row rather than only the per-record modified ones. The range must be contiguous.
+
 ## Simple row retrieval via structs
 
 When only read access is needed, you can use a simple `struct` to represent the row,

--- a/src/Lightweight/DataBinder/BasicStringBinder.hpp
+++ b/src/Lightweight/DataBinder/BasicStringBinder.hpp
@@ -6,8 +6,10 @@
 #include "UnicodeConverter.hpp"
 
 #include <cassert>
+#include <cstddef>
 #include <cstring>
 #include <memory>
+#include <ranges>
 #include <utility>
 
 namespace Lightweight
@@ -269,6 +271,47 @@ struct SqlDataBinder<AnsiStringType>
                                 (SQLPOINTER) values,
                                 sizeof(AnsiStringType),
                                 indicators);
+    }
+
+    /// Binds an inline fixed-capacity string column of a native row-wise batch zero-copy.
+    ///
+    /// Only available for fixed-capacity string types (those exposing @c ::Capacity, e.g.
+    /// @c SqlFixedString / @c SqlAnsiString), whose character buffer is stored inline in the object —
+    /// so each row's characters are addressed at @c Data(elem0) + i*rowStride and bound directly,
+    /// while per-row lengths are supplied through a temporary row-strided indicator buffer. Heap-backed
+    /// strings (e.g. @c std::string) do not satisfy the constraint and use the soft batch path.
+    ///
+    /// @note Like the column-major batch binder, this binds @c SQL_C_CHAR without the PostgreSQL
+    /// UTF-16 round-trip, so it is correct for ASCII/single-byte content (matching existing batch
+    /// semantics); non-ASCII payloads on PostgreSQL should use the per-row path.
+    /// @note PRE (guaranteed by the caller): row-wise binding with @c SQL_ATTR_PARAM_BIND_TYPE ==
+    /// @p rowStride and @c rowStride % alignof(SQLLEN) == 0.
+    static SQLRETURN BatchRowWiseInputParameter(SQLHSTMT stmt,
+                                                SQLUSMALLINT column,
+                                                AnsiStringType const* elem0,
+                                                std::size_t rowStride,
+                                                std::size_t rowCount,
+                                                SqlDataBinderCallback& cb) noexcept
+        requires requires { AnsiStringType::Capacity; }
+    {
+        auto const* sourceBytes = reinterpret_cast<std::byte const*>(elem0);
+        auto* const indicatorBytes = cb.ProvideBatchStagingBuffer(((rowCount - 1) * rowStride) + sizeof(SQLLEN));
+        for (auto const i: std::views::iota(std::size_t { 0 }, rowCount))
+        {
+            auto const& str = *reinterpret_cast<AnsiStringType const*>(sourceBytes + (i * rowStride));
+            *reinterpret_cast<SQLLEN*>(indicatorBytes + (i * rowStride)) = static_cast<SQLLEN>(StringTraits::Size(&str));
+        }
+
+        return SQLBindParameter(stmt,
+                                column,
+                                SQL_PARAM_INPUT,
+                                SQL_C_CHAR,
+                                SQL_VARCHAR,
+                                AnsiStringType::Capacity,
+                                0,
+                                (SQLPOINTER) StringTraits::Data(elem0),
+                                static_cast<SQLLEN>(AnsiStringType::Capacity) + 1,
+                                reinterpret_cast<SQLLEN*>(indicatorBytes));
     }
 
     static LIGHTWEIGHT_FORCE_INLINE SQLRETURN OutputColumn(

--- a/src/Lightweight/DataBinder/BasicStringBinder.hpp
+++ b/src/Lightweight/DataBinder/BasicStringBinder.hpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <cstring>
 #include <memory>
+#include <optional>
 #include <ranges>
 #include <utility>
 
@@ -302,6 +303,22 @@ struct SqlDataBinder<AnsiStringType>
             *reinterpret_cast<SQLLEN*>(indicatorBytes + (i * rowStride)) = static_cast<SQLLEN>(StringTraits::Size(&str));
         }
 
+        return BatchRowWiseBindInline(stmt, column, elem0, reinterpret_cast<SQLLEN*>(indicatorBytes));
+    }
+
+    /// Issues the row-wise @c SQLBindParameter for an inline fixed-capacity string array.
+    ///
+    /// @p elem0 points at row 0's string; the driver strides its character buffer by the statement's
+    /// @c SQL_ATTR_PARAM_BIND_TYPE. @p indicators is a caller-prepared row-strided buffer whose per-row
+    /// slot already holds the string length, or @c SQL_NULL_DATA for a NULL row. Shared by the
+    /// non-optional row-wise binder and the @c std::optional row-wise binder so the bind incantation
+    /// (and its @c Capacity / buffer-length arithmetic) lives in exactly one place.
+    static SQLRETURN BatchRowWiseBindInline(SQLHSTMT stmt,
+                                            SQLUSMALLINT column,
+                                            AnsiStringType const* elem0,
+                                            SQLLEN* indicators) noexcept
+        requires requires { AnsiStringType::Capacity; }
+    {
         return SQLBindParameter(stmt,
                                 column,
                                 SQL_PARAM_INPUT,
@@ -311,7 +328,50 @@ struct SqlDataBinder<AnsiStringType>
                                 0,
                                 (SQLPOINTER) StringTraits::Data(elem0),
                                 static_cast<SQLLEN>(AnsiStringType::Capacity) + 1,
-                                reinterpret_cast<SQLLEN*>(indicatorBytes));
+                                indicators);
+    }
+
+    /// Binds an array of @c std::optional<fixed-capacity-string> in a native row-wise batch zero-copy.
+    ///
+    /// Mirrors @ref BatchRowWiseInputParameter but is NULL-aware: each row's indicator slot holds the
+    /// contained string's length when the optional is engaged, or @c SQL_NULL_DATA when disengaged. The
+    /// bind then targets row 0's contained character buffer and the driver strides by @p rowStride. Only
+    /// the address of the contained string is taken — disengaged storage is never read (its indicator is
+    /// @c SQL_NULL_DATA, so the driver ignores those bytes).
+    ///
+    /// This is the delegation target for @c SqlDataBinder<std::optional<T>>::BatchRowWiseInputParameter
+    /// when @p T is a length-bearing inline type (i.e. a fixed-capacity string).
+    ///
+    /// @note PRE (guaranteed by the caller): row-wise binding with @c SQL_ATTR_PARAM_BIND_TYPE ==
+    /// @p rowStride and @c rowStride % alignof(SQLLEN) == 0.
+    static SQLRETURN BatchRowWiseInputParameterOptional(SQLHSTMT stmt,
+                                                        SQLUSMALLINT column,
+                                                        std::optional<AnsiStringType> const* elem0,
+                                                        std::size_t rowStride,
+                                                        std::size_t rowCount,
+                                                        SqlDataBinderCallback& cb) noexcept
+        requires requires { AnsiStringType::Capacity; }
+    {
+        using OptionalType = std::optional<AnsiStringType>;
+
+        // Offset of the contained string within the optional (computed robustly, not assumed 0).
+        OptionalType const probe { AnsiStringType {} };
+        auto const valueOffset = static_cast<std::size_t>(reinterpret_cast<std::byte const*>(std::addressof(*probe))
+                                                          - reinterpret_cast<std::byte const*>(std::addressof(probe)));
+
+        auto const* sourceBytes = reinterpret_cast<std::byte const*>(elem0);
+        auto* const indicatorBytes = cb.ProvideBatchStagingBuffer(((rowCount - 1) * rowStride) + sizeof(SQLLEN));
+        for (auto const i: std::views::iota(std::size_t { 0 }, rowCount))
+        {
+            auto const& optional = *reinterpret_cast<OptionalType const*>(sourceBytes + (i * rowStride));
+            *reinterpret_cast<SQLLEN*>(indicatorBytes + (i * rowStride)) =
+                optional.has_value() ? static_cast<SQLLEN>(StringTraits::Size(std::addressof(*optional)))
+                                     : SQLLEN { SQL_NULL_DATA };
+        }
+
+        // Bind at row 0's contained string buffer (address only; disengaged storage is never read).
+        auto const* containedRow0 = reinterpret_cast<AnsiStringType const*>(sourceBytes + valueOffset);
+        return BatchRowWiseBindInline(stmt, column, containedRow0, reinterpret_cast<SQLLEN*>(indicatorBytes));
     }
 
     static LIGHTWEIGHT_FORCE_INLINE SQLRETURN OutputColumn(

--- a/src/Lightweight/DataBinder/Core.hpp
+++ b/src/Lightweight/DataBinder/Core.hpp
@@ -115,6 +115,13 @@ struct SqlBasicStringOperations;
 namespace detail
 {
 
+    /// @brief Satisfied when @p T is the same type as at least one of @p Us.
+    ///
+    /// Mirrors @c Lightweight::detail::OneOf, but lives in the DataBinder layer so the low-level binder
+    /// headers can use it without reaching up to the higher-level Utils.hpp.
+    template <typename T, typename... Us>
+    concept IsAnyOf = (std::same_as<T, Us> || ...);
+
     // clang-format off
 template <typename T>
 concept HasGetStringAndGetLength = requires(T const& t) {

--- a/src/Lightweight/DataBinder/Core.hpp
+++ b/src/Lightweight/DataBinder/Core.hpp
@@ -84,6 +84,10 @@ class LIGHTWEIGHT_API SqlDataBinderCallback
     ///
     /// @note The buffer contents are unspecified; the caller is responsible for initializing it.
     /// @note The returned storage is aligned to at least @c alignof(std::max_align_t).
+    /// @note Row-wise callers request @c ~rowStride*rowCount bytes to hold only @c rowCount @c SQLLEN
+    /// indicators. This over-allocation is intrinsic to ODBC row-wise binding, which strides the
+    /// @c StrLen_or_IndPtr array by @c SQL_ATTR_PARAM_BIND_TYPE (the row stride) — there is no separate
+    /// indicator stride — so a tightly packed indicator array would require descriptor-level binding.
     ///
     /// @param byteCount The number of bytes to provide.
     /// @return A pointer to the first byte of the buffer.
@@ -205,8 +209,11 @@ inline constexpr bool SqlIsNativeRowBindableValue = false;
 template <typename T>
 inline constexpr bool SqlIsNumericValue = false;
 
-/// @brief Whether @p T is a @c std::optional specialization. Distinct name from any DataMapper trait to
-/// avoid one-definition-rule clashes when both headers are included.
+/// @brief Whether @p T is a @c std::optional specialization.
+///
+/// Defined locally rather than reusing @c Lightweight::IsSpecializationOf (Utils.hpp) or the DataMapper
+/// @c IsStdOptional (Field.hpp): this low-level binder header is deliberately kept free of dependencies on
+/// those higher-level headers, so it carries its own minimal optional traits.
 template <typename T>
 inline constexpr bool SqlIsStdOptional = false;
 

--- a/src/Lightweight/DataBinder/Core.hpp
+++ b/src/Lightweight/DataBinder/Core.hpp
@@ -217,13 +217,13 @@ inline constexpr bool SqlIsStdOptional<std::optional<T>> = true;
 template <typename T>
 struct SqlOptionalInner
 {
-    using type = T;
+    using type = T; ///< @p T itself, since @p T is not a @c std::optional.
 };
 
 template <typename T>
 struct SqlOptionalInner<std::optional<T>>
 {
-    using type = T;
+    using type = T; ///< The value type contained in the @c std::optional.
 };
 
 template <typename T>

--- a/src/Lightweight/DataBinder/Core.hpp
+++ b/src/Lightweight/DataBinder/Core.hpp
@@ -220,22 +220,6 @@ inline constexpr bool SqlIsStdOptional = false;
 template <typename T>
 inline constexpr bool SqlIsStdOptional<std::optional<T>> = true;
 
-/// @brief The contained value type of a @c std::optional (or @p T itself when not an optional).
-template <typename T>
-struct SqlOptionalInner
-{
-    using type = T; ///< @p T itself, since @p T is not a @c std::optional.
-};
-
-template <typename T>
-struct SqlOptionalInner<std::optional<T>>
-{
-    using type = T; ///< The value type contained in the @c std::optional.
-};
-
-template <typename T>
-using SqlOptionalInnerType = typename SqlOptionalInner<T>::type;
-
 template <typename T>
 concept SqlGetColumnNativeType =
     requires(SQLHSTMT hStmt, SQLUSMALLINT column, T* result, SQLLEN* indicator, SqlDataBinderCallback const& cb) {

--- a/src/Lightweight/DataBinder/Core.hpp
+++ b/src/Lightweight/DataBinder/Core.hpp
@@ -10,7 +10,9 @@
 #include "../SqlServerType.hpp"
 
 #include <concepts>
+#include <cstddef>
 #include <functional>
+#include <optional>
 
 #include <sql.h>
 #include <sqlext.h>
@@ -72,6 +74,20 @@ class LIGHTWEIGHT_API SqlDataBinderCallback
     /// @param rowCount The number of rows in the batch.
     /// @return A pointer to the first element of the indicator array.
     virtual SQLLEN* ProvideInputIndicators(size_t rowCount) = 0;
+
+    /// Provides a pointer to a contiguous, suitably aligned temporary byte buffer that remains valid
+    /// until the statement is executed.
+    ///
+    /// This is used by batch input parameter binders that need scratch storage whose lifetime must
+    /// outlive the bind call but not the execution — for example a row-strided NULL/length indicator
+    /// array used by native row-wise array binding of @c std::optional columns.
+    ///
+    /// @note The buffer contents are unspecified; the caller is responsible for initializing it.
+    /// @note The returned storage is aligned to at least @c alignof(std::max_align_t).
+    ///
+    /// @param byteCount The number of bytes to provide.
+    /// @return A pointer to the first byte of the buffer.
+    virtual std::byte* ProvideBatchStagingBuffer(std::size_t byteCount) = 0;
 
     /// @return The server type of the database.
     [[nodiscard]] virtual SqlServerType ServerType() const noexcept = 0;
@@ -168,6 +184,50 @@ concept SqlInputParameterBatchBinder =
                 hStmt, column, std::declval<std::ranges::range_value_t<T>>(), cb)
         } -> std::same_as<SQLRETURN>;
     };
+
+/// @brief Opt-in trait marking a value type as bindable in a native ODBC row-wise parameter array.
+///
+/// A type qualifies when it is fixed-width, stored inline, bound via a plain @c SQLBindParameter with
+/// no per-call heap conversion, and identically across all supported backends — so its address can be
+/// handed to ODBC and strided by @c SQL_ATTR_PARAM_BIND_TYPE. The primary template is @c false; each
+/// eligible binder header specializes it to @c true (primitives, date/time/datetime, numeric).
+///
+/// @note @c SqlGuid is intentionally NOT marked: on SQLite it is bound via a per-value text conversion,
+/// which cannot be expressed as a zero-copy row-wise array — GUID columns use the soft batch path.
+template <typename T>
+inline constexpr bool SqlIsNativeRowBindableValue = false;
+
+/// @brief Opt-in trait marking a value type as an @c SqlNumeric specialization.
+///
+/// Numeric values are row-wise bindable, but @c std::optional<SqlNumeric> is not (the contained value
+/// is not bound at a uniform offset/representation across backends), so the optional batch path
+/// excludes them via this trait.
+template <typename T>
+inline constexpr bool SqlIsNumericValue = false;
+
+/// @brief Whether @p T is a @c std::optional specialization. Distinct name from any DataMapper trait to
+/// avoid one-definition-rule clashes when both headers are included.
+template <typename T>
+inline constexpr bool SqlIsStdOptional = false;
+
+template <typename T>
+inline constexpr bool SqlIsStdOptional<std::optional<T>> = true;
+
+/// @brief The contained value type of a @c std::optional (or @p T itself when not an optional).
+template <typename T>
+struct SqlOptionalInner
+{
+    using type = T;
+};
+
+template <typename T>
+struct SqlOptionalInner<std::optional<T>>
+{
+    using type = T;
+};
+
+template <typename T>
+using SqlOptionalInnerType = typename SqlOptionalInner<T>::type;
 
 template <typename T>
 concept SqlGetColumnNativeType =

--- a/src/Lightweight/DataBinder/Primitives.cpp
+++ b/src/Lightweight/DataBinder/Primitives.cpp
@@ -32,8 +32,12 @@ SQLRETURN Int64DataBinderHelper<Int64Type, TheCType>::InputParameter(SQLHSTMT st
 }
 
 template <typename Int64Type, SQLSMALLINT TheCType>
-SQLRETURN Int64DataBinderHelper<Int64Type, TheCType>::BatchInputParameter(
-    SQLHSTMT stmt, SQLUSMALLINT column, Int64Type const* values, size_t rowCount, SqlDataBinderCallback& cb) noexcept
+SQLRETURN Int64DataBinderHelper<Int64Type, TheCType>::BatchInputParameter(SQLHSTMT stmt,
+                                                                          SQLUSMALLINT column,
+                                                                          Int64Type const* values,
+                                                                          size_t rowCount,
+                                                                          SqlDataBinderCallback& cb,
+                                                                          SQLLEN* indicators) noexcept
 {
     // clang-format off
     static constexpr auto map = std::array {
@@ -45,7 +49,7 @@ SQLRETURN Int64DataBinderHelper<Int64Type, TheCType>::BatchInputParameter(
     };
     // clang-format on
     auto const index = static_cast<size_t>(cb.ServerType());
-    return map[index](stmt, column, values, rowCount, cb);
+    return map[index](stmt, column, values, rowCount, cb, indicators);
 }
 
 template <typename Int64Type, SQLSMALLINT TheCType>

--- a/src/Lightweight/DataBinder/Primitives.hpp
+++ b/src/Lightweight/DataBinder/Primitives.hpp
@@ -110,20 +110,17 @@ template <> struct SqlDataBinder<std::size_t>: SqlSimpleDataBinder<std::size_t, 
 
 // These fixed-width primitives bind via a plain SQLBindParameter and are eligible for native row-wise
 // batch binding (see SqlIsNativeRowBindableValue in Core.hpp). A single constrained partial
-// specialization covers them all. std::same_as is used rather than detail::OneOf so this low-level
-// binder header does not have to include Utils.hpp (which transitively pulls in reflection-cpp).
+// specialization, keyed on detail::IsAnyOf, covers them all.
 template <typename T>
-    requires(std::same_as<T, bool> || std::same_as<T, char> || std::same_as<T, int8_t> || std::same_as<T, uint8_t>
-             || std::same_as<T, int16_t> || std::same_as<T, uint16_t> || std::same_as<T, int32_t>
-             || std::same_as<T, uint32_t> || std::same_as<T, int64_t> || std::same_as<T, uint64_t>
-             || std::same_as<T, float> || std::same_as<T, double>
+    requires detail::IsAnyOf<T, bool, char, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t,
+                             float, double
 #if !defined(_WIN32) && !defined(__APPLE__)
-             || std::same_as<T, long long> || std::same_as<T, unsigned long long>
+                             , long long, unsigned long long
 #endif
 #if defined(__APPLE__)
-             || std::same_as<T, std::size_t>
+                             , std::size_t
 #endif
-    )
+                             >
 inline constexpr bool SqlIsNativeRowBindableValue<T> = true;
 // clang-format on
 

--- a/src/Lightweight/DataBinder/Primitives.hpp
+++ b/src/Lightweight/DataBinder/Primitives.hpp
@@ -109,26 +109,22 @@ template <> struct SqlDataBinder<std::size_t>: SqlSimpleDataBinder<std::size_t, 
 #endif
 
 // These fixed-width primitives bind via a plain SQLBindParameter and are eligible for native row-wise
-// batch binding (see SqlIsNativeRowBindableValue in Core.hpp).
-template <> inline constexpr bool SqlIsNativeRowBindableValue<bool> = true;
-template <> inline constexpr bool SqlIsNativeRowBindableValue<char> = true;
-template <> inline constexpr bool SqlIsNativeRowBindableValue<int8_t> = true;
-template <> inline constexpr bool SqlIsNativeRowBindableValue<uint8_t> = true;
-template <> inline constexpr bool SqlIsNativeRowBindableValue<int16_t> = true;
-template <> inline constexpr bool SqlIsNativeRowBindableValue<uint16_t> = true;
-template <> inline constexpr bool SqlIsNativeRowBindableValue<int32_t> = true;
-template <> inline constexpr bool SqlIsNativeRowBindableValue<uint32_t> = true;
-template <> inline constexpr bool SqlIsNativeRowBindableValue<int64_t> = true;
-template <> inline constexpr bool SqlIsNativeRowBindableValue<uint64_t> = true;
-template <> inline constexpr bool SqlIsNativeRowBindableValue<float> = true;
-template <> inline constexpr bool SqlIsNativeRowBindableValue<double> = true;
+// batch binding (see SqlIsNativeRowBindableValue in Core.hpp). A single constrained partial
+// specialization covers them all. std::same_as is used rather than detail::OneOf so this low-level
+// binder header does not have to include Utils.hpp (which transitively pulls in reflection-cpp).
+template <typename T>
+    requires(std::same_as<T, bool> || std::same_as<T, char> || std::same_as<T, int8_t> || std::same_as<T, uint8_t>
+             || std::same_as<T, int16_t> || std::same_as<T, uint16_t> || std::same_as<T, int32_t>
+             || std::same_as<T, uint32_t> || std::same_as<T, int64_t> || std::same_as<T, uint64_t>
+             || std::same_as<T, float> || std::same_as<T, double>
 #if !defined(_WIN32) && !defined(__APPLE__)
-template <> inline constexpr bool SqlIsNativeRowBindableValue<long long> = true;
-template <> inline constexpr bool SqlIsNativeRowBindableValue<unsigned long long> = true;
+             || std::same_as<T, long long> || std::same_as<T, unsigned long long>
 #endif
 #if defined(__APPLE__)
-template <> inline constexpr bool SqlIsNativeRowBindableValue<std::size_t> = true;
+             || std::same_as<T, std::size_t>
 #endif
+    )
+inline constexpr bool SqlIsNativeRowBindableValue<T> = true;
 // clang-format on
 
 } // namespace Lightweight

--- a/src/Lightweight/DataBinder/Primitives.hpp
+++ b/src/Lightweight/DataBinder/Primitives.hpp
@@ -23,11 +23,20 @@ struct SqlSimpleDataBinder
         return SQLBindParameter(stmt, column, SQL_PARAM_INPUT, TheCType, TheSqlType, 0, 0, (SQLPOINTER) &value, 0, nullptr);
     }
 
-    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN BatchInputParameter(
-        SQLHSTMT stmt, SQLUSMALLINT column, T const* values, size_t /*rowCount*/, SqlDataBinderCallback& /*cb*/) noexcept
+    /// Binds a contiguous (column-wise) or row-strided (row-wise) array of values as an input parameter.
+    ///
+    /// @param indicators Optional per-row NULL/length indicator array. Passed straight to ODBC as the
+    /// StrLen_or_IndPtr; defaults to nullptr (no NULLs). For row-wise binding the driver strides it by
+    /// the statement's SQL_ATTR_PARAM_BIND_TYPE, matching the value stride.
+    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN BatchInputParameter(SQLHSTMT stmt,
+                                                                  SQLUSMALLINT column,
+                                                                  T const* values,
+                                                                  size_t /*rowCount*/,
+                                                                  SqlDataBinderCallback& /*cb*/,
+                                                                  SQLLEN* indicators = nullptr) noexcept
     {
         return SQLBindParameter(
-            stmt, column, SQL_PARAM_INPUT, TheCType, TheSqlType, 0, 0, (SQLPOINTER) values, sizeof(T), nullptr);
+            stmt, column, SQL_PARAM_INPUT, TheCType, TheSqlType, 0, 0, (SQLPOINTER) values, sizeof(T), indicators);
     }
 
     static LIGHTWEIGHT_FORCE_INLINE SQLRETURN OutputColumn(
@@ -58,8 +67,12 @@ struct Int64DataBinderHelper
                                                     Int64Type const& value,
                                                     SqlDataBinderCallback& cb) noexcept;
 
-    static LIGHTWEIGHT_API SQLRETURN BatchInputParameter(
-        SQLHSTMT stmt, SQLUSMALLINT column, Int64Type const* values, size_t rowCount, SqlDataBinderCallback& cb) noexcept;
+    static LIGHTWEIGHT_API SQLRETURN BatchInputParameter(SQLHSTMT stmt,
+                                                         SQLUSMALLINT column,
+                                                         Int64Type const* values,
+                                                         size_t rowCount,
+                                                         SqlDataBinderCallback& cb,
+                                                         SQLLEN* indicators = nullptr) noexcept;
 
     static LIGHTWEIGHT_API SQLRETURN OutputColumn(
         SQLHSTMT stmt, SQLUSMALLINT column, Int64Type* result, SQLLEN* indicator, SqlDataBinderCallback& cb) noexcept;
@@ -93,6 +106,28 @@ template <> struct SqlDataBinder<unsigned long long>: Int64DataBinderHelper<unsi
 #endif
 #if defined(__APPLE__) // size_t is a different type on macOS
 template <> struct SqlDataBinder<std::size_t>: SqlSimpleDataBinder<std::size_t, SQL_C_SBIGINT, SqlColumnTypeDefinitions::Bigint {}> {};
+#endif
+
+// These fixed-width primitives bind via a plain SQLBindParameter and are eligible for native row-wise
+// batch binding (see SqlIsNativeRowBindableValue in Core.hpp).
+template <> inline constexpr bool SqlIsNativeRowBindableValue<bool> = true;
+template <> inline constexpr bool SqlIsNativeRowBindableValue<char> = true;
+template <> inline constexpr bool SqlIsNativeRowBindableValue<int8_t> = true;
+template <> inline constexpr bool SqlIsNativeRowBindableValue<uint8_t> = true;
+template <> inline constexpr bool SqlIsNativeRowBindableValue<int16_t> = true;
+template <> inline constexpr bool SqlIsNativeRowBindableValue<uint16_t> = true;
+template <> inline constexpr bool SqlIsNativeRowBindableValue<int32_t> = true;
+template <> inline constexpr bool SqlIsNativeRowBindableValue<uint32_t> = true;
+template <> inline constexpr bool SqlIsNativeRowBindableValue<int64_t> = true;
+template <> inline constexpr bool SqlIsNativeRowBindableValue<uint64_t> = true;
+template <> inline constexpr bool SqlIsNativeRowBindableValue<float> = true;
+template <> inline constexpr bool SqlIsNativeRowBindableValue<double> = true;
+#if !defined(_WIN32) && !defined(__APPLE__)
+template <> inline constexpr bool SqlIsNativeRowBindableValue<long long> = true;
+template <> inline constexpr bool SqlIsNativeRowBindableValue<unsigned long long> = true;
+#endif
+#if defined(__APPLE__)
+template <> inline constexpr bool SqlIsNativeRowBindableValue<std::size_t> = true;
 #endif
 // clang-format on
 

--- a/src/Lightweight/DataBinder/SqlDate.hpp
+++ b/src/Lightweight/DataBinder/SqlDate.hpp
@@ -119,6 +119,28 @@ struct SqlDataBinder<SqlDate>
             stmt, column, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, SQL_TYPE_DATE, 0, 0, (SQLPOINTER) &value.sqlValue, 0, nullptr);
     }
 
+    /// Binds an array of dates as an input parameter for native (row-wise or column-wise) batch
+    /// execution. @p values points at the first element; the driver strides by the statement's
+    /// SQL_ATTR_PARAM_BIND_TYPE. @p indicators optionally supplies per-row NULL flags.
+    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN BatchInputParameter(SQLHSTMT stmt,
+                                                                  SQLUSMALLINT column,
+                                                                  SqlDate const* values,
+                                                                  size_t /*rowCount*/,
+                                                                  SqlDataBinderCallback& /*cb*/,
+                                                                  SQLLEN* indicators = nullptr) noexcept
+    {
+        return SQLBindParameter(stmt,
+                                column,
+                                SQL_PARAM_INPUT,
+                                SQL_C_TYPE_DATE,
+                                SQL_TYPE_DATE,
+                                0,
+                                0,
+                                (SQLPOINTER) &values->sqlValue,
+                                sizeof(values->sqlValue),
+                                indicators);
+    }
+
     static LIGHTWEIGHT_FORCE_INLINE SQLRETURN OutputColumn(
         SQLHSTMT stmt, SQLUSMALLINT column, SqlDate* result, SQLLEN* indicator, SqlDataBinderCallback& /*cb*/) noexcept
     {
@@ -136,5 +158,8 @@ struct SqlDataBinder<SqlDate>
         return std::format("{}", value);
     }
 };
+
+template <>
+inline constexpr bool SqlIsNativeRowBindableValue<SqlDate> = true;
 
 } // namespace Lightweight

--- a/src/Lightweight/DataBinder/SqlDateTime.hpp
+++ b/src/Lightweight/DataBinder/SqlDateTime.hpp
@@ -372,6 +372,57 @@ struct LIGHTWEIGHT_API SqlDataBinder<SqlDateTime>
                                 nullptr);
     }
 
+    /// Binds an array of timestamps as an input parameter for native (row-wise or column-wise) batch
+    /// execution. @p values points at the first element; the driver strides by the statement's
+    /// SQL_ATTR_PARAM_BIND_TYPE. @p indicators optionally supplies per-row NULL flags.
+    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN BatchInputParameter(SQLHSTMT stmt,
+                                                                  SQLUSMALLINT column,
+                                                                  SqlDateTime const* values,
+                                                                  size_t /*rowCount*/,
+                                                                  [[maybe_unused]] SqlDataBinderCallback& cb,
+                                                                  SQLLEN* indicators = nullptr) noexcept
+    {
+#if defined(_WIN32) || defined(_WIN64)
+        using namespace std::string_view_literals;
+        if (cb.ServerType() == SqlServerType::MICROSOFT_SQL && cb.DriverName() == "SQLSRV32.DLL"sv)
+        {
+            struct
+            {
+                SQLSMALLINT sqlType { SQL_TYPE_TIMESTAMP };
+                SQLULEN paramSize { 23 };
+                SQLSMALLINT decimalDigits { 3 };
+                SQLSMALLINT nullable {};
+            } hints;
+            auto const sqlDescribeParamResult =
+                SQLDescribeParam(stmt, column, &hints.sqlType, &hints.paramSize, &hints.decimalDigits, &hints.nullable);
+            if (SQL_SUCCEEDED(sqlDescribeParamResult))
+            {
+                return SQLBindParameter(stmt,
+                                        column,
+                                        SQL_PARAM_INPUT,
+                                        SQL_C_TIMESTAMP,
+                                        hints.sqlType,
+                                        hints.paramSize,
+                                        hints.decimalDigits,
+                                        (SQLPOINTER) &values->sqlValue,
+                                        sizeof(*values),
+                                        indicators);
+            }
+        }
+#endif
+
+        return SQLBindParameter(stmt,
+                                column,
+                                SQL_PARAM_INPUT,
+                                SQL_C_TIMESTAMP,
+                                SQL_TYPE_TIMESTAMP,
+                                27,
+                                7,
+                                (SQLPOINTER) &values->sqlValue,
+                                sizeof(*values),
+                                indicators);
+    }
+
     static LIGHTWEIGHT_FORCE_INLINE SQLRETURN OutputColumn(
         SQLHSTMT stmt, SQLUSMALLINT column, SqlDateTime* result, SQLLEN* indicator, SqlDataBinderCallback& /*cb*/) noexcept
     {
@@ -394,5 +445,8 @@ struct LIGHTWEIGHT_API SqlDataBinder<SqlDateTime>
         return std::format("{}", value);
     }
 };
+
+template <>
+inline constexpr bool SqlIsNativeRowBindableValue<SqlDateTime> = true;
 
 } // namespace Lightweight

--- a/src/Lightweight/DataBinder/SqlFixedString.hpp
+++ b/src/Lightweight/DataBinder/SqlFixedString.hpp
@@ -494,6 +494,12 @@ struct SqlBasicStringOperations<SqlFixedString<N, T, Mode>>
     }
 };
 
+// char-based fixed-capacity strings store their characters inline and can be bound zero-copy in a
+// native row-wise batch (via the AnsiString binder's BatchRowWiseInputParameter). Wide fixed strings
+// require encoding conversion and therefore use the soft batch path.
+template <std::size_t N, SqlFixedStringMode Mode>
+inline constexpr bool SqlIsNativeRowBindableValue<SqlFixedString<N, char, Mode>> = true;
+
 } // namespace Lightweight
 
 template <std::size_t N, typename T, Lightweight::SqlFixedStringMode P>

--- a/src/Lightweight/DataBinder/SqlNumeric.hpp
+++ b/src/Lightweight/DataBinder/SqlNumeric.hpp
@@ -240,13 +240,18 @@ struct SqlDataBinder<SqlNumeric<Precision, Scale>>
                                     nullptr);
         }
 
+        // Bind with the type's compile-time Precision/Scale rather than value.sqlValue.precision/scale:
+        // the latter is 0 for a default-constructed (never-assigned) value. On the native row-wise batch
+        // path a single bind descriptor (taken from row 0) governs the whole array, so a default-constructed
+        // row 0 would otherwise mis-bind every row. The template constants are correct for every value of
+        // SqlNumeric<Precision, Scale> by definition (assign() always sets these same values).
         return SQLBindParameter(stmt,
                                 column,
                                 SQL_PARAM_INPUT,
                                 SQL_C_NUMERIC,
                                 SQL_NUMERIC,
-                                value.sqlValue.precision,
-                                value.sqlValue.scale,
+                                static_cast<SQLULEN>(Precision),
+                                static_cast<SQLSMALLINT>(Scale),
                                 (SQLPOINTER) &value,
                                 sizeof(value),
                                 nullptr);

--- a/src/Lightweight/DataBinder/SqlNumeric.hpp
+++ b/src/Lightweight/DataBinder/SqlNumeric.hpp
@@ -291,6 +291,14 @@ struct SqlDataBinder<SqlNumeric<Precision, Scale>>
         return value.ToString();
     }
 };
+
+// SqlNumeric binds a fixed-width inline struct and is row-wise batchable for non-nullable columns. It
+// is flagged as numeric so the std::optional batch path excludes it (its contained value is not bound
+// at a uniform offset/representation across backends).
+template <std::size_t ThePrecision, std::size_t TheScale>
+inline constexpr bool SqlIsNativeRowBindableValue<SqlNumeric<ThePrecision, TheScale>> = true;
+template <std::size_t ThePrecision, std::size_t TheScale>
+inline constexpr bool SqlIsNumericValue<SqlNumeric<ThePrecision, TheScale>> = true;
 // clang-format off
 
 } // namespace Lightweight

--- a/src/Lightweight/DataBinder/SqlTime.hpp
+++ b/src/Lightweight/DataBinder/SqlTime.hpp
@@ -143,6 +143,28 @@ struct SqlDataBinder<SqlTime>
             stmt, column, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, SQL_TYPE_TIME, 0, 0, (SQLPOINTER) &value.sqlValue, 0, nullptr);
     }
 
+    /// Binds an array of times as an input parameter for native (row-wise or column-wise) batch
+    /// execution. @p values points at the first element; the driver strides by the statement's
+    /// SQL_ATTR_PARAM_BIND_TYPE. @p indicators optionally supplies per-row NULL flags.
+    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN BatchInputParameter(SQLHSTMT stmt,
+                                                                  SQLUSMALLINT column,
+                                                                  SqlTime const* values,
+                                                                  size_t /*rowCount*/,
+                                                                  SqlDataBinderCallback& /*cb*/,
+                                                                  SQLLEN* indicators = nullptr) noexcept
+    {
+        return SQLBindParameter(stmt,
+                                column,
+                                SQL_PARAM_INPUT,
+                                SQL_C_TYPE_TIME,
+                                SQL_TYPE_TIME,
+                                0,
+                                0,
+                                (SQLPOINTER) &values->sqlValue,
+                                sizeof(values->sqlValue),
+                                indicators);
+    }
+
     static LIGHTWEIGHT_FORCE_INLINE SQLRETURN OutputColumn(
         SQLHSTMT stmt, SQLUSMALLINT column, SqlTime* result, SQLLEN* indicator, SqlDataBinderCallback& /*cb*/) noexcept
     {
@@ -164,6 +186,9 @@ struct SqlDataBinder<SqlTime>
                            value.sqlValue.fraction);
     }
 };
+
+template <>
+inline constexpr bool SqlIsNativeRowBindableValue<SqlTime> = true;
 
 } // namespace Lightweight
 

--- a/src/Lightweight/DataBinder/StdOptional.hpp
+++ b/src/Lightweight/DataBinder/StdOptional.hpp
@@ -5,8 +5,11 @@
 #include "Core.hpp"
 #include "SqlNullValue.hpp"
 
-#include <format>
+#include <cstddef>
+#include <memory>
 #include <optional>
+#include <ranges>
+#include <string>
 
 namespace Lightweight
 {
@@ -27,6 +30,60 @@ struct SqlDataBinder<std::optional<T>>
             return SqlDataBinder<T>::InputParameter(stmt, column, *value, cb);
         else
             return SqlDataBinder<SqlNullType>::InputParameter(stmt, column, SqlNullValue, cb);
+    }
+
+    /// Binds an optional column of a native row-wise batch zero-copy, supplying per-row NULL-ness via a
+    /// temporary row-strided indicator buffer.
+    ///
+    /// The contained value of each row's @c std::optional<T> is bound in place (no copy); the driver
+    /// strides by the statement's @c SQL_ATTR_PARAM_BIND_TYPE (== @p rowStride). For rows whose optional
+    /// is disengaged the indicator is set to @c SQL_NULL_DATA so the (indeterminate) value bytes are
+    /// ignored — the value storage is never dereferenced as a @c T, only its address is taken.
+    ///
+    /// @note PRE (guaranteed by the caller): the statement is in row-wise binding mode with
+    /// @c SQL_ATTR_PARAM_BIND_TYPE == @p rowStride, and @c rowStride % alignof(SQLLEN) == 0 so the
+    /// indicator slots at @c i*rowStride stay aligned and non-overlapping.
+    /// @note Only provided for fixed-width @c T whose binder offers @c BatchInputParameter (primitives,
+    /// date/time/datetime, GUID). Variable-length / numeric @c T route through the soft path instead.
+    ///
+    /// @param stmt The ODBC statement handle.
+    /// @param column The 1-based parameter column index.
+    /// @param elem0 Address of the @c std::optional<T> within row 0 of the contiguous record array.
+    /// @param rowStride The row-wise bind stride (== sizeof of the row element).
+    /// @param rowCount The number of rows in the batch.
+    /// @param cb The data binder callback (provides the temporary indicator buffer).
+    /// @return The ODBC return code of the underlying bind.
+    static SQLRETURN BatchRowWiseInputParameter(SQLHSTMT stmt,
+                                                SQLUSMALLINT column,
+                                                OptionalValue const* elem0,
+                                                std::size_t rowStride,
+                                                std::size_t rowCount,
+                                                SqlDataBinderCallback& cb) noexcept
+    {
+        // Offset of the contained value within std::optional<T> (0 on all known standard libraries,
+        // but computed robustly so the address arithmetic below does not bake in that assumption).
+        OptionalValue const probe { T {} };
+        auto const valueOffset = static_cast<std::size_t>(reinterpret_cast<std::byte const*>(std::addressof(*probe))
+                                                          - reinterpret_cast<std::byte const*>(std::addressof(probe)));
+
+        // Row-strided indicator buffer: ODBC reads the indicator for row i at base + i*rowStride. The
+        // optionals themselves are embedded in the row structs, so they are also addressed at
+        // sourceBytes + i*rowStride (NOT elem0[i], which would stride by sizeof(std::optional<T>)).
+        auto const* sourceBytes = reinterpret_cast<std::byte const*>(elem0);
+        auto* const indicatorBytes = cb.ProvideBatchStagingBuffer(((rowCount - 1) * rowStride) + sizeof(SQLLEN));
+        for (auto const i: std::views::iota(std::size_t { 0 }, rowCount))
+        {
+            // The optional and its indicator slot for row i both live at offset i*rowStride (row-wise).
+            auto const& optional = *reinterpret_cast<OptionalValue const*>(sourceBytes + (i * rowStride));
+            auto* const indicatorSlot = reinterpret_cast<SQLLEN*>(indicatorBytes + (i * rowStride));
+            *indicatorSlot = optional.has_value() ? SQLLEN { 0 } : SQLLEN { SQL_NULL_DATA };
+        }
+
+        // Zero-copy value bind: point at row 0's contained value; T's batch binder issues the
+        // SQLBindParameter (taking only the address, never forming a T& to possibly-disengaged storage).
+        auto const* valueBase = reinterpret_cast<T const*>(reinterpret_cast<std::byte const*>(elem0) + valueOffset);
+        return SqlDataBinder<T>::BatchInputParameter(
+            stmt, column, valueBase, rowCount, cb, reinterpret_cast<SQLLEN*>(indicatorBytes));
     }
 
     static LIGHTWEIGHT_FORCE_INLINE SQLRETURN OutputColumn(

--- a/src/Lightweight/DataBinder/StdOptional.hpp
+++ b/src/Lightweight/DataBinder/StdOptional.hpp
@@ -14,6 +14,20 @@
 namespace Lightweight
 {
 
+namespace detail
+{
+    /// Whether @p T's binder exposes an optional-aware row-wise batch binder
+    /// (@c BatchRowWiseInputParameterOptional). True for length-bearing inline inner types
+    /// (fixed-capacity strings), which need a per-row length indicator; false for plain fixed-width inner
+    /// types (primitives, date/time), which carry only a NULL indicator and bind via
+    /// @c BatchInputParameter.
+    template <typename T>
+    concept SqlHasOptionalRowWiseBatchBinder = requires(
+        SQLHSTMT stmt, SQLUSMALLINT column, std::optional<T> const* elem0, std::size_t rowCount, SqlDataBinderCallback& cb) {
+        SqlDataBinder<T>::BatchRowWiseInputParameterOptional(stmt, column, elem0, rowCount, rowCount, cb);
+    };
+} // namespace detail
+
 template <typename T>
 struct SqlDataBinder<std::optional<T>>
 {
@@ -35,16 +49,18 @@ struct SqlDataBinder<std::optional<T>>
     /// Binds an optional column of a native row-wise batch zero-copy, supplying per-row NULL-ness via a
     /// temporary row-strided indicator buffer.
     ///
-    /// The contained value of each row's @c std::optional<T> is bound in place (no copy); the driver
-    /// strides by the statement's @c SQL_ATTR_PARAM_BIND_TYPE (== @p rowStride). For rows whose optional
-    /// is disengaged the indicator is set to @c SQL_NULL_DATA so the (indeterminate) value bytes are
-    /// ignored — the value storage is never dereferenced as a @c T, only its address is taken.
+    /// Dispatches on the inner type @p T:
+    /// - Length-bearing inline types (fixed-capacity strings): delegates to @p T's binder, which fills
+    ///   the per-row length-or-@c SQL_NULL_DATA indicator and binds the inline character buffers.
+    /// - Plain fixed-width types (primitives, date/time): the contained value of each row is bound in
+    ///   place (no copy); the driver strides by the statement's @c SQL_ATTR_PARAM_BIND_TYPE (== @p
+    ///   rowStride). For rows whose optional is disengaged the indicator is @c SQL_NULL_DATA so the
+    ///   (indeterminate) value bytes are ignored — the value storage is never dereferenced as a @c T,
+    ///   only its address is taken.
     ///
     /// @note PRE (guaranteed by the caller): the statement is in row-wise binding mode with
     /// @c SQL_ATTR_PARAM_BIND_TYPE == @p rowStride, and @c rowStride % alignof(SQLLEN) == 0 so the
     /// indicator slots at @c i*rowStride stay aligned and non-overlapping.
-    /// @note Only provided for fixed-width @c T whose binder offers @c BatchInputParameter (primitives,
-    /// date/time/datetime, GUID). Variable-length / numeric @c T route through the soft path instead.
     ///
     /// @param stmt The ODBC statement handle.
     /// @param column The 1-based parameter column index.
@@ -60,30 +76,39 @@ struct SqlDataBinder<std::optional<T>>
                                                 std::size_t rowCount,
                                                 SqlDataBinderCallback& cb) noexcept
     {
-        // Offset of the contained value within std::optional<T> (0 on all known standard libraries,
-        // but computed robustly so the address arithmetic below does not bake in that assumption).
-        OptionalValue const probe { T {} };
-        auto const valueOffset = static_cast<std::size_t>(reinterpret_cast<std::byte const*>(std::addressof(*probe))
-                                                          - reinterpret_cast<std::byte const*>(std::addressof(probe)));
-
-        // Row-strided indicator buffer: ODBC reads the indicator for row i at base + i*rowStride. The
-        // optionals themselves are embedded in the row structs, so they are also addressed at
-        // sourceBytes + i*rowStride (NOT elem0[i], which would stride by sizeof(std::optional<T>)).
-        auto const* sourceBytes = reinterpret_cast<std::byte const*>(elem0);
-        auto* const indicatorBytes = cb.ProvideBatchStagingBuffer(((rowCount - 1) * rowStride) + sizeof(SQLLEN));
-        for (auto const i: std::views::iota(std::size_t { 0 }, rowCount))
+        if constexpr (detail::SqlHasOptionalRowWiseBatchBinder<T>)
         {
-            // The optional and its indicator slot for row i both live at offset i*rowStride (row-wise).
-            auto const& optional = *reinterpret_cast<OptionalValue const*>(sourceBytes + (i * rowStride));
-            auto* const indicatorSlot = reinterpret_cast<SQLLEN*>(indicatorBytes + (i * rowStride));
-            *indicatorSlot = optional.has_value() ? SQLLEN { 0 } : SQLLEN { SQL_NULL_DATA };
+            // Length-bearing inline inner type (fixed-capacity string): its binder owns the
+            // NULL-or-length indicator fill and the zero-copy bind.
+            return SqlDataBinder<T>::BatchRowWiseInputParameterOptional(stmt, column, elem0, rowStride, rowCount, cb);
         }
+        else
+        {
+            // Offset of the contained value within std::optional<T> (0 on all known standard libraries,
+            // but computed robustly so the address arithmetic below does not bake in that assumption).
+            OptionalValue const probe { T {} };
+            auto const valueOffset = static_cast<std::size_t>(reinterpret_cast<std::byte const*>(std::addressof(*probe))
+                                                              - reinterpret_cast<std::byte const*>(std::addressof(probe)));
 
-        // Zero-copy value bind: point at row 0's contained value; T's batch binder issues the
-        // SQLBindParameter (taking only the address, never forming a T& to possibly-disengaged storage).
-        auto const* valueBase = reinterpret_cast<T const*>(reinterpret_cast<std::byte const*>(elem0) + valueOffset);
-        return SqlDataBinder<T>::BatchInputParameter(
-            stmt, column, valueBase, rowCount, cb, reinterpret_cast<SQLLEN*>(indicatorBytes));
+            // Row-strided indicator buffer: ODBC reads the indicator for row i at base + i*rowStride. The
+            // optionals themselves are embedded in the row structs, so they are also addressed at
+            // sourceBytes + i*rowStride (NOT elem0[i], which would stride by sizeof(std::optional<T>)).
+            auto const* sourceBytes = reinterpret_cast<std::byte const*>(elem0);
+            auto* const indicatorBytes = cb.ProvideBatchStagingBuffer(((rowCount - 1) * rowStride) + sizeof(SQLLEN));
+            for (auto const i: std::views::iota(std::size_t { 0 }, rowCount))
+            {
+                // The optional and its indicator slot for row i both live at offset i*rowStride (row-wise).
+                auto const& optional = *reinterpret_cast<OptionalValue const*>(sourceBytes + (i * rowStride));
+                auto* const indicatorSlot = reinterpret_cast<SQLLEN*>(indicatorBytes + (i * rowStride));
+                *indicatorSlot = optional.has_value() ? SQLLEN { 0 } : SQLLEN { SQL_NULL_DATA };
+            }
+
+            // Zero-copy value bind: point at row 0's contained value; T's batch binder issues the
+            // SQLBindParameter (taking only the address, never forming a T& to possibly-disengaged storage).
+            auto const* valueBase = reinterpret_cast<T const*>(reinterpret_cast<std::byte const*>(elem0) + valueOffset);
+            return SqlDataBinder<T>::BatchInputParameter(
+                stmt, column, valueBase, rowCount, cb, reinterpret_cast<SQLLEN*>(indicatorBytes));
+        }
     }
 
     static LIGHTWEIGHT_FORCE_INLINE SQLRETURN OutputColumn(

--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -22,7 +22,6 @@
 #include <concepts>
 #include <memory>
 #include <ranges>
-#include <span>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -577,14 +576,6 @@ class DataMapper
         Record const& record,
         std::optional<std::conditional_t<std::is_void_v<RecordPrimaryKeyType<Record>>, int, RecordPrimaryKeyType<Record>>>
             pkOverride = std::nullopt);
-
-    /// @brief Core implementation of CreateAll() operating on a contiguous span of records.
-    template <typename Record>
-    void CreateAllSpan(std::span<Record const> records);
-
-    /// @brief Core implementation of UpdateAll() operating on a contiguous span of records.
-    template <typename Record>
-    void UpdateAllSpan(std::span<Record const> records);
 
     SqlConnection _connection;
     SqlStatement _stmt;
@@ -1510,18 +1501,10 @@ void DataMapper::CreateAll(Records const& records)
     using Record = std::remove_cvref_t<std::ranges::range_value_t<Records>>;
     static_assert(DataMapperRecord<Record>, "Record must satisfy DataMapperRecord");
 
-    CreateAllSpan(std::span<Record const> { std::ranges::data(records), std::ranges::size(records) });
-}
-
-template <typename Record>
-void DataMapper::CreateAllSpan(std::span<Record const> records)
-{
-    static_assert(DataMapperRecord<Record>, "Record must satisfy DataMapperRecord");
-
     ZoneScopedN("DataMapper::CreateAll");
     ZoneTextObject(RecordTableName<Record>);
 
-    if (records.empty())
+    if (std::ranges::empty(records))
         return;
 
     // Build the INSERT once, with the same column set and order as CreateInternal().
@@ -1691,20 +1674,12 @@ void DataMapper::UpdateAll(Records const& records)
                   "std::span, or a C array); native row-wise array binding needs the records laid out contiguously.");
     using Record = std::remove_cvref_t<std::ranges::range_value_t<Records>>;
     static_assert(DataMapperRecord<Record>, "Record must satisfy DataMapperRecord");
-
-    UpdateAllSpan(std::span<Record const> { std::ranges::data(records), std::ranges::size(records) });
-}
-
-template <typename Record>
-void DataMapper::UpdateAllSpan(std::span<Record const> records)
-{
-    static_assert(DataMapperRecord<Record>, "Record must satisfy DataMapperRecord");
     static_assert(HasPrimaryKey<Record>, "UpdateAll requires a record type with a primary key");
 
     ZoneScopedN("DataMapper::UpdateAll");
     ZoneTextObject(RecordTableName<Record>);
 
-    if (records.empty())
+    if (std::ranges::empty(records))
         return;
 
     // Build one UPDATE that writes all storable non-primary-key columns, matched on the primary key(s).

--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -1439,6 +1439,21 @@ RecordPrimaryKeyType<Record> DataMapper::CreateExplicit(Record const& record)
 
 namespace detail
 {
+    /// @brief Whether member field type @p FieldType is an insertable column for a batched CREATE
+    /// (bindable and not an auto-increment primary key). Single source of truth shared by the INSERT
+    /// column-list builder and the value-accessor builder, so the bound `?` count and the accessor count
+    /// cannot drift apart.
+    template <typename FieldType>
+    constexpr bool IsBatchInsertColumn = SqlInputParameterBinder<FieldType> && !IsAutoIncrementPrimaryKey<FieldType>;
+
+    /// @brief Whether @p FieldType is a SET column for a batched UPDATE (storable, non-primary-key).
+    template <typename FieldType>
+    constexpr bool IsBatchUpdateSetColumn = FieldWithStorage<FieldType> && !IsPrimaryKey<FieldType>;
+
+    /// @brief Whether @p FieldType is a WHERE (key) column for a batched UPDATE (a primary key).
+    template <typename FieldType>
+    constexpr bool IsBatchUpdateWhereColumn = IsPrimaryKey<FieldType>;
+
     /// @brief Column accessor for batched DataMapper operations: maps a record to the value of its
     /// I-th member field, returning a reference so the native row-wise batch path binds it in place.
     template <std::size_t I>
@@ -1457,7 +1472,7 @@ namespace detail
     auto MakeCreateColumnAccessor()
     {
         using FieldType = Reflection::MemberTypeOf<I, Record>;
-        if constexpr (SqlInputParameterBinder<FieldType> && !IsAutoIncrementPrimaryKey<FieldType>)
+        if constexpr (IsBatchInsertColumn<FieldType>)
             return std::tuple<FieldValueAccessor<I>> {};
         else
             return std::tuple<> {};
@@ -1468,7 +1483,7 @@ namespace detail
     auto MakeUpdateSetAccessor()
     {
         using FieldType = Reflection::MemberTypeOf<I, Record>;
-        if constexpr (FieldWithStorage<FieldType> && !IsPrimaryKey<FieldType>)
+        if constexpr (IsBatchUpdateSetColumn<FieldType>)
             return std::tuple<FieldValueAccessor<I>> {};
         else
             return std::tuple<> {};
@@ -1479,7 +1494,7 @@ namespace detail
     auto MakeUpdateWhereAccessor()
     {
         using FieldType = Reflection::MemberTypeOf<I, Record>;
-        if constexpr (IsPrimaryKey<FieldType>)
+        if constexpr (IsBatchUpdateWhereColumn<FieldType>)
             return std::tuple<FieldValueAccessor<I>> {};
         else
             return std::tuple<> {};
@@ -1512,7 +1527,7 @@ void DataMapper::CreateAllSpan(std::span<Record const> records)
     // Build the INSERT once, with the same column set and order as CreateInternal().
     auto query = _connection.Query(RecordTableName<Record>).Insert(nullptr);
     Reflection::EnumerateMembers<Record>([&query]<auto I, typename FieldType>() {
-        if constexpr (SqlInputParameterBinder<FieldType> && !IsAutoIncrementPrimaryKey<FieldType>)
+        if constexpr (detail::IsBatchInsertColumn<FieldType>)
             query.Set(FieldNameAt<I, Record>, SqlWildcard);
     });
     _stmt.Prepare(query);
@@ -1695,11 +1710,11 @@ void DataMapper::UpdateAllSpan(std::span<Record const> records)
     // Build one UPDATE that writes all storable non-primary-key columns, matched on the primary key(s).
     auto query = _connection.Query(RecordTableName<Record>).Update();
     Reflection::EnumerateMembers<Record>([&query]<auto I, typename FieldType>() {
-        if constexpr (FieldWithStorage<FieldType> && !IsPrimaryKey<FieldType>)
+        if constexpr (detail::IsBatchUpdateSetColumn<FieldType>)
             query.Set(FieldNameAt<I, Record>, SqlWildcard);
     });
     Reflection::EnumerateMembers<Record>([&query]<auto I, typename FieldType>() {
-        if constexpr (IsPrimaryKey<FieldType>)
+        if constexpr (detail::IsBatchUpdateWhereColumn<FieldType>)
             std::ignore = query.Where(FieldNameAt<I, Record>, SqlWildcard);
     });
     _stmt.Prepare(query);

--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -21,9 +21,12 @@
 #include <cassert>
 #include <concepts>
 #include <memory>
+#include <ranges>
+#include <span>
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace Lightweight
 {
@@ -199,6 +202,28 @@ class DataMapper
     /// @return The primary key of the newly created record.
     template <typename Record>
     RecordPrimaryKeyType<Record> CreateExplicit(Record const& record);
+
+    /// @brief Batch-inserts a span of records with a single prepared statement.
+    ///
+    /// The INSERT is prepared once and the whole batch is submitted via
+    /// SqlStatement::ExecuteBatch(rows, accessors...), which uses native zero-copy row-wise array
+    /// binding when every inserted column is row-bindable (primitives, date/time/datetime, numeric, or
+    /// std::optional of a fixed non-numeric type) and the driver supports parameter arrays, otherwise a
+    /// prepare-once + per-row execute. This is dramatically faster than calling CreateExplicit() in a
+    /// loop (which re-prepares per row).
+    ///
+    /// @note Like CreateExplicit(), this does not write back primary keys, relations, or modified-state
+    /// onto the records; callers should treat the inserted records as write-only inputs. Auto-increment
+    /// primary keys are not retrieved.
+    ///
+    /// Accepts any contiguous, sized range of records (e.g. std::vector, std::array, std::span, or a C
+    /// array), so `dm.CreateAll(records)` works without an explicit std::span wrapper. Non-contiguous
+    /// ranges are rejected at compile time via static_assert (no implicit copy is made).
+    ///
+    /// @tparam Records A contiguous range whose element type is the record type to insert.
+    /// @param records The records to insert. An empty range is a no-op.
+    template <std::ranges::range Records>
+    void CreateAll(Records const& records);
 
     /// @brief Creates a copy of an existing record in the database.
     ///
@@ -407,6 +432,25 @@ class DataMapper
     template <typename Record>
     void Update(Record& record);
 
+    /// @brief Batch-updates a span of records with a single prepared statement.
+    ///
+    /// One UPDATE is prepared that writes **all** storable non-primary-key columns of the record,
+    /// matched on the primary key(s) (`UPDATE … SET <all non-PK columns> WHERE <pk> = ?`), and the whole
+    /// batch is submitted via SqlStatement::ExecuteBatch(rows, accessors...) — natively row-wise when
+    /// possible, otherwise prepare-once + per-row execute.
+    ///
+    /// @note Unlike Update(), which writes only the modified fields of a single record, this writes a
+    /// uniform set of columns for every row, because a single prepared statement must bind the same
+    /// columns for the whole batch. Per-row modified-state is therefore not consulted, and is not reset.
+    ///
+    /// Accepts any contiguous, sized range of records (see CreateAll), so `dm.UpdateAll(records)` works
+    /// without an explicit std::span wrapper. Non-contiguous ranges are rejected at compile time.
+    ///
+    /// @tparam Records A contiguous range whose element type is the record type to update (with a primary key).
+    /// @param records The records to update. An empty range is a no-op.
+    template <std::ranges::range Records>
+    void UpdateAll(Records const& records);
+
     /// Deletes the record from the database.
     ///
     /// The record is identified by its primary key(s). The row is removed from the backing table.
@@ -533,6 +577,14 @@ class DataMapper
         Record const& record,
         std::optional<std::conditional_t<std::is_void_v<RecordPrimaryKeyType<Record>>, int, RecordPrimaryKeyType<Record>>>
             pkOverride = std::nullopt);
+
+    /// @brief Core implementation of CreateAll() operating on a contiguous span of records.
+    template <typename Record>
+    void CreateAllSpan(std::span<Record const> records);
+
+    /// @brief Core implementation of UpdateAll() operating on a contiguous span of records.
+    template <typename Record>
+    void UpdateAllSpan(std::span<Record const> records);
 
     SqlConnection _connection;
     SqlStatement _stmt;
@@ -1385,6 +1437,93 @@ RecordPrimaryKeyType<Record> DataMapper::CreateExplicit(Record const& record)
     return CreateInternal<PrimaryKeySource::Record>(record);
 }
 
+namespace detail
+{
+    /// @brief Column accessor for batched DataMapper operations: maps a record to the value of its
+    /// I-th member field, returning a reference so the native row-wise batch path binds it in place.
+    template <std::size_t I>
+    struct FieldValueAccessor
+    {
+        template <typename Record>
+        decltype(auto) operator()(Record const& record) const
+        {
+            return Reflection::GetMemberAt<I>(record).Value();
+        }
+    };
+
+    /// Returns a one-element accessor tuple for member I when it is an insertable column (bindable and
+    /// not an auto-increment primary key), or an empty tuple otherwise — to be flattened via tuple_cat.
+    template <std::size_t I, typename Record>
+    auto MakeCreateColumnAccessor()
+    {
+        using FieldType = Reflection::MemberTypeOf<I, Record>;
+        if constexpr (SqlInputParameterBinder<FieldType> && !IsAutoIncrementPrimaryKey<FieldType>)
+            return std::tuple<FieldValueAccessor<I>> {};
+        else
+            return std::tuple<> {};
+    }
+
+    /// Accessor tuple for the SET clause of a batched UPDATE: storable, non-primary-key columns.
+    template <std::size_t I, typename Record>
+    auto MakeUpdateSetAccessor()
+    {
+        using FieldType = Reflection::MemberTypeOf<I, Record>;
+        if constexpr (FieldWithStorage<FieldType> && !IsPrimaryKey<FieldType>)
+            return std::tuple<FieldValueAccessor<I>> {};
+        else
+            return std::tuple<> {};
+    }
+
+    /// Accessor tuple for the WHERE clause of a batched UPDATE: primary-key columns.
+    template <std::size_t I, typename Record>
+    auto MakeUpdateWhereAccessor()
+    {
+        using FieldType = Reflection::MemberTypeOf<I, Record>;
+        if constexpr (IsPrimaryKey<FieldType>)
+            return std::tuple<FieldValueAccessor<I>> {};
+        else
+            return std::tuple<> {};
+    }
+} // namespace detail
+
+template <std::ranges::range Records>
+void DataMapper::CreateAll(Records const& records)
+{
+    static_assert(std::ranges::contiguous_range<Records> && std::ranges::sized_range<Records>,
+                  "CreateAll requires a contiguous, sized range of records (e.g. std::vector, std::array, "
+                  "std::span, or a C array); native row-wise array binding needs the records laid out contiguously.");
+    using Record = std::remove_cvref_t<std::ranges::range_value_t<Records>>;
+    static_assert(DataMapperRecord<Record>, "Record must satisfy DataMapperRecord");
+
+    CreateAllSpan(std::span<Record const> { std::ranges::data(records), std::ranges::size(records) });
+}
+
+template <typename Record>
+void DataMapper::CreateAllSpan(std::span<Record const> records)
+{
+    static_assert(DataMapperRecord<Record>, "Record must satisfy DataMapperRecord");
+
+    ZoneScopedN("DataMapper::CreateAll");
+    ZoneTextObject(RecordTableName<Record>);
+
+    if (records.empty())
+        return;
+
+    // Build the INSERT once, with the same column set and order as CreateInternal().
+    auto query = _connection.Query(RecordTableName<Record>).Insert(nullptr);
+    Reflection::EnumerateMembers<Record>([&query]<auto I, typename FieldType>() {
+        if constexpr (SqlInputParameterBinder<FieldType> && !IsAutoIncrementPrimaryKey<FieldType>)
+            query.Set(FieldNameAt<I, Record>, SqlWildcard);
+    });
+    _stmt.Prepare(query);
+
+    // Build one value accessor per bound column (same filter/order) and submit the whole batch.
+    [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+        std::apply([&](auto const&... accessors) { std::ignore = _stmt.ExecuteBatch(records, accessors...); },
+                   std::tuple_cat(detail::MakeCreateColumnAccessor<Is, Record>()...));
+    }(std::make_index_sequence<Reflection::CountMembers<Record>> {});
+}
+
 template <DataMapperOptions QueryOptions, typename Record>
 RecordPrimaryKeyType<Record> DataMapper::CreateCopyOf(Record const& originalRecord)
 {
@@ -1527,6 +1666,50 @@ void DataMapper::Update(Record& record)
     [[maybe_unused]] auto cursor = _stmt.Execute();
 
     SetModifiedState<ModifiedState::NotModified>(record);
+}
+
+template <std::ranges::range Records>
+void DataMapper::UpdateAll(Records const& records)
+{
+    static_assert(std::ranges::contiguous_range<Records> && std::ranges::sized_range<Records>,
+                  "UpdateAll requires a contiguous, sized range of records (e.g. std::vector, std::array, "
+                  "std::span, or a C array); native row-wise array binding needs the records laid out contiguously.");
+    using Record = std::remove_cvref_t<std::ranges::range_value_t<Records>>;
+    static_assert(DataMapperRecord<Record>, "Record must satisfy DataMapperRecord");
+
+    UpdateAllSpan(std::span<Record const> { std::ranges::data(records), std::ranges::size(records) });
+}
+
+template <typename Record>
+void DataMapper::UpdateAllSpan(std::span<Record const> records)
+{
+    static_assert(DataMapperRecord<Record>, "Record must satisfy DataMapperRecord");
+    static_assert(HasPrimaryKey<Record>, "UpdateAll requires a record type with a primary key");
+
+    ZoneScopedN("DataMapper::UpdateAll");
+    ZoneTextObject(RecordTableName<Record>);
+
+    if (records.empty())
+        return;
+
+    // Build one UPDATE that writes all storable non-primary-key columns, matched on the primary key(s).
+    auto query = _connection.Query(RecordTableName<Record>).Update();
+    Reflection::EnumerateMembers<Record>([&query]<auto I, typename FieldType>() {
+        if constexpr (FieldWithStorage<FieldType> && !IsPrimaryKey<FieldType>)
+            query.Set(FieldNameAt<I, Record>, SqlWildcard);
+    });
+    Reflection::EnumerateMembers<Record>([&query]<auto I, typename FieldType>() {
+        if constexpr (IsPrimaryKey<FieldType>)
+            std::ignore = query.Where(FieldNameAt<I, Record>, SqlWildcard);
+    });
+    _stmt.Prepare(query);
+
+    // Accessor order must match the SQL parameter order: SET columns first, then the WHERE key(s).
+    [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+        std::apply([&](auto const&... accessors) { std::ignore = _stmt.ExecuteBatch(records, accessors...); },
+                   std::tuple_cat(detail::MakeUpdateSetAccessor<Is, Record>()...,
+                                  detail::MakeUpdateWhereAccessor<Is, Record>()...));
+    }(std::make_index_sequence<Reflection::CountMembers<Record>> {});
 }
 
 template <typename Record>

--- a/src/Lightweight/SqlConnection.hpp
+++ b/src/Lightweight/SqlConnection.hpp
@@ -137,6 +137,18 @@ class SqlConnection final
     /// Retrieves a query formatter suitable for the SQL server being connected.
     [[nodiscard]] SqlQueryFormatter const& QueryFormatter() const noexcept;
 
+    /// @brief Whether this connection's ODBC driver supports native parameter-array binding
+    /// (`SQL_ATTR_PARAMSET_SIZE` > 1) for batched row-wise execution.
+    ///
+    /// The batched `SqlStatement::ExecuteBatch(rows, accessors...)` consults this to decide whether it
+    /// may submit the whole batch in a single row-wise `SQLExecute`, or must fall back to a single
+    /// prepare followed by consecutive per-row executes. This is a driver/backend capability — not a
+    /// SQL-dialect concern — so it belongs to the connection, which knows both the server type and the
+    /// driver name (either of which a future carve-out can branch on).
+    ///
+    /// @return `true` if the driver honours parameter arrays.
+    [[nodiscard]] bool SupportsNativeRowBatch() const noexcept;
+
     /// Creates a new query builder for the given table, compatible with the current connection.
     ///
     /// @param table The table to query.
@@ -215,6 +227,24 @@ inline std::string const& SqlConnection::DriverName() const noexcept
 inline SqlQueryFormatter const& SqlConnection::QueryFormatter() const noexcept
 {
     return *m_queryFormatter;
+}
+
+inline bool SqlConnection::SupportsNativeRowBatch() const noexcept
+{
+    // Native ODBC parameter-array binding (SQL_ATTR_PARAMSET_SIZE > 1) is a per-driver capability.
+    // Every backend Lightweight supports and tests against honours it; an unverified backend takes the
+    // always-correct per-row path rather than risk a driver that silently ignores the parameter array.
+    switch (ServerType())
+    {
+        case SqlServerType::MICROSOFT_SQL:
+        case SqlServerType::POSTGRESQL:
+        case SqlServerType::SQLITE:
+            return true;
+        case SqlServerType::MYSQL:
+        case SqlServerType::UNKNOWN:
+            return false;
+    }
+    return false;
 }
 
 } // namespace Lightweight

--- a/src/Lightweight/SqlQueryFormatter.hpp
+++ b/src/Lightweight/SqlQueryFormatter.hpp
@@ -189,18 +189,6 @@ class [[nodiscard]] LIGHTWEIGHT_API SqlQueryFormatter
         return false;
     }
 
-    /// @brief Whether the backend's ODBC driver supports native parameter-array binding
-    /// (`SQL_ATTR_PARAMSET_SIZE` > 1) for batched row-wise execution.
-    ///
-    /// Defaults to `true`; the batched `SqlStatement::ExecuteBatch(rows, accessors...)` consults this
-    /// to decide whether it may submit the whole batch in a single row-wise `SQLExecute`, or must fall
-    /// back to a single prepare followed by consecutive per-row executes. Override and return `false`
-    /// for a dialect whose driver cannot honour parameter arrays.
-    [[nodiscard]] virtual bool SupportsNativeRowBatch() const noexcept
-    {
-        return true;
-    }
-
     /// @brief Builds the canonical foreign-key constraint name for a set of columns.
     ///
     /// Produces `FK_<table>_<col1>[_<col2>…]`. A single-column FK collapses to

--- a/src/Lightweight/SqlQueryFormatter.hpp
+++ b/src/Lightweight/SqlQueryFormatter.hpp
@@ -189,6 +189,18 @@ class [[nodiscard]] LIGHTWEIGHT_API SqlQueryFormatter
         return false;
     }
 
+    /// @brief Whether the backend's ODBC driver supports native parameter-array binding
+    /// (`SQL_ATTR_PARAMSET_SIZE` > 1) for batched row-wise execution.
+    ///
+    /// Defaults to `true`; the batched `SqlStatement::ExecuteBatch(rows, accessors...)` consults this
+    /// to decide whether it may submit the whole batch in a single row-wise `SQLExecute`, or must fall
+    /// back to a single prepare followed by consecutive per-row executes. Override and return `false`
+    /// for a dialect whose driver cannot honour parameter arrays.
+    [[nodiscard]] virtual bool SupportsNativeRowBatch() const noexcept
+    {
+        return true;
+    }
+
     /// @brief Builds the canonical foreign-key constraint name for a set of columns.
     ///
     /// Produces `FK_<table>_<col1>[_<col2>…]`. A single-column FK collapses to

--- a/src/Lightweight/SqlStatement.cpp
+++ b/src/Lightweight/SqlStatement.cpp
@@ -7,6 +7,7 @@
 #include "TracyProfiler.hpp"
 #include "Utils.hpp"
 
+#include <cstddef>
 #include <deque>
 #include <vector>
 
@@ -19,6 +20,8 @@ struct SqlStatement::Data
     std::vector<SQLLEN> indicators;                  // Holds the indicators for the bound output columns
     std::deque<SQLLEN> inputIndicators;              // Holds the indicators for the bound input parameters
     std::deque<std::vector<SQLLEN>> batchIndicators; // Holds the indicators for the bound batch input parameters
+    std::deque<std::vector<std::byte>>
+        batchStagingBuffers; // Holds temporary scratch buffers for batch input parameter binders
     std::vector<std::function<void()>> postExecuteCallbacks;
     std::vector<std::function<void()>> postProcessOutputColumnCallbacks;
 
@@ -56,10 +59,19 @@ SQLLEN* SqlStatement::ProvideInputIndicators(size_t rowCount)
     return m_data->batchIndicators.back().data();
 }
 
+std::byte* SqlStatement::ProvideBatchStagingBuffer(std::size_t byteCount)
+{
+    // std::vector<std::byte> allocates via operator new, which yields max_align_t-aligned storage.
+    m_data->batchStagingBuffers.emplace_back(byteCount);
+    return m_data->batchStagingBuffers.back().data();
+}
+
 void SqlStatement::ClearBatchIndicators()
 {
     m_data->batchIndicators.clear();
     m_data->batchIndicators.shrink_to_fit();
+    m_data->batchStagingBuffers.clear();
+    m_data->batchStagingBuffers.shrink_to_fit();
 }
 
 void SqlStatement::PlanPostExecuteCallback(std::function<void()>&& cb)
@@ -95,6 +107,7 @@ SqlStatement::SqlStatement():
                  .indicators = {},
                  .inputIndicators = {},
                  .batchIndicators = {},
+                 .batchStagingBuffers = {},
                  .postExecuteCallbacks = {},
                  .postProcessOutputColumnCallbacks = {},
              },
@@ -153,7 +166,8 @@ SqlStatement::SqlStatement(SqlConnection& relatedConnection):
 }
 
 SqlStatement::SqlStatement(std::nullopt_t /*nullopt*/):
-    m_data { const_cast<Data*>(&Data::NoData), [](Data* /*data*/) {} }
+    m_data { const_cast<Data*>(&Data::NoData), [](Data* /*data*/) {
+            } }
 {
 }
 
@@ -183,6 +197,18 @@ void SqlStatement::Prepare(std::string_view query) &
     m_data->postProcessOutputColumnCallbacks.clear();
     m_data->inputIndicators.clear();
     m_data->batchIndicators.clear();
+    m_data->batchStagingBuffers.clear();
+
+    // Reset parameter-array binding attributes that a preceding batch execution may have left on the
+    // handle. SqlStatement handles are reused (e.g. by DataMapper) across single and batched executes;
+    // without this reset a subsequent single Execute() would inherit a stale PARAMSET_SIZE and a
+    // dangling row-wise PARAM_BIND_OFFSET_PTR/PARAM_BIND_TYPE.
+    // clang-format off
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER) 1, 0));
+    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAM_BIND_TYPE, SQL_PARAM_BIND_BY_COLUMN, 0));
+    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, nullptr, 0));
+    // clang-format on
 
     // Unbinds the columns, if any
     RequireSuccess(SQLFreeStmt(m_hStmt, SQL_UNBIND));

--- a/src/Lightweight/SqlStatement.cpp
+++ b/src/Lightweight/SqlStatement.cpp
@@ -166,8 +166,7 @@ SqlStatement::SqlStatement(SqlConnection& relatedConnection):
 }
 
 SqlStatement::SqlStatement(std::nullopt_t /*nullopt*/):
-    m_data { const_cast<Data*>(&Data::NoData), [](Data* /*data*/) {
-            } }
+    m_data { const_cast<Data*>(&Data::NoData), [](Data* /*data*/) {} }
 {
 }
 

--- a/src/Lightweight/SqlStatement.cpp
+++ b/src/Lightweight/SqlStatement.cpp
@@ -9,6 +9,7 @@
 
 #include <cstddef>
 #include <deque>
+#include <format>
 #include <vector>
 
 namespace Lightweight
@@ -72,6 +73,52 @@ void SqlStatement::ClearBatchIndicators()
     m_data->batchIndicators.shrink_to_fit();
     m_data->batchStagingBuffers.clear();
     m_data->batchStagingBuffers.shrink_to_fit();
+}
+
+void SqlStatement::ResetParameterArrayBinding() noexcept
+{
+    // Restore single-row, column-bound parameter binding (the ODBC default). Invoked from Prepare() and,
+    // via a scope guard, after a native row-wise batch — including the exception path, which is why this
+    // is noexcept and ignores the return codes (resetting to defaults on a live handle does not
+    // meaningfully fail, and a cleanup running during stack unwinding must never throw).
+    // clang-format off
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER) 1, 0);
+    SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAM_BIND_TYPE, SQL_PARAM_BIND_BY_COLUMN, 0);
+    SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, nullptr, 0);
+    SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAMS_PROCESSED_PTR, nullptr, 0);
+    // clang-format on
+}
+
+void SqlStatement::RequireExecuteSucceededOrNoData(SQLRETURN result, std::source_location sourceLocation) const
+{
+    // A searched UPDATE/DELETE that matched no rows returns SQL_NO_DATA (per the ODBC spec): the
+    // statement executed, it simply changed nothing. Treat it as success, matching Execute().
+    if (result != SQL_NO_DATA && result != SQL_SUCCESS && result != SQL_SUCCESS_WITH_INFO)
+        throw SqlException(SqlErrorInfo::FromStatementHandle(m_hStmt), sourceLocation);
+}
+
+void SqlStatement::RequireSuccessfulBatchExecute(SQLRETURN result,
+                                                 SQLULEN processedCount,
+                                                 SQLULEN expectedCount,
+                                                 std::source_location sourceLocation) const
+{
+    RequireExecuteSucceededOrNoData(result, sourceLocation);
+
+    // Guard against a driver that silently honours fewer parameter sets than requested. The caller
+    // initialises processedCount to expectedCount, so a driver that ignores SQL_ATTR_PARAMS_PROCESSED_PTR
+    // never trips this; only one that reports a short count does.
+    if (SQL_SUCCEEDED(result) && processedCount != expectedCount)
+        throw SqlException(
+            SqlErrorInfo {
+                .nativeErrorCode = 0,
+                .sqlState = "HY000",
+                .message = std::format("Native row-wise batch processed {} of {} parameter sets; the ODBC "
+                                       "driver did not honour the full parameter array.",
+                                       processedCount,
+                                       expectedCount),
+            },
+            sourceLocation);
 }
 
 void SqlStatement::PlanPostExecuteCallback(std::function<void()>&& cb)
@@ -202,12 +249,7 @@ void SqlStatement::Prepare(std::string_view query) &
     // handle. SqlStatement handles are reused (e.g. by DataMapper) across single and batched executes;
     // without this reset a subsequent single Execute() would inherit a stale PARAMSET_SIZE and a
     // dangling row-wise PARAM_BIND_OFFSET_PTR/PARAM_BIND_TYPE.
-    // clang-format off
-    // NOLINTNEXTLINE(performance-no-int-to-ptr)
-    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER) 1, 0));
-    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAM_BIND_TYPE, SQL_PARAM_BIND_BY_COLUMN, 0));
-    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, nullptr, 0));
-    // clang-format on
+    ResetParameterArrayBinding();
 
     // Unbinds the columns, if any
     RequireSuccess(SQLFreeStmt(m_hStmt, SQL_UNBIND));

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -188,7 +188,7 @@ class [[nodiscard]] SqlStatement final: public SqlDataBinderCallback
     /// The native row-wise path is taken when every column value type is row-bindable
     /// (@c SqlNativeRowBindableValue, or @c std::optional of such a non-numeric type), every accessor
     /// returns an lvalue reference, the row stride satisfies the indicator-alignment requirement, and the
-    /// driver advertises parameter-array support (@ref SqlQueryFormatter::SupportsNativeRowBatch). A
+    /// driver advertises parameter-array support (@ref SqlConnection::SupportsNativeRowBatch). A
     /// per-row runtime stride check guards against accessors that are not constant-offset subobjects.
     /// Otherwise the soft path is used, which correctly binds every supported type (strings, binary,
     /// variant, @c std::optional of any type, …) one row at a time.
@@ -308,6 +308,20 @@ class [[nodiscard]] SqlStatement final: public SqlDataBinderCallback
     LIGHTWEIGHT_API SQLLEN* ProvideInputIndicators(size_t rowCount) override;
     LIGHTWEIGHT_API std::byte* ProvideBatchStagingBuffer(std::size_t byteCount) override;
     LIGHTWEIGHT_API void ClearBatchIndicators();
+    /// Restores single-row, column-bound parameter binding (the ODBC default). @c noexcept so it can run
+    /// from a scope guard on the native-batch exception path.
+    LIGHTWEIGHT_API void ResetParameterArrayBinding() noexcept;
+    /// Throws unless @p result is a success code or @c SQL_NO_DATA (a searched UPDATE/DELETE that matched
+    /// no rows). Mirrors @c Execute() so the batch execute paths tolerate zero-row updates.
+    LIGHTWEIGHT_API void RequireExecuteSucceededOrNoData(
+        SQLRETURN result, std::source_location sourceLocation = std::source_location::current()) const;
+    /// Native-batch execute check: tolerates @c SQL_NO_DATA and, on success, verifies the driver
+    /// processed all @p expectedCount parameter sets (guards against silent partial array execution).
+    LIGHTWEIGHT_API void RequireSuccessfulBatchExecute(
+        SQLRETURN result,
+        SQLULEN processedCount,
+        SQLULEN expectedCount,
+        std::source_location sourceLocation = std::source_location::current()) const;
     LIGHTWEIGHT_API void RequireIndicators();
     LIGHTWEIGHT_API SQLLEN* GetIndicatorForColumn(SQLUSMALLINT column) noexcept;
 
@@ -959,7 +973,7 @@ SqlResultCursor SqlStatement::ExecuteBatch(Rows const& rows, ColumnAccessors con
         };
         bool const rowStrideOk = rowCount < 2 || (accessorStrideMatchesRow(accessors) && ...);
 
-        if (m_connection->QueryFormatter().SupportsNativeRowBatch() && rowStrideOk)
+        if (m_connection->SupportsNativeRowBatch() && rowStrideOk)
             return ExecuteBatchNativeRowWise(rows, accessors...);
     }
 
@@ -977,6 +991,19 @@ SqlResultCursor SqlStatement::ExecuteBatchNativeRowWise(Rows const& rows, Column
     ZoneValue(rowCount);
     auto const* rowData = std::ranges::data(rows);
 
+    // Optimistic init: a driver that ignores SQL_ATTR_PARAMS_PROCESSED_PTR leaves this == rowCount, so the
+    // post-execute completeness check never false-trips on such a driver.
+    SQLULEN processedCount = rowCount;
+
+    // Restore single-row binding and release scratch buffers on EVERY exit — success or exception — so a
+    // throwing bind/execute can never leave the handle in a stale multi-paramset/row-wise state for a
+    // later reuse (e.g. a single Execute() without re-Prepare). Installed before the attributes are set,
+    // so a failure mid-setup is unwound too.
+    auto const restoreParameterBinding = detail::Finally([this] {
+        ResetParameterArrayBinding();
+        ClearBatchIndicators();
+    });
+
     // Row-wise array binding: the driver strides every bound value and indicator pointer by sizeof(RowElem).
     // clang-format off
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
@@ -985,8 +1012,8 @@ SqlResultCursor SqlStatement::ExecuteBatchNativeRowWise(Rows const& rows, Column
     RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAM_BIND_TYPE, (SQLPOINTER) sizeof(RowElem), 0));
     RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, nullptr, 0));
     RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAM_OPERATION_PTR, SQL_PARAM_PROCEED, 0));
+    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &processedCount, 0));
     // clang-format on
-    ClearBatchIndicators();
 
     SQLUSMALLINT column = 0;
     auto const bindColumn = [&](auto const& accessor) {
@@ -1003,17 +1030,11 @@ SqlResultCursor SqlStatement::ExecuteBatchNativeRowWise(Rows const& rows, Column
     (bindColumn(accessors), ...);
 
     SqlLogger::GetLogger().OnExecuteBatch();
-    RequireSuccess(SQLExecute(m_hStmt));
+    // Capture the result before reading processedCount: SQLExecute updates it via the bound pointer, and
+    // function-argument evaluation order is unspecified.
+    auto const executeResult = SQLExecute(m_hStmt);
+    RequireSuccessfulBatchExecute(executeResult, processedCount, static_cast<SQLULEN>(rowCount));
     ProcessPostExecuteCallbacks();
-
-    // Restore single-row binding so a subsequent reuse of this handle (without re-Prepare) is unaffected.
-    // clang-format off
-    // NOLINTNEXTLINE(performance-no-int-to-ptr)
-    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER) 1, 0));
-    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAM_BIND_TYPE, SQL_PARAM_BIND_BY_COLUMN, 0));
-    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, nullptr, 0));
-    // clang-format on
-    ClearBatchIndicators();
 
     return SqlResultCursor { *this };
 }
@@ -1037,7 +1058,7 @@ SqlResultCursor SqlStatement::ExecuteBatchSoftRowMajor(Rows const& rows, ColumnA
               m_hStmt, column, accessors(row), *this))),
          ...);
         SqlLogger::GetLogger().OnExecute(m_preparedQuery);
-        RequireSuccess(SQLExecute(m_hStmt));
+        RequireExecuteSucceededOrNoData(SQLExecute(m_hStmt));
         ProcessPostExecuteCallbacks();
     }
 

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -820,6 +820,18 @@ concept SqlOptionalRowBindable =
 template <typename V>
 concept SqlRowBindableColumn = SqlNativeRowBindableValue<V> || SqlOptionalRowBindable<V>;
 
+/// @brief Whether @p V's binder provides a row-wise batch entry point (@c BatchRowWiseInputParameter).
+///
+/// Such types (e.g. @c std::optional of a fixed type, or inline fixed-capacity strings) need a
+/// temporary row-strided NULL/length indicator buffer, which in turn requires the row stride to keep
+/// @c SQLLEN indicator slots aligned. Plain indicator-free fixed values bind via @c InputParameter and
+/// do not satisfy this concept.
+template <typename V>
+concept SqlHasRowWiseBatchBinder =
+    requires(SQLHSTMT stmt, SQLUSMALLINT column, V const* elem0, std::size_t n, SqlDataBinderCallback& cb) {
+        { SqlDataBinder<V>::BatchRowWiseInputParameter(stmt, column, elem0, n, n, cb) } -> std::same_as<SQLRETURN>;
+    };
+
 template <SqlInputParameterBatchBinder FirstColumnBatch, std::ranges::contiguous_range... MoreColumnBatches>
 SqlResultCursor SqlStatement::ExecuteBatchNative(FirstColumnBatch const& firstColumnBatch,
                                                  MoreColumnBatches const&... moreColumnBatches)
@@ -923,18 +935,18 @@ SqlResultCursor SqlStatement::ExecuteBatch(Rows const& rows, ColumnAccessors con
 
     // Compile-time eligibility for the native row-wise path: every column must be row-bindable, every
     // accessor must return an lvalue reference (so the bound address is a stable subobject), and — when
-    // any column is an optional needing a row-strided indicator — the row stride must keep SQLLEN
-    // indicator slots aligned and non-overlapping.
+    // any column needs a row-strided indicator (optionals, inline fixed-capacity strings) — the row
+    // stride must keep SQLLEN indicator slots aligned and non-overlapping.
     constexpr bool allColumnsRowBindable =
         (SqlRowBindableColumn<std::remove_cvref_t<std::invoke_result_t<ColumnAccessors const&, RowElem const&>>> && ...);
     constexpr bool allAccessorsReturnReference =
         (std::is_reference_v<std::invoke_result_t<ColumnAccessors const&, RowElem const&>> && ...);
-    constexpr bool anyOptionalColumn =
-        (SqlOptionalRowBindable<std::remove_cvref_t<std::invoke_result_t<ColumnAccessors const&, RowElem const&>>> || ...);
+    constexpr bool anyStridedIndicatorColumn =
+        (SqlHasRowWiseBatchBinder<std::remove_cvref_t<std::invoke_result_t<ColumnAccessors const&, RowElem const&>>> || ...);
     constexpr bool indicatorAlignmentSatisfied = (sizeof(RowElem) % alignof(SQLLEN)) == 0;
 
     if constexpr (allColumnsRowBindable && allAccessorsReturnReference
-                  && (!anyOptionalColumn || indicatorAlignmentSatisfied))
+                  && (!anyStridedIndicatorColumn || indicatorAlignmentSatisfied))
     {
         auto const* rowData = std::ranges::data(rows);
 
@@ -980,7 +992,9 @@ SqlResultCursor SqlStatement::ExecuteBatchNativeRowWise(Rows const& rows, Column
     auto const bindColumn = [&](auto const& accessor) {
         ++column;
         using ValueType = std::remove_cvref_t<decltype(accessor(rowData[0]))>;
-        if constexpr (SqlIsStdOptional<ValueType>)
+        // Types needing a per-row indicator (optionals, inline fixed-capacity strings) provide a
+        // row-wise batch binder; indicator-free fixed values bind directly via InputParameter.
+        if constexpr (SqlHasRowWiseBatchBinder<ValueType>)
             RequireSuccess(SqlDataBinder<ValueType>::BatchRowWiseInputParameter(
                 m_hStmt, column, std::addressof(accessor(rowData[0])), sizeof(RowElem), rowCount, *this));
         else
@@ -988,6 +1002,7 @@ SqlResultCursor SqlStatement::ExecuteBatchNativeRowWise(Rows const& rows, Column
     };
     (bindColumn(accessors), ...);
 
+    SqlLogger::GetLogger().OnExecuteBatch();
     RequireSuccess(SQLExecute(m_hStmt));
     ProcessPostExecuteCallbacks();
 
@@ -1021,6 +1036,7 @@ SqlResultCursor SqlStatement::ExecuteBatchSoftRowMajor(Rows const& rows, ColumnA
           RequireSuccess(SqlDataBinder<std::remove_cvref_t<decltype(accessors(row))>>::InputParameter(
               m_hStmt, column, accessors(row), *this))),
          ...);
+        SqlLogger::GetLogger().OnExecute(m_preparedQuery);
         RequireSuccess(SQLExecute(m_hStmt));
         ProcessPostExecuteCallbacks();
     }

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -7,8 +7,10 @@
 #endif
 
 #include "Api.hpp"
+#include "DataBinder/Core.hpp"
 #include "SqlConnection.hpp"
 #include "SqlQuery.hpp"
+#include "SqlQueryFormatter.hpp"
 #include "SqlServerType.hpp"
 #include "TracyProfiler.hpp"
 #include "Utils.hpp"
@@ -172,6 +174,33 @@ class [[nodiscard]] SqlStatement final: public SqlDataBinderCallback
     /// @param rowCount The number of rows to execute.
     [[nodiscard]] LIGHTWEIGHT_API SqlResultCursor ExecuteBatch(std::span<SqlRawColumn const> columns, size_t rowCount);
 
+    /// Executes the prepared statement once per row of a *row-major* batch, preferring native ODBC
+    /// row-wise array binding (a single zero-copy @c SQLExecute) and transparently falling back to a
+    /// prepare-once + per-row execute when native binding is not possible.
+    ///
+    /// Unlike the column-major @c ExecuteBatch overloads, the data here is laid out as an array of row
+    /// structs (e.g. records). Each @p accessors invocable maps a row to one bound column's value,
+    /// returning a reference into the row (so the native path binds the value in place):
+    /// @code
+    /// stmt.ExecuteBatch(std::span { records }, [](Record const& r) -> auto const& { return r.id.Value(); }, ...);
+    /// @endcode
+    ///
+    /// The native row-wise path is taken when every column value type is row-bindable
+    /// (@ref SqlNativeRowBindableValue, or @c std::optional of such a non-numeric type), every accessor
+    /// returns an lvalue reference, the row stride satisfies the indicator-alignment requirement, and the
+    /// driver advertises parameter-array support (@ref SqlQueryFormatter::SupportsNativeRowBatch). A
+    /// per-row runtime stride check guards against accessors that are not constant-offset subobjects.
+    /// Otherwise the soft path is used, which correctly binds every supported type (strings, binary,
+    /// variant, @c std::optional of any type, …) one row at a time.
+    ///
+    /// @param rows Contiguous range of row structs (e.g. @c std::span<Record const>).
+    /// @param accessors One invocable per bound column; @c accessor(row) yields that column's value.
+    /// @return A result cursor for the executed batch (empty when @p rows is empty).
+    template <std::ranges::contiguous_range Rows, typename... ColumnAccessors>
+        requires(sizeof...(ColumnAccessors) >= 1
+                 && (std::invocable<ColumnAccessors const&, std::ranges::range_value_t<Rows> const&> && ...))
+    [[nodiscard]] SqlResultCursor ExecuteBatch(Rows const& rows, ColumnAccessors const&... accessors);
+
     /// Executes the given query directly.
     [[nodiscard]] LIGHTWEIGHT_API SqlResultCursor
     ExecuteDirect(std::string_view const& query, std::source_location location = std::source_location::current());
@@ -251,6 +280,16 @@ class [[nodiscard]] SqlStatement final: public SqlDataBinderCallback
     template <SqlGetColumnNativeType T>
     [[nodiscard]] T GetColumn(SQLUSMALLINT column) const;
 
+    /// @brief Native row-wise batch execution: binds each column in place over @p rows and submits the
+    /// whole batch in a single @c SQLExecute. Precondition: every column is row-bindable.
+    template <std::ranges::contiguous_range Rows, typename... ColumnAccessors>
+    [[nodiscard]] SqlResultCursor ExecuteBatchNativeRowWise(Rows const& rows, ColumnAccessors const&... accessors);
+
+    /// @brief Soft row-major batch execution: binds and executes each row individually. Works for every
+    /// supported column type and is the fallback when native row-wise binding does not apply.
+    template <std::ranges::contiguous_range Rows, typename... ColumnAccessors>
+    [[nodiscard]] SqlResultCursor ExecuteBatchSoftRowMajor(Rows const& rows, ColumnAccessors const&... accessors);
+
     template <SqlGetColumnNativeType T>
     [[nodiscard]] std::optional<T> GetNullableColumn(SQLUSMALLINT column) const;
 
@@ -267,6 +306,7 @@ class [[nodiscard]] SqlStatement final: public SqlDataBinderCallback
 
     LIGHTWEIGHT_API SQLLEN* ProvideInputIndicator() override;
     LIGHTWEIGHT_API SQLLEN* ProvideInputIndicators(size_t rowCount) override;
+    LIGHTWEIGHT_API std::byte* ProvideBatchStagingBuffer(std::size_t byteCount) override;
     LIGHTWEIGHT_API void ClearBatchIndicators();
     LIGHTWEIGHT_API void RequireIndicators();
     LIGHTWEIGHT_API SQLLEN* GetIndicatorForColumn(SQLUSMALLINT column) noexcept;
@@ -762,6 +802,24 @@ concept SqlNativeBatchable =
 
 // clang-format on
 
+/// @brief A value type that can be bound in a native ODBC row-wise parameter array (fixed-width,
+/// inline, indicator-free, bound identically across backends). Backed by the data-driven
+/// @ref SqlIsNativeRowBindableValue trait that each eligible binder header opts into.
+template <typename V>
+concept SqlNativeRowBindableValue = SqlIsNativeRowBindableValue<V>;
+
+/// @brief A @c std::optional column that can be bound zero-copy in a native row-wise batch: the
+/// contained type is row-bindable and non-numeric (numeric optionals are not bound at a uniform
+/// offset/representation across backends and therefore use the soft path).
+template <typename V>
+concept SqlOptionalRowBindable =
+    SqlIsStdOptional<V> && SqlNativeRowBindableValue<SqlOptionalInnerType<V>> && !SqlIsNumericValue<SqlOptionalInnerType<V>>;
+
+/// @brief A column value type usable on the native row-wise batch path — either a row-bindable fixed
+/// value or a row-bindable optional of one.
+template <typename V>
+concept SqlRowBindableColumn = SqlNativeRowBindableValue<V> || SqlOptionalRowBindable<V>;
+
 template <SqlInputParameterBatchBinder FirstColumnBatch, std::ranges::contiguous_range... MoreColumnBatches>
 SqlResultCursor SqlStatement::ExecuteBatchNative(FirstColumnBatch const& firstColumnBatch,
                                                  MoreColumnBatches const&... moreColumnBatches)
@@ -843,6 +901,130 @@ SqlResultCursor SqlStatement::ExecuteBatchSoft(FirstColumnBatch const& firstColu
                 std::ref(
                     *std::ranges::next(std::ranges::begin(moreColumnBatches), static_cast<std::ptrdiff_t>(rowIndex)))...));
     }
+    return SqlResultCursor { *this };
+}
+
+template <std::ranges::contiguous_range Rows, typename... ColumnAccessors>
+    requires(sizeof...(ColumnAccessors) >= 1
+             && (std::invocable<ColumnAccessors const&, std::ranges::range_value_t<Rows> const&> && ...))
+SqlResultCursor SqlStatement::ExecuteBatch(Rows const& rows, ColumnAccessors const&... accessors)
+{
+    ZoneScopedN("SqlStatement::ExecuteBatch(row-major)");
+    ZoneTextObject(m_preparedQuery);
+
+    using RowElem = std::ranges::range_value_t<Rows>;
+
+    auto const rowCount = std::ranges::size(rows);
+    if (rowCount == 0)
+        return SqlResultCursor { *this };
+
+    if (m_expectedParameterCount != static_cast<SQLSMALLINT>(sizeof...(accessors)))
+        throw std::invalid_argument { "Invalid number of columns" };
+
+    // Compile-time eligibility for the native row-wise path: every column must be row-bindable, every
+    // accessor must return an lvalue reference (so the bound address is a stable subobject), and — when
+    // any column is an optional needing a row-strided indicator — the row stride must keep SQLLEN
+    // indicator slots aligned and non-overlapping.
+    constexpr bool allColumnsRowBindable =
+        (SqlRowBindableColumn<std::remove_cvref_t<std::invoke_result_t<ColumnAccessors const&, RowElem const&>>> && ...);
+    constexpr bool allAccessorsReturnReference =
+        (std::is_reference_v<std::invoke_result_t<ColumnAccessors const&, RowElem const&>> && ...);
+    constexpr bool anyOptionalColumn =
+        (SqlOptionalRowBindable<std::remove_cvref_t<std::invoke_result_t<ColumnAccessors const&, RowElem const&>>> || ...);
+    constexpr bool indicatorAlignmentSatisfied = (sizeof(RowElem) % alignof(SQLLEN)) == 0;
+
+    if constexpr (allColumnsRowBindable && allAccessorsReturnReference
+                  && (!anyOptionalColumn || indicatorAlignmentSatisfied))
+    {
+        auto const* rowData = std::ranges::data(rows);
+
+        // Runtime guard: confirm each accessor yields a constant-offset subobject (stride == sizeof row),
+        // so binding row 0's address and striding by sizeof(RowElem) addresses every row correctly.
+        auto const accessorStrideMatchesRow = [&](auto const& accessor) noexcept -> bool {
+            auto const* first = reinterpret_cast<std::byte const*>(std::addressof(accessor(rowData[0])));
+            auto const* second = reinterpret_cast<std::byte const*>(std::addressof(accessor(rowData[1])));
+            return static_cast<std::size_t>(second - first) == sizeof(RowElem);
+        };
+        bool const rowStrideOk = rowCount < 2 || (accessorStrideMatchesRow(accessors) && ...);
+
+        if (m_connection->QueryFormatter().SupportsNativeRowBatch() && rowStrideOk)
+            return ExecuteBatchNativeRowWise(rows, accessors...);
+    }
+
+    return ExecuteBatchSoftRowMajor(rows, accessors...);
+}
+
+template <std::ranges::contiguous_range Rows, typename... ColumnAccessors>
+SqlResultCursor SqlStatement::ExecuteBatchNativeRowWise(Rows const& rows, ColumnAccessors const&... accessors)
+{
+    ZoneScopedN("SqlStatement::ExecuteBatchNativeRowWise");
+    ZoneTextObject(m_preparedQuery);
+
+    using RowElem = std::ranges::range_value_t<Rows>;
+    auto const rowCount = std::ranges::size(rows);
+    ZoneValue(rowCount);
+    auto const* rowData = std::ranges::data(rows);
+
+    // Row-wise array binding: the driver strides every bound value and indicator pointer by sizeof(RowElem).
+    // clang-format off
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER) rowCount, 0));
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAM_BIND_TYPE, (SQLPOINTER) sizeof(RowElem), 0));
+    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, nullptr, 0));
+    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAM_OPERATION_PTR, SQL_PARAM_PROCEED, 0));
+    // clang-format on
+    ClearBatchIndicators();
+
+    SQLUSMALLINT column = 0;
+    auto const bindColumn = [&](auto const& accessor) {
+        ++column;
+        using ValueType = std::remove_cvref_t<decltype(accessor(rowData[0]))>;
+        if constexpr (SqlIsStdOptional<ValueType>)
+            RequireSuccess(SqlDataBinder<ValueType>::BatchRowWiseInputParameter(
+                m_hStmt, column, std::addressof(accessor(rowData[0])), sizeof(RowElem), rowCount, *this));
+        else
+            RequireSuccess(SqlDataBinder<ValueType>::InputParameter(m_hStmt, column, accessor(rowData[0]), *this));
+    };
+    (bindColumn(accessors), ...);
+
+    RequireSuccess(SQLExecute(m_hStmt));
+    ProcessPostExecuteCallbacks();
+
+    // Restore single-row binding so a subsequent reuse of this handle (without re-Prepare) is unaffected.
+    // clang-format off
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER) 1, 0));
+    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAM_BIND_TYPE, SQL_PARAM_BIND_BY_COLUMN, 0));
+    RequireSuccess(SQLSetStmtAttr(m_hStmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, nullptr, 0));
+    // clang-format on
+    ClearBatchIndicators();
+
+    return SqlResultCursor { *this };
+}
+
+template <std::ranges::contiguous_range Rows, typename... ColumnAccessors>
+SqlResultCursor SqlStatement::ExecuteBatchSoftRowMajor(Rows const& rows, ColumnAccessors const&... accessors)
+{
+    ZoneScopedN("SqlStatement::ExecuteBatchSoftRowMajor");
+    ZoneTextObject(m_preparedQuery);
+
+    auto const* rowData = std::ranges::data(rows);
+    auto const rowCount = std::ranges::size(rows);
+    ZoneValue(rowCount);
+
+    for (auto const rowIndex: std::views::iota(std::size_t { 0 }, rowCount))
+    {
+        auto const& row = rowData[rowIndex];
+        SQLUSMALLINT column = 0;
+        ((++column,
+          RequireSuccess(SqlDataBinder<std::remove_cvref_t<decltype(accessors(row))>>::InputParameter(
+              m_hStmt, column, accessors(row), *this))),
+         ...);
+        RequireSuccess(SQLExecute(m_hStmt));
+        ProcessPostExecuteCallbacks();
+    }
+
     return SqlResultCursor { *this };
 }
 

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -827,7 +827,7 @@ concept SqlNativeRowBindableValue = SqlIsNativeRowBindableValue<V>;
 /// offset/representation across backends and therefore use the soft path).
 template <typename V>
 concept SqlOptionalRowBindable =
-    SqlIsStdOptional<V> && SqlNativeRowBindableValue<SqlOptionalInnerType<V>> && !SqlIsNumericValue<SqlOptionalInnerType<V>>;
+    SqlIsStdOptional<V> && SqlNativeRowBindableValue<typename V::value_type> && !SqlIsNumericValue<typename V::value_type>;
 
 /// @brief A column value type usable on the native row-wise batch path — either a row-bindable fixed
 /// value or a row-bindable optional of one.

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -186,7 +186,7 @@ class [[nodiscard]] SqlStatement final: public SqlDataBinderCallback
     /// @endcode
     ///
     /// The native row-wise path is taken when every column value type is row-bindable
-    /// (@ref SqlNativeRowBindableValue, or @c std::optional of such a non-numeric type), every accessor
+    /// (@c SqlNativeRowBindableValue, or @c std::optional of such a non-numeric type), every accessor
     /// returns an lvalue reference, the row stride satisfies the indicator-alignment requirement, and the
     /// driver advertises parameter-array support (@ref SqlQueryFormatter::SupportsNativeRowBatch). A
     /// per-row runtime stride check guards against accessors that are not constant-offset subobjects.
@@ -804,7 +804,7 @@ concept SqlNativeBatchable =
 
 /// @brief A value type that can be bound in a native ODBC row-wise parameter array (fixed-width,
 /// inline, indicator-free, bound identically across backends). Backed by the data-driven
-/// @ref SqlIsNativeRowBindableValue trait that each eligible binder header opts into.
+/// @c SqlIsNativeRowBindableValue trait that each eligible binder header opts into.
 template <typename V>
 concept SqlNativeRowBindableValue = SqlIsNativeRowBindableValue<V>;
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -78,6 +78,7 @@ set(SOURCE_FILES
     PluginDiscoveryTests.cpp
     PluginIngestionTests.cpp
     SecretResolverTests.cpp
+    DataMapper/BatchTests.cpp
     DataMapper/CreateTests.cpp
     DataMapper/MiscTests.cpp
     DataMapper/NamingTests.cpp

--- a/src/tests/CoreTests.cpp
+++ b/src/tests/CoreTests.cpp
@@ -11,6 +11,10 @@
 #include <array>
 #include <cstdlib>
 #include <list>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
 
 // NOLINTBEGIN(readability-container-size-empty)
 
@@ -369,6 +373,202 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlStatement.ExecuteBatchNative", "[SqlStateme
     CHECK(cursor.GetColumn<int>(3) == 50'000);
 
     REQUIRE(!cursor.FetchRow());
+}
+
+namespace
+{
+// All-fixed-width row: eligible for native zero-copy row-wise batch binding.
+struct PlainBatchRow
+{
+    int64_t id {};
+    double value {};
+    int32_t count {};
+};
+
+// Fixed-width row with a nullable column. sizeof is a multiple of alignof(SQLLEN), so the optional
+// native row-wise path (with its row-strided indicator) applies.
+struct NullableBatchRow
+{
+    int64_t id {};
+    std::optional<int32_t> maybe {};
+};
+static_assert(sizeof(NullableBatchRow) % alignof(SQLLEN) == 0);
+
+// Row that contains a std::string column: always routed through the soft batch path.
+struct StringBatchRow
+{
+    int32_t id {};
+    std::string name;
+    std::optional<int32_t> maybe {};
+};
+} // namespace
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlStatement.ExecuteBatch: row-major native (all fixed)", "[SqlStatement]")
+{
+    auto stmt = Lightweight::SqlStatement {};
+    stmt.MigrateDirect([](Lightweight::SqlMigrationQueryBuilder& migration) {
+        migration.CreateTable("RowMajor")
+            .Column("Id", Lightweight::SqlColumnTypeDefinitions::Bigint {})
+            .Column("Value", Lightweight::SqlColumnTypeDefinitions::Real {})
+            .Column("Count", Lightweight::SqlColumnTypeDefinitions::Integer {});
+    });
+
+    stmt.Prepare(R"(INSERT INTO "RowMajor" ("Id", "Value", "Count") VALUES (?, ?, ?))");
+
+    auto const rows = std::array {
+        PlainBatchRow { .id = 1, .value = 1.5, .count = 10 },
+        PlainBatchRow { .id = 2, .value = 2.5, .count = 20 },
+        PlainBatchRow { .id = 3, .value = 3.5, .count = 30 },
+    };
+
+    (void) stmt.ExecuteBatch(
+        std::span { rows },
+        [](PlainBatchRow const& r) -> int64_t const& { return r.id; },
+        [](PlainBatchRow const& r) -> double const& { return r.value; },
+        [](PlainBatchRow const& r) -> int32_t const& { return r.count; });
+
+    auto cursor = stmt.ExecuteDirect(R"(SELECT "Id", "Value", "Count" FROM "RowMajor" ORDER BY "Id")");
+    for (auto const& expected: rows)
+    {
+        REQUIRE(cursor.FetchRow());
+        CHECK(cursor.GetColumn<int64_t>(1) == expected.id);
+        CHECK_THAT(cursor.GetColumn<double>(2), Catch::Matchers::WithinAbs(expected.value, 0.000'001));
+        CHECK(cursor.GetColumn<int>(3) == expected.count);
+    }
+    REQUIRE(!cursor.FetchRow());
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlStatement.ExecuteBatch: row-major native with optional", "[SqlStatement]")
+{
+    auto stmt = Lightweight::SqlStatement {};
+    stmt.MigrateDirect([](Lightweight::SqlMigrationQueryBuilder& migration) {
+        migration.CreateTable("RowMajorOpt")
+            .Column("Id", Lightweight::SqlColumnTypeDefinitions::Bigint {})
+            .Column("Maybe", Lightweight::SqlColumnTypeDefinitions::Integer {}); // nullable by default
+    });
+
+    stmt.Prepare(R"(INSERT INTO "RowMajorOpt" ("Id", "Maybe") VALUES (?, ?))");
+
+    auto const rows = std::array {
+        NullableBatchRow { .id = 1, .maybe = 100 },
+        NullableBatchRow { .id = 2, .maybe = std::nullopt },
+        NullableBatchRow { .id = 3, .maybe = 300 },
+    };
+
+    (void) stmt.ExecuteBatch(
+        std::span { rows },
+        [](NullableBatchRow const& r) -> int64_t const& { return r.id; },
+        [](NullableBatchRow const& r) -> std::optional<int32_t> const& { return r.maybe; });
+
+    auto cursor = stmt.ExecuteDirect(R"(SELECT "Id", "Maybe" FROM "RowMajorOpt" ORDER BY "Id")");
+    for (auto const& expected: rows)
+    {
+        REQUIRE(cursor.FetchRow());
+        CHECK(cursor.GetColumn<int64_t>(1) == expected.id);
+        CHECK(cursor.GetColumn<std::optional<int>>(2) == expected.maybe);
+    }
+    REQUIRE(!cursor.FetchRow());
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlStatement.ExecuteBatch: row-major soft (string + optional)", "[SqlStatement]")
+{
+    auto stmt = Lightweight::SqlStatement {};
+    stmt.MigrateDirect([](Lightweight::SqlMigrationQueryBuilder& migration) {
+        migration.CreateTable("RowMajorStr")
+            .Column("Id", Lightweight::SqlColumnTypeDefinitions::Integer {})
+            .Column("Name", Lightweight::SqlColumnTypeDefinitions::Varchar { 64 })
+            .Column("Maybe", Lightweight::SqlColumnTypeDefinitions::Integer {}); // nullable by default
+    });
+
+    stmt.Prepare(R"(INSERT INTO "RowMajorStr" ("Id", "Name", "Maybe") VALUES (?, ?, ?))");
+
+    auto rows = std::vector<StringBatchRow> {};
+    rows.push_back({ .id = 1, .name = "", .maybe = 11 }); // empty string
+    rows.push_back({ .id = 2, .name = "Alice", .maybe = std::nullopt });
+    rows.push_back({ .id = 3, .name = "a longer string value", .maybe = 33 });
+
+    (void) stmt.ExecuteBatch(
+        std::span<StringBatchRow const> { rows },
+        [](StringBatchRow const& r) -> int32_t const& { return r.id; },
+        [](StringBatchRow const& r) -> std::string const& { return r.name; },
+        [](StringBatchRow const& r) -> std::optional<int32_t> const& { return r.maybe; });
+
+    auto cursor = stmt.ExecuteDirect(R"(SELECT "Id", "Name", "Maybe" FROM "RowMajorStr" ORDER BY "Id")");
+    for (auto const& expected: rows)
+    {
+        REQUIRE(cursor.FetchRow());
+        CHECK(cursor.GetColumn<int>(1) == expected.id);
+        CHECK(cursor.GetColumn<std::string>(2) == expected.name);
+        CHECK(cursor.GetColumn<std::optional<int>>(3) == expected.maybe);
+    }
+    REQUIRE(!cursor.FetchRow());
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlStatement.ExecuteBatch: row-major edge cases", "[SqlStatement]")
+{
+    auto stmt = Lightweight::SqlStatement {};
+    stmt.MigrateDirect([](Lightweight::SqlMigrationQueryBuilder& migration) {
+        migration.CreateTable("RowMajorEdge")
+            .Column("Id", Lightweight::SqlColumnTypeDefinitions::Bigint {})
+            .Column("Value", Lightweight::SqlColumnTypeDefinitions::Real {})
+            .Column("Count", Lightweight::SqlColumnTypeDefinitions::Integer {});
+    });
+    stmt.Prepare(R"(INSERT INTO "RowMajorEdge" ("Id", "Value", "Count") VALUES (?, ?, ?))");
+
+    auto const idOf = [](PlainBatchRow const& r) -> int64_t const& {
+        return r.id;
+    };
+    auto const valueOf = [](PlainBatchRow const& r) -> double const& {
+        return r.value;
+    };
+    auto const countOf = [](PlainBatchRow const& r) -> int32_t const& {
+        return r.count;
+    };
+
+    SECTION("empty span is a no-op")
+    {
+        auto const empty = std::vector<PlainBatchRow> {};
+        (void) stmt.ExecuteBatch(std::span<PlainBatchRow const> { empty }, idOf, valueOf, countOf);
+        CHECK(stmt.ExecuteDirectScalar<int>(R"(SELECT COUNT(*) FROM "RowMajorEdge")").value_or(-1) == 0);
+    }
+
+    SECTION("single-row batch")
+    {
+        auto const one = std::array { PlainBatchRow { .id = 7, .value = 7.5, .count = 70 } };
+        (void) stmt.ExecuteBatch(std::span { one }, idOf, valueOf, countOf);
+        CHECK(stmt.ExecuteDirectScalar<int>(R"(SELECT COUNT(*) FROM "RowMajorEdge")").value_or(-1) == 1);
+    }
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlStatement.ExecuteBatch: native batch then single Execute reuse", "[SqlStatement]")
+{
+    // Regression: a native row-wise batch sets PARAMSET_SIZE / PARAM_BIND_TYPE on the handle; a
+    // subsequent re-Prepare + single Execute on the same statement must not inherit that state.
+    auto stmt = Lightweight::SqlStatement {};
+    stmt.MigrateDirect([](Lightweight::SqlMigrationQueryBuilder& migration) {
+        migration.CreateTable("RowMajorReuse")
+            .Column("Id", Lightweight::SqlColumnTypeDefinitions::Bigint {})
+            .Column("Value", Lightweight::SqlColumnTypeDefinitions::Real {})
+            .Column("Count", Lightweight::SqlColumnTypeDefinitions::Integer {});
+    });
+
+    stmt.Prepare(R"(INSERT INTO "RowMajorReuse" ("Id", "Value", "Count") VALUES (?, ?, ?))");
+    auto const rows = std::array {
+        PlainBatchRow { .id = 1, .value = 1.5, .count = 10 },
+        PlainBatchRow { .id = 2, .value = 2.5, .count = 20 },
+    };
+    (void) stmt.ExecuteBatch(
+        std::span { rows },
+        [](PlainBatchRow const& r) -> int64_t const& { return r.id; },
+        [](PlainBatchRow const& r) -> double const& { return r.value; },
+        [](PlainBatchRow const& r) -> int32_t const& { return r.count; });
+
+    // Re-prepare and execute a single row; must insert exactly one row (not 2).
+    stmt.Prepare(R"(INSERT INTO "RowMajorReuse" ("Id", "Value", "Count") VALUES (?, ?, ?))");
+    (void) stmt.Execute(int64_t { 99 }, 9.5, 90);
+
+    CHECK(stmt.ExecuteDirectScalar<int>(R"(SELECT COUNT(*) FROM "RowMajorReuse")").value_or(-1) == 3);
+    CHECK(stmt.ExecuteDirectScalar<int>(R"(SELECT "Count" FROM "RowMajorReuse" WHERE "Id" = 99)").value_or(-1) == 90);
 }
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlConnection: manual connect", "[SqlConnection]")

--- a/src/tests/CoreTests.cpp
+++ b/src/tests/CoreTests.cpp
@@ -571,6 +571,46 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlStatement.ExecuteBatch: native batch then s
     CHECK(stmt.ExecuteDirectScalar<int>(R"(SELECT "Count" FROM "RowMajorReuse" WHERE "Id" = 99)").value_or(-1) == 90);
 }
 
+TEST_CASE_METHOD(SqlTestFixture, "SqlStatement.ExecuteBatch: throwing native batch restores handle state", "[SqlStatement]")
+{
+    // Regression: if SQLExecute throws mid-batch, the row-wise PARAMSET_SIZE / PARAM_BIND_TYPE must still
+    // be restored (via the scope guard), so a later single Execute() on the same handle — without
+    // re-Prepare — inserts exactly one row instead of striding a single bind across rowCount param sets.
+    auto stmt = Lightweight::SqlStatement {};
+    stmt.MigrateDirect([](Lightweight::SqlMigrationQueryBuilder& migration) {
+        migration.CreateTable("RowMajorThrow")
+            .PrimaryKey("Id", Lightweight::SqlColumnTypeDefinitions::Bigint {})
+            .Column("Value", Lightweight::SqlColumnTypeDefinitions::Real {})
+            .Column("Count", Lightweight::SqlColumnTypeDefinitions::Integer {});
+    });
+
+    // Seed Id = 2 so the batch below collides on the primary key and SQLExecute fails.
+    stmt.Prepare(R"(INSERT INTO "RowMajorThrow" ("Id", "Value", "Count") VALUES (?, ?, ?))");
+    (void) stmt.Execute(int64_t { 2 }, 2.5, 20);
+
+    stmt.Prepare(R"(INSERT INTO "RowMajorThrow" ("Id", "Value", "Count") VALUES (?, ?, ?))");
+    auto const rows = std::array {
+        PlainBatchRow { .id = 1, .value = 1.5, .count = 10 },
+        PlainBatchRow { .id = 2, .value = 9.9, .count = 99 }, // duplicate primary key -> violation
+        PlainBatchRow { .id = 3, .value = 3.5, .count = 30 },
+    };
+    auto const idOf = [](PlainBatchRow const& r) -> int64_t const& {
+        return r.id;
+    };
+    auto const valueOf = [](PlainBatchRow const& r) -> double const& {
+        return r.value;
+    };
+    auto const countOf = [](PlainBatchRow const& r) -> int32_t const& {
+        return r.count;
+    };
+    CHECK_THROWS_AS((void) stmt.ExecuteBatch(std::span { rows }, idOf, valueOf, countOf), Lightweight::SqlException);
+
+    // Same statement, still prepared; a single Execute WITHOUT re-Prepare must insert exactly one row.
+    (void) stmt.Execute(int64_t { 7 }, 7.5, 70);
+    CHECK(stmt.ExecuteDirectScalar<int>(R"(SELECT COUNT(*) FROM "RowMajorThrow" WHERE "Id" = 7)").value_or(-1) == 1);
+    CHECK(stmt.ExecuteDirectScalar<int>(R"(SELECT "Count" FROM "RowMajorThrow" WHERE "Id" = 7)").value_or(-1) == 70);
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "SqlConnection: manual connect", "[SqlConnection]")
 {
     auto conn = Lightweight::SqlConnection { std::nullopt };

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -3239,6 +3239,10 @@ TEST_CASE_METHOD(SqlTestFixture, "std::optional<T>::OutputColumn: nullptr result
         {
             return nullptr;
         }
+        std::byte* ProvideBatchStagingBuffer(std::size_t /*byteCount*/) override
+        {
+            return nullptr;
+        }
         [[nodiscard]] SqlServerType ServerType() const noexcept override
         {
             return SqlServerType::SQLITE;

--- a/src/tests/DataMapper/BatchTests.cpp
+++ b/src/tests/DataMapper/BatchTests.cpp
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "../Utils.hpp"
+
+#include <Lightweight/Lightweight.hpp>
+
+#include <reflection-cpp/reflection.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <optional>
+#include <ranges>
+#include <string>
+#include <vector>
+
+using namespace Lightweight;
+
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
+
+// Record types must have linkage (not in an anonymous namespace) for reflection-cpp.
+
+// All fixed-width columns: CreateAll/UpdateAll take the native zero-copy row-wise batch path.
+struct BatchFixedRecord
+{
+    Field<int64_t, PrimaryKey::AutoAssign> id;
+    Field<double> value;
+    Field<int32_t> count;
+};
+
+// Contains a std::string (aggregate member) and a nullable column: routed through the soft batch path.
+struct BatchAggregateRecord
+{
+    Field<int32_t, PrimaryKey::AutoAssign> id;
+    Field<std::string> name;
+    Field<std::optional<int32_t>> maybe;
+};
+
+TEST_CASE_METHOD(SqlTestFixture, "DataMapper.CreateAll: native (all fixed-width)", "[DataMapper][batch]")
+{
+    auto dm = DataMapper {};
+    dm.CreateTable<BatchFixedRecord>();
+
+    auto records = std::vector<BatchFixedRecord> {};
+    for (auto const i: std::views::iota(1, 6))
+        records.push_back({ .id = i, .value = i * 1.5, .count = i * 10 });
+
+    dm.CreateAll(records);
+
+    CHECK(dm.Query<BatchFixedRecord>().Count() == 5);
+    for (auto const& expected: records)
+    {
+        auto const actual = dm.QuerySingle<BatchFixedRecord>(expected.id.Value());
+        REQUIRE(actual.has_value());
+        CHECK(actual->id.Value() == expected.id.Value());
+        CHECK_THAT(actual->value.Value(), Catch::Matchers::WithinAbs(expected.value.Value(), 0.000'001));
+        CHECK(actual->count.Value() == expected.count.Value());
+    }
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "DataMapper.CreateAll: soft (std::string + optional)", "[DataMapper][batch]")
+{
+    auto dm = DataMapper {};
+    dm.CreateTable<BatchAggregateRecord>();
+
+    auto records = std::vector<BatchAggregateRecord> {};
+    records.push_back({ .id = 1, .name = std::string {}, .maybe = 11 });                    // empty string
+    records.push_back({ .id = 2, .name = std::string { "Alice" }, .maybe = std::nullopt }); // NULL
+    records.push_back({ .id = 3, .name = std::string { "a longer aggregate value" }, .maybe = 33 });
+
+    dm.CreateAll(records);
+
+    CHECK(dm.Query<BatchAggregateRecord>().Count() == 3);
+    for (auto const& expected: records)
+    {
+        auto const actual = dm.QuerySingle<BatchAggregateRecord>(expected.id.Value());
+        REQUIRE(actual.has_value());
+        CHECK(actual->name.Value() == expected.name.Value());
+        CHECK(actual->maybe.Value() == expected.maybe.Value());
+    }
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "DataMapper.CreateAll: empty and single span", "[DataMapper][batch]")
+{
+    auto dm = DataMapper {};
+    dm.CreateTable<BatchFixedRecord>();
+
+    SECTION("empty span is a no-op")
+    {
+        auto const empty = std::vector<BatchFixedRecord> {};
+        dm.CreateAll(empty);
+        CHECK(dm.Query<BatchFixedRecord>().Count() == 0);
+    }
+
+    SECTION("single-record span")
+    {
+        auto const one = std::vector<BatchFixedRecord> { { .id = 42, .value = 4.2, .count = 420 } };
+        dm.CreateAll(one);
+        CHECK(dm.Query<BatchFixedRecord>().Count() == 1);
+        CHECK(dm.QuerySingle<BatchFixedRecord>(42).value().count.Value() == 420);
+    }
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "DataMapper.UpdateAll: writes all columns incl. NULL", "[DataMapper][batch]")
+{
+    auto dm = DataMapper {};
+    dm.CreateTable<BatchAggregateRecord>();
+
+    auto records = std::vector<BatchAggregateRecord> {};
+    records.push_back({ .id = 1, .name = std::string { "one" }, .maybe = 1 });
+    records.push_back({ .id = 2, .name = std::string { "two" }, .maybe = 2 });
+    records.push_back({ .id = 3, .name = std::string { "three" }, .maybe = 3 });
+    dm.CreateAll(records);
+
+    // Mutate: change names, and set one column to NULL.
+    records[0].name = std::string { "ONE" };
+    records[1].maybe = std::nullopt;
+    records[2].name = std::string { "THREE" };
+    records[2].maybe = 30;
+    dm.UpdateAll(records);
+
+    for (auto const& expected: records)
+    {
+        auto const actual = dm.QuerySingle<BatchAggregateRecord>(expected.id.Value());
+        REQUIRE(actual.has_value());
+        CHECK(actual->name.Value() == expected.name.Value());
+        CHECK(actual->maybe.Value() == expected.maybe.Value());
+    }
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "DataMapper.CreateAll then single Create reuses statement safely", "[DataMapper][batch]")
+{
+    // Regression: CreateAll uses native row-wise array binding (PARAMSET_SIZE/PARAM_BIND_TYPE on the
+    // shared statement); a following single Create() must insert exactly one row.
+    auto dm = DataMapper {};
+    dm.CreateTable<BatchFixedRecord>();
+
+    auto records = std::vector<BatchFixedRecord> {};
+    records.push_back({ .id = 1, .value = 1.5, .count = 10 });
+    records.push_back({ .id = 2, .value = 2.5, .count = 20 });
+    dm.CreateAll(records);
+    REQUIRE(dm.Query<BatchFixedRecord>().Count() == 2);
+
+    auto single = BatchFixedRecord { .id = 99, .value = 9.5, .count = 990 };
+    dm.CreateExplicit(single);
+
+    CHECK(dm.Query<BatchFixedRecord>().Count() == 3);
+    CHECK(dm.QuerySingle<BatchFixedRecord>(99).value().count.Value() == 990);
+}
+
+// NOLINTEND(bugprone-unchecked-optional-access)

--- a/src/tests/DataMapper/BatchTests.cpp
+++ b/src/tests/DataMapper/BatchTests.cpp
@@ -12,6 +12,7 @@
 #include <optional>
 #include <ranges>
 #include <string>
+#include <string_view>
 #include <vector>
 
 using namespace Lightweight;
@@ -34,6 +35,33 @@ struct BatchAggregateRecord
     Field<int32_t, PrimaryKey::AutoAssign> id;
     Field<std::string> name;
     Field<std::optional<int32_t>> maybe;
+};
+
+// All columns fixed-width, including inline fixed-capacity strings (SqlAnsiString is a SqlFixedString
+// specialization): eligible for the native zero-copy row-wise batch path.
+struct BatchFixedStringRecord
+{
+    Field<int32_t, PrimaryKey::AutoAssign> id;
+    Field<SqlAnsiString<32>> name;
+    Field<SqlAnsiString<16>> code;
+};
+
+// Counts which batch execution path SqlStatement took: the native row-wise path emits a single
+// OnExecuteBatch(), the soft fallback emits one OnExecute() per row.
+class BatchPathCountingLogger: public SqlLogger::Null
+{
+  public:
+    int executeBatchCount = 0;
+    int executeCount = 0;
+
+    void OnExecuteBatch() override
+    {
+        ++executeBatchCount;
+    }
+    void OnExecute(std::string_view const& /*query*/) override
+    {
+        ++executeCount;
+    }
 };
 
 TEST_CASE_METHOD(SqlTestFixture, "DataMapper.CreateAll: native (all fixed-width)", "[DataMapper][batch]")
@@ -146,6 +174,40 @@ TEST_CASE_METHOD(SqlTestFixture, "DataMapper.CreateAll then single Create reuses
 
     CHECK(dm.Query<BatchFixedRecord>().Count() == 3);
     CHECK(dm.QuerySingle<BatchFixedRecord>(99).value().count.Value() == 990);
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "DataMapper.CreateAll: native fixed-capacity strings", "[DataMapper][batch]")
+{
+    // All currently supported backends (MS SQL Server, PostgreSQL, SQLite3) accept native parameter
+    // arrays, so an all-fixed-width record — including inline fixed-capacity strings — must take the
+    // native row-wise path (a single batched execute), not one execute per row.
+    static_assert(sizeof(BatchFixedStringRecord) % alignof(SQLLEN) == 0,
+                  "fixed-capacity-string record must satisfy the row-strided indicator alignment requirement");
+
+    auto dm = DataMapper {};
+    dm.CreateTable<BatchFixedStringRecord>();
+
+    auto records = std::vector<BatchFixedStringRecord> {};
+    records.push_back({ .id = 1, .name = "Alice", .code = "AAA" });
+    records.push_back({ .id = 2, .name = "Bob", .code = "BB" });
+    records.push_back({ .id = 3, .name = "Charlie Brown", .code = "CCCCCCC" });
+
+    BatchPathCountingLogger logger;
+    auto& previousLogger = SqlLogger::GetLogger();
+    SqlLogger::SetLogger(logger);
+    dm.CreateAll(records);
+    SqlLogger::SetLogger(previousLogger);
+
+    CHECK(logger.executeBatchCount == 1); // native row-wise path: exactly one batched execute
+    CHECK(logger.executeCount == 0);      // and no per-row executes
+
+    for (auto const& expected: records)
+    {
+        auto const actual = dm.QuerySingle<BatchFixedStringRecord>(expected.id.Value());
+        REQUIRE(actual.has_value());
+        CHECK(actual->name.Value() == expected.name.Value());
+        CHECK(actual->code.Value() == expected.code.Value());
+    }
 }
 
 // NOLINTEND(bugprone-unchecked-optional-access)

--- a/src/tests/DataMapper/BatchTests.cpp
+++ b/src/tests/DataMapper/BatchTests.cpp
@@ -9,6 +9,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include <chrono>
 #include <optional>
 #include <ranges>
 #include <string>
@@ -44,6 +45,48 @@ struct BatchFixedStringRecord
     Field<int32_t, PrimaryKey::AutoAssign> id;
     Field<SqlAnsiString<32>> name;
     Field<SqlAnsiString<16>> code;
+};
+
+// Nullable inline fixed-capacity string + fixed columns: exercises the native zero-copy path for
+// std::optional<SqlAnsiString<N>> (per-row NULL-or-length row-strided indicator).
+struct BatchOptionalFixedStringRecord
+{
+    Field<int32_t, PrimaryKey::AutoAssign> id;
+    Field<std::optional<SqlAnsiString<32>>> name;
+    Field<int32_t> count;
+};
+
+// Fixed-point numeric column: native path via the singular InputParameter bound with the type's
+// compile-time precision/scale.
+struct BatchNumericRecord
+{
+    Field<int32_t, PrimaryKey::AutoAssign> id;
+    Field<SqlNumeric<10, 2>> amount;
+};
+
+// Temporal columns (all fixed-width): native path via the singular InputParameter.
+struct BatchTemporalRecord
+{
+    Field<int32_t, PrimaryKey::AutoAssign> id;
+    Field<SqlDate> date;
+    Field<SqlTime> time;
+    Field<SqlDateTime> when;
+};
+
+// Nullable timestamp: exercises std::optional<SqlDateTime> batch binding (NULL + value round-trip).
+struct BatchOptionalTemporalRecord
+{
+    Field<int32_t, PrimaryKey::AutoAssign> id;
+    Field<std::optional<SqlDateTime>> when;
+};
+
+// Server-side auto-increment PK + storable columns: the auto-increment PK must be excluded from the
+// batched INSERT column set (shared IsBatchInsertColumn predicate) yet used as the UpdateAll WHERE key.
+struct BatchMixedColumnRecord
+{
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id;
+    Field<std::string> label;
+    Field<int32_t> number;
 };
 
 // Counts which batch execution path SqlStatement took: the native row-wise path emits a single
@@ -208,6 +251,196 @@ TEST_CASE_METHOD(SqlTestFixture, "DataMapper.CreateAll: native fixed-capacity st
         CHECK(actual->name.Value() == expected.name.Value());
         CHECK(actual->code.Value() == expected.code.Value());
     }
+}
+
+TEST_CASE_METHOD(SqlTestFixture,
+                 "DataMapper.CreateAll/UpdateAll: native optional fixed-capacity string",
+                 "[DataMapper][batch]")
+{
+    static_assert(sizeof(BatchOptionalFixedStringRecord) % alignof(SQLLEN) == 0,
+                  "nullable fixed-capacity-string record must satisfy the row-strided indicator alignment requirement");
+
+    auto dm = DataMapper {};
+    dm.CreateTable<BatchOptionalFixedStringRecord>();
+
+    auto records = std::vector<BatchOptionalFixedStringRecord> {};
+    records.push_back({ .id = 1, .name = SqlAnsiString<32> { "Alice" }, .count = 10 });
+    records.push_back({ .id = 2, .name = std::nullopt, .count = 20 });         // NULL
+    records.push_back({ .id = 3, .name = SqlAnsiString<32> {}, .count = 30 }); // empty string
+    records.push_back({ .id = 4, .name = SqlAnsiString<32> { "0123456789012345678901234567890" }, .count = 40 }); // 31 chars
+
+    BatchPathCountingLogger logger;
+    auto& previousLogger = SqlLogger::GetLogger();
+    SqlLogger::SetLogger(logger);
+    dm.CreateAll(records);
+    SqlLogger::SetLogger(previousLogger);
+
+    CHECK(logger.executeBatchCount == 1); // native row-wise path: exactly one batched execute
+    CHECK(logger.executeCount == 0);      // and no per-row executes
+
+    auto const verify = [&](std::vector<BatchOptionalFixedStringRecord> const& expectedRecords) {
+        for (auto const& expected: expectedRecords)
+        {
+            auto const actual = dm.QuerySingle<BatchOptionalFixedStringRecord>(expected.id.Value());
+            REQUIRE(actual.has_value());
+            CHECK(actual->count.Value() == expected.count.Value());
+            CHECK(actual->name.Value().has_value() == expected.name.Value().has_value());
+            if (expected.name.Value().has_value())
+                CHECK(actual->name.Value().value() == expected.name.Value().value());
+        }
+    };
+    verify(records);
+
+    // UpdateAll over the same record shape stays native; flip value<->NULL and mutate a fixed column.
+    records[0].name = std::nullopt;                // value -> NULL
+    records[1].name = SqlAnsiString<32> { "Bob" }; // NULL -> value
+    records[3].count = 444;
+    dm.UpdateAll(records);
+    verify(records);
+}
+
+TEST_CASE_METHOD(SqlTestFixture,
+                 "DataMapper.CreateAll: SqlNumeric binds with the column's precision/scale",
+                 "[DataMapper][batch]")
+{
+    // Row 0 is a default-constructed (never-assigned) SqlNumeric, whose sqlValue.precision/scale are 0.
+    // The native row-wise batch binds a single descriptor (taken from row 0) for the whole array, so
+    // before the fix this corrupted/rejected the assigned values in rows 1..n on SQL_C_NUMERIC backends.
+    auto dm = DataMapper {};
+    dm.CreateTable<BatchNumericRecord>();
+
+    auto records = std::vector<BatchNumericRecord> {};
+    records.push_back({ .id = 1, .amount = SqlNumeric<10, 2> {} }); // default-constructed
+    records.push_back({ .id = 2, .amount = SqlNumeric<10, 2> { 12.34 } });
+    records.push_back({ .id = 3, .amount = SqlNumeric<10, 2> { 99.99 } });
+
+    dm.CreateAll(records);
+
+    CHECK(dm.Query<BatchNumericRecord>().Count() == 3);
+    // The assigned rows must round-trip exactly (mis-bound from row 0's precision before the fix).
+    CHECK(dm.QuerySingle<BatchNumericRecord>(2).value().amount.Value().ToString() == SqlNumeric<10, 2> { 12.34 }.ToString());
+    CHECK(dm.QuerySingle<BatchNumericRecord>(3).value().amount.Value().ToString() == SqlNumeric<10, 2> { 99.99 }.ToString());
+    REQUIRE(dm.QuerySingle<BatchNumericRecord>(1).has_value()); // default row present
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "DataMapper.CreateAll: native temporal columns", "[DataMapper][batch]")
+{
+    auto dm = DataMapper {};
+    dm.CreateTable<BatchTemporalRecord>();
+
+    auto const makeRecord = [](int32_t id, unsigned day) {
+        return BatchTemporalRecord {
+            .id = id,
+            .date = SqlDate { std::chrono::year { 2026 }, std::chrono::month { 5 }, std::chrono::day { day } },
+            .time = SqlTime { std::chrono::hours { 13 }, std::chrono::minutes { 14 }, std::chrono::seconds { 15 } },
+            .when = SqlDateTime { std::chrono::year { 2026 },
+                                  std::chrono::month { 5 },
+                                  std::chrono::day { day },
+                                  std::chrono::hours { 8 },
+                                  std::chrono::minutes { 30 },
+                                  std::chrono::seconds { 45 },
+                                  std::chrono::nanoseconds { 0 } },
+        };
+    };
+    auto records = std::vector<BatchTemporalRecord> {};
+    records.push_back(makeRecord(1, 6));
+    records.push_back(makeRecord(2, 7));
+    records.push_back(makeRecord(3, 8));
+
+    BatchPathCountingLogger logger;
+    auto& previousLogger = SqlLogger::GetLogger();
+    SqlLogger::SetLogger(logger);
+    dm.CreateAll(records);
+    SqlLogger::SetLogger(previousLogger);
+
+    CHECK(logger.executeBatchCount == 1); // native row-wise path (date/time bind by address, no indicators)
+    CHECK(logger.executeCount == 0);
+
+    for (auto const& expected: records)
+    {
+        auto const actual = dm.QuerySingle<BatchTemporalRecord>(expected.id.Value());
+        REQUIRE(actual.has_value());
+        CHECK(actual->date.Value() == expected.date.Value());
+        CHECK(actual->time.Value() == expected.time.Value());
+        CHECK(actual->when.Value() == expected.when.Value());
+    }
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "DataMapper.CreateAll: optional timestamp NULL and value round-trip", "[DataMapper][batch]")
+{
+    auto dm = DataMapper {};
+    dm.CreateTable<BatchOptionalTemporalRecord>();
+
+    auto records = std::vector<BatchOptionalTemporalRecord> {};
+    records.push_back({ .id = 1,
+                        .when = SqlDateTime { std::chrono::year { 2026 },
+                                              std::chrono::month { 1 },
+                                              std::chrono::day { 2 },
+                                              std::chrono::hours { 3 },
+                                              std::chrono::minutes { 4 },
+                                              std::chrono::seconds { 5 },
+                                              std::chrono::nanoseconds { 0 } } });
+    records.push_back({ .id = 2, .when = std::nullopt });
+    dm.CreateAll(records);
+
+    auto const engaged = dm.QuerySingle<BatchOptionalTemporalRecord>(1);
+    REQUIRE(engaged.has_value());
+    REQUIRE(engaged->when.Value().has_value());
+    CHECK(engaged->when.Value().value() == records[0].when.Value().value());
+
+    auto const disengaged = dm.QuerySingle<BatchOptionalTemporalRecord>(2);
+    REQUIRE(disengaged.has_value());
+    CHECK(!disengaged->when.Value().has_value());
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "DataMapper.UpdateAll: zero-row match does not throw (native)", "[DataMapper][batch]")
+{
+    auto dm = DataMapper {};
+    dm.CreateTable<BatchFixedRecord>();
+
+    // Table is empty: a searched UPDATE matches no rows and the driver returns SQL_NO_DATA. UpdateAll
+    // must tolerate it (like single Update()), not throw.
+    auto records = std::vector<BatchFixedRecord> {};
+    records.push_back({ .id = 100, .value = 1.0, .count = 1 });
+    records.push_back({ .id = 200, .value = 2.0, .count = 2 });
+    CHECK_NOTHROW(dm.UpdateAll(records));
+    CHECK(dm.Query<BatchFixedRecord>().Count() == 0);
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "DataMapper.UpdateAll: soft path tolerates non-matching rows", "[DataMapper][batch]")
+{
+    auto dm = DataMapper {};
+    dm.CreateTable<BatchAggregateRecord>();
+
+    auto seed = std::vector<BatchAggregateRecord> {};
+    seed.push_back({ .id = 1, .name = std::string { "one" }, .maybe = 1 });
+    dm.CreateAll(seed);
+
+    auto updates = std::vector<BatchAggregateRecord> {};
+    updates.push_back({ .id = 1, .name = std::string { "updated" }, .maybe = 2 }); // matches
+    updates.push_back({ .id = 999, .name = std::string { "ghost" }, .maybe = 3 }); // no such row
+    CHECK_NOTHROW(dm.UpdateAll(updates));
+
+    auto const row1 = dm.QuerySingle<BatchAggregateRecord>(1);
+    REQUIRE(row1.has_value());
+    CHECK(row1->name.Value() == "updated");
+    CHECK(!dm.QuerySingle<BatchAggregateRecord>(999).has_value());
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "DataMapper.CreateAll: excludes server-side auto-increment PK", "[DataMapper][batch]")
+{
+    // IsBatchInsertColumn must exclude the ServerSideAutoIncrement id; otherwise every row would bind
+    // id = 0 and collide on the primary key (or desync the bound `?` count from the value accessors).
+    auto dm = DataMapper {};
+    dm.CreateTable<BatchMixedColumnRecord>();
+
+    auto records = std::vector<BatchMixedColumnRecord> {};
+    records.push_back({ .id = {}, .label = std::string { "alpha" }, .number = 1 });
+    records.push_back({ .id = {}, .label = std::string { "beta" }, .number = 2 });
+    records.push_back({ .id = {}, .label = std::string { "gamma" }, .number = 3 });
+
+    CHECK_NOTHROW(dm.CreateAll(records));
+    CHECK(dm.Query<BatchMixedColumnRecord>().Count() == 3);
 }
 
 // NOLINTEND(bugprone-unchecked-optional-access)


### PR DESCRIPTION
Inserting or updating many records previously meant calling `Create`/`CreateExplicit`/`Update` in a loop, which re-prepares the statement for every single row. This adds a batched path that prepares once and submits the whole batch, preferring native ODBC row-wise array binding (a single zero-copy `SQLExecute`) and falling back to a prepare-once + per-row execute only when native binding cannot apply.

## Changes

- **`SqlStatement`**: new row-major `ExecuteBatch(rows, accessors...)` overload. Native row-wise binding (`SQL_ATTR_PARAM_BIND_TYPE = sizeof(row)`) is used when every bound column is row-bindable — primitives, `SqlDate`/`SqlTime`/`SqlDateTime`, `SqlNumeric`, or `std::optional` of a fixed non-numeric type — otherwise it falls back to a per-row soft path that handles every supported type (strings, binary, variant, …).
- **`std::optional` columns** stay zero-copy on the native path: the contained value is bound in place and per-row NULLs are supplied through a temporary, row-strided indicator buffer (new `SqlDataBinderCallback::ProvideBatchStagingBuffer`).
- **Eligibility** is data-driven via the opt-in `SqlIsNativeRowBindableValue` trait, and guarded by three gates: compile-time type/reference checks (incl. `sizeof(row) % alignof(SQLLEN) == 0` for optional columns), the new per-DBMS `SqlQueryFormatter::SupportsNativeRowBatch()` capability, and a runtime accessor-stride check.
- **`DataMapper`**: new `CreateAll` / `UpdateAll` accepting any contiguous, sized range of records (`std::vector`, `std::array`, `std::span`, C array; non-contiguous ranges are rejected at compile time). `UpdateAll` writes all storable non-primary-key columns matched on the primary key.
- **`SqlStatement::Prepare`** now resets the parameter-array binding attributes (`PARAMSET_SIZE` / `PARAM_BIND_TYPE` / `PARAM_BIND_OFFSET_PTR`) so a statement handle reused across batched and single executes — as `DataMapper` does — is never left in a stale row-wise binding state.
- `SqlDate`/`SqlTime`/`SqlDateTime` gain a column-wise `BatchInputParameter`, and the primitive batch binders accept an optional indicator pointer, to support the optional native path.

**Performance:** for fixed-width records the batch is a single prepare + single row-wise `SQLExecute` (zero-copy); for records with variable-length columns it is a single prepare + per-row execute — both eliminate the per-row re-prepare of the previous loop-based approach.

**Risk:** per-DBMS row-wise array binding behaviour is the main risk (gated by `SupportsNativeRowBatch()`); `SqlGuid` is deliberately excluded from native batching because SQLite binds it via a per-value text conversion. Covered by tests across SQLite, MS SQL Server and PostgreSQL.