### PR TITLE
Add macOS CI support (fix libc++ build + macOS test job)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -456,6 +456,81 @@ jobs:
           }
 
   # }}}
+  # {{{ macOS
+  macos:
+    # macOS coverage for the Homebrew-LLVM / libc++ toolchain, which differs in
+    # non-obvious ways from the Linux libstdc++ and Windows MSVC STLs (e.g.
+    # libc++ has no <stacktrace>, gates utc_clock behind its tz database, and
+    # rejects std::char_traits<unsigned char>). GitHub's macOS runners cannot
+    # run Docker, so only the natively-installable SQLite backend is exercised
+    # here; MSSQL/PostgreSQL stay covered by the Linux/Windows matrices.
+    name: "macOS (Homebrew LLVM, SQLite)"
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+      - name: Fetch tags
+        # cmake/Version.cmake derives the project version from the latest `v*`
+        # git tag; actions/checkout does a shallow clone without tags.
+        run: git fetch --prune --unshallow --tags
+      - name: "Install dependencies (Homebrew)"
+        # llvm@${{ env.CLANG_TOOLS_VERSION }} pins the same major Clang the rest
+        # of the project targets, so libc++/C++23 behaviour matches local dev
+        # (the runner's stock AppleClang would diverge under the warning set).
+        run: |
+          brew update
+          brew install \
+            llvm@${{ env.CLANG_TOOLS_VERSION }} \
+            cmake ninja catch2 yaml-cpp libzip unixodbc sqliteodbc
+      - name: "Register the SQLite3 ODBC driver"
+        # Homebrew's sqliteodbc ships the driver dylib but does not register it
+        # with unixODBC. Register BOTH names the test suite uses on non-Windows:
+        # `SQLite3 ODBC Driver` (scripts/tests/.test-env.yml `sqlite3` key, used
+        # by `LightweightTest --test-env=sqlite3`) and `SQLite3` (the default
+        # string baked into the binary and into the DbToolIntegrationTest ctest,
+        # see src/tests/CMakeLists.txt). One dylib, two stanzas.
+        run: |
+          set -ex
+          SQLITE_ODBC="$(brew --prefix)/lib/libsqlite3odbc.dylib"
+          test -f "$SQLITE_ODBC"
+          {
+            printf '[SQLite3 ODBC Driver]\nDescription=SQLite3 ODBC Driver\nDriver=%s\nSetup=%s\nThreading=2\n\n' \
+              "$SQLITE_ODBC" "$SQLITE_ODBC"
+            printf '[SQLite3]\nDescription=SQLite3 ODBC Driver\nDriver=%s\nSetup=%s\nThreading=2\n' \
+              "$SQLITE_ODBC" "$SQLITE_ODBC"
+          } > "$RUNNER_TEMP/sqlite3-odbc.ini"
+          odbcinst -i -d -f "$RUNNER_TEMP/sqlite3-odbc.ini"
+          odbcinst -q -d
+      - name: "Configure"
+        # Reuse the Darwin-capable clang-debug preset but disable the checks the
+        # macOS leg should not re-run: clang-tidy and the sanitizers are already
+        # covered by the Linux jobs, and PEDANTIC_COMPILER=OFF drops the
+        # warning block + -Werror (which is gated on it). A dedicated -B dir
+        # keeps this independent of the preset's own binaryDir.
+        run: |
+          set -ex
+          LLVM="$(brew --prefix llvm@${{ env.CLANG_TOOLS_VERSION }})"
+          cmake --preset clang-debug -B out/build/macos-ci \
+                -D CMAKE_CXX_COMPILER="$LLVM/bin/clang++" \
+                -D CMAKE_C_COMPILER="$LLVM/bin/clang" \
+                -D ENABLE_TIDY=OFF \
+                -D PEDANTIC_COMPILER=OFF \
+                -D PEDANTIC_COMPILER_WERROR=OFF \
+                -D ENABLE_SANITIZER_ADDRESS=OFF \
+                -D ENABLE_SANITIZER_UNDEFINED=OFF
+      - name: "Build"
+        run: cmake --build out/build/macos-ci --parallel "$(sysctl -n hw.ncpu)"
+      - name: "Install Python YAML"
+        # Needed by test_dbtool.py (and harmless for ctest); the macOS runner's
+        # python is externally managed, so --break-system-packages is required.
+        run: python3 -m pip install --break-system-packages --disable-pip-version-check pyyaml
+      - name: "Run tests (SQLite via ctest)"
+        # ctest runs both LightweightTest (default `DRIVER=SQLite3` connection)
+        # and DbToolIntegrationTest (the test_dbtool.py suite, also `SQLite3`).
+        env:
+          PYTHONUNBUFFERED: "1"
+        run: ctest --test-dir out/build/macos-ci --output-on-failure
+
+  # }}}
   # {{{ Ubuntu build CC matrix
   ubuntu_build_cc_matrix:
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -465,7 +465,9 @@ jobs:
     # run Docker, so only the natively-installable SQLite backend is exercised
     # here; MSSQL/PostgreSQL stay covered by the Linux/Windows matrices.
     name: "macOS (Homebrew LLVM, SQLite)"
-    runs-on: macos-14
+    # Newest available runner; we don't target old macOS. (Doesn't relax libc++
+    # availability gates like float std::from_chars, which needs macOS 26.)
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
       - name: Fetch tags

--- a/AGENT.md
+++ b/AGENT.md
@@ -129,6 +129,37 @@ cmake --build --preset clangcl-debug
 
 ## Testing
 
+### ODBC driver prerequisite (one-time setup)
+
+The tests connect through ODBC, so the **driver named in the connection string must be registered** with the
+driver manager. The default connection string (used by `ctest` and by `LightweightTest` with no `--test-env`) is
+`DRIVER=SQLite3;Database=test.db`, which requires a driver registered under the exact name **`SQLite3`** in
+`odbcinst.ini`. Installing the driver package (e.g. `brew install sqliteodbc`) ships the shared library but does
+**not** register that name — so a fresh checkout fails at connect with:
+
+```
+Failed to connect to the database: 01000 (0) - [unixODBC][Driver Manager]Can't open lib 'SQLite3' : file not found
+```
+
+Register it once (idempotent). On macOS / Homebrew:
+
+```sh
+# Locate the driver shared library (Apple Silicon shown; Intel uses /usr/local/lib)
+SQLITE_ODBC=$(brew --prefix)/lib/libsqlite3odbc.dylib
+printf '[SQLite3]\nDescription=SQLite3 ODBC Driver\nDriver=%s\nSetup=%s\nThreading=2\n' \
+  "$SQLITE_ODBC" "$SQLITE_ODBC" > /tmp/sqlite3-odbc.ini
+odbcinst -i -d -f /tmp/sqlite3-odbc.ini    # writes to $(odbcinst -j | grep DRIVERS)
+odbcinst -q -d                              # verify: [SQLite3] now listed
+```
+
+On Debian/Ubuntu the `libsqliteodbc` package registers the `SQLite3` name automatically; if not, point `Driver=`
+at `libsqlite3odbc.so` the same way. Verify with `odbcinst -q -d` — the `[SQLite3]` stanza must be present before
+running `ctest --preset clang-debug`. (To bypass the registry entirely, set
+`ODBC_CONNECTION_STRING="DRIVER=/full/path/to/libsqlite3odbc.dylib;Database=test.db"`, but registering the name is
+preferred so the project default works unchanged.)
+
+### Running the suite
+
 Catch2 tests live in `src/tests/` and produce a single `LightweightTest` binary. Database selection is parameterised:
 
 ```sh

--- a/src/Lightweight/CMakeLists.txt
+++ b/src/Lightweight/CMakeLists.txt
@@ -233,8 +233,19 @@ else()
     target_compile_options(Lightweight PUBLIC ${ODBC_CFLAGS})
     target_link_libraries(Lightweight PUBLIC ${ODBC_LDFLAGS})
 
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        target_link_libraries(Lightweight PUBLIC stdc++exp) # GCC >= 14
+    # libstdc++ (GCC >= 14, and Clang when configured with -stdlib=libstdc++) ships the experimental
+    # runtime bits for <stacktrace>/std::print in a separate `stdc++exp` library that must be linked
+    # explicitly. libc++ (the default for Clang on macOS) does not provide this library, so a blanket
+    # "GNU or Clang" link breaks there with `ld: library 'stdc++exp' not found`. Probe for the library
+    # instead of guessing from the compiler id, so it is linked exactly when it exists.
+    include(CheckCXXSourceCompiles)
+    set(CMAKE_REQUIRED_LIBRARIES_SAVED "${CMAKE_REQUIRED_LIBRARIES}")
+    set(CMAKE_REQUIRED_LIBRARIES stdc++exp)
+    check_cxx_source_compiles("int main() { return 0; }" LIGHTWEIGHT_HAVE_STDCXXEXP)
+    set(CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES_SAVED}")
+    unset(CMAKE_REQUIRED_LIBRARIES_SAVED)
+    if(LIGHTWEIGHT_HAVE_STDCXXEXP)
+        target_link_libraries(Lightweight PUBLIC stdc++exp)
     endif()
 
     # Find library libuuid via pkg-config, and if available, link against it

--- a/src/Lightweight/DataBinder/BasicStringBinder.hpp
+++ b/src/Lightweight/DataBinder/BasicStringBinder.hpp
@@ -355,13 +355,8 @@ struct SqlDataBinder<AnsiStringType>
     {
         using OptionalType = std::optional<AnsiStringType>;
 
-        // Offset of the contained string within the optional (computed robustly, not assumed 0).
-        // The offset is derived from the integer addresses rather than via pointer subtraction: the
-        // contained value and the optional are distinct objects, so `byte* - byte*` would be undefined
-        // behaviour, whereas subtracting their `std::uintptr_t` addresses is well-defined here.
-        OptionalType const probe { AnsiStringType {} };
-        auto const valueOffset = reinterpret_cast<std::uintptr_t>(std::addressof(*probe))
-                                 - reinterpret_cast<std::uintptr_t>(std::addressof(probe));
+        // Offset of the contained string within the optional (see detail::OptionalValueOffset).
+        auto const valueOffset = detail::OptionalValueOffset<AnsiStringType>();
 
         auto const* sourceBytes = reinterpret_cast<std::byte const*>(elem0);
         auto* const indicatorBytes = cb.ProvideBatchStagingBuffer(((rowCount - 1) * rowStride) + sizeof(SQLLEN));

--- a/src/Lightweight/DataBinder/BasicStringBinder.hpp
+++ b/src/Lightweight/DataBinder/BasicStringBinder.hpp
@@ -7,6 +7,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <optional>
@@ -355,9 +356,12 @@ struct SqlDataBinder<AnsiStringType>
         using OptionalType = std::optional<AnsiStringType>;
 
         // Offset of the contained string within the optional (computed robustly, not assumed 0).
+        // The offset is derived from the integer addresses rather than via pointer subtraction: the
+        // contained value and the optional are distinct objects, so `byte* - byte*` would be undefined
+        // behaviour, whereas subtracting their `std::uintptr_t` addresses is well-defined here.
         OptionalType const probe { AnsiStringType {} };
-        auto const valueOffset = static_cast<std::size_t>(reinterpret_cast<std::byte const*>(std::addressof(*probe))
-                                                          - reinterpret_cast<std::byte const*>(std::addressof(probe)));
+        auto const valueOffset = reinterpret_cast<std::uintptr_t>(std::addressof(*probe))
+                                 - reinterpret_cast<std::uintptr_t>(std::addressof(probe));
 
         auto const* sourceBytes = reinterpret_cast<std::byte const*>(elem0);
         auto* const indicatorBytes = cb.ProvideBatchStagingBuffer(((rowCount - 1) * rowStride) + sizeof(SQLLEN));

--- a/src/Lightweight/DataBinder/Core.hpp
+++ b/src/Lightweight/DataBinder/Core.hpp
@@ -11,7 +11,9 @@
 
 #include <concepts>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 
 #include <sql.h>
@@ -121,6 +123,23 @@ namespace detail
     /// headers can use it without reaching up to the higher-level Utils.hpp.
     template <typename T, typename... Us>
     concept IsAnyOf = (std::same_as<T, Us> || ...);
+
+    /// @brief Byte offset of the contained value within a @c std::optional<T>.
+    ///
+    /// Used by the row-wise batch binders to address the inner value of each row's optional in place. The
+    /// offset is 0 on all known standard libraries, but is computed rather than assumed so the address
+    /// arithmetic does not bake in that assumption. It is derived from the integer addresses of a probe
+    /// optional and its contained value (rather than @c byte* subtraction) to keep the computation defined.
+    ///
+    /// @tparam T The contained value type.
+    /// @return The offset, in bytes, of the contained value within the optional.
+    template <typename T>
+    [[nodiscard]] inline std::size_t OptionalValueOffset() noexcept
+    {
+        std::optional<T> const probe { T {} };
+        return static_cast<std::size_t>(reinterpret_cast<std::uintptr_t>(std::addressof(*probe))
+                                        - reinterpret_cast<std::uintptr_t>(std::addressof(probe)));
+    }
 
     // clang-format off
 template <typename T>

--- a/src/Lightweight/DataBinder/Primitives.hpp
+++ b/src/Lightweight/DataBinder/Primitives.hpp
@@ -105,7 +105,9 @@ template <> struct SqlDataBinder<long long>: Int64DataBinderHelper<long long, SQ
 template <> struct SqlDataBinder<unsigned long long>: Int64DataBinderHelper<unsigned long long, SQL_C_UBIGINT> {};
 #endif
 #if defined(__APPLE__) // size_t is a different type on macOS
-template <> struct SqlDataBinder<std::size_t>: SqlSimpleDataBinder<std::size_t, SQL_C_SBIGINT, SQL_BIGINT, SqlColumnTypeDefinitions::Bigint {}> {};
+// std::size_t is unsigned, so bind it with the unsigned C type (matching SqlDataBinder<uint64_t> above);
+// SQL_C_SBIGINT would sign-corrupt values above INT64_MAX.
+template <> struct SqlDataBinder<std::size_t>: SqlSimpleDataBinder<std::size_t, SQL_C_UBIGINT, SQL_BIGINT, SqlColumnTypeDefinitions::Bigint {}> {};
 #endif
 
 // These fixed-width primitives bind via a plain SQLBindParameter and are eligible for native row-wise

--- a/src/Lightweight/DataBinder/Primitives.hpp
+++ b/src/Lightweight/DataBinder/Primitives.hpp
@@ -105,7 +105,7 @@ template <> struct SqlDataBinder<long long>: Int64DataBinderHelper<long long, SQ
 template <> struct SqlDataBinder<unsigned long long>: Int64DataBinderHelper<unsigned long long, SQL_C_UBIGINT> {};
 #endif
 #if defined(__APPLE__) // size_t is a different type on macOS
-template <> struct SqlDataBinder<std::size_t>: SqlSimpleDataBinder<std::size_t, SQL_C_SBIGINT, SqlColumnTypeDefinitions::Bigint {}> {};
+template <> struct SqlDataBinder<std::size_t>: SqlSimpleDataBinder<std::size_t, SQL_C_SBIGINT, SQL_BIGINT, SqlColumnTypeDefinitions::Bigint {}> {};
 #endif
 
 // These fixed-width primitives bind via a plain SQLBindParameter and are eligible for native row-wise

--- a/src/Lightweight/DataBinder/SqlDateTime.hpp
+++ b/src/Lightweight/DataBinder/SqlDateTime.hpp
@@ -38,16 +38,13 @@ struct SqlDateTime
     /// Return the current date and time in UTC.
     [[nodiscard]] static LIGHTWEIGHT_FORCE_INLINE SqlDateTime NowUTC() noexcept
     {
-        // `std::chrono::utc_clock` is part of the C++20 chrono extensions and is only available when the
-        // standard library reports `__cpp_lib_chrono >= 201907` (e.g. libc++ disables it when its time-zone
-        // database is not built in, which is the case for the Homebrew toolchain on macOS). `system_clock`
-        // already represents Unix time (UTC, no leap seconds), so it is the correct portable fallback for the
-        // `SqlDateTime` value, which is itself a `system_clock::time_point`.
-    #if defined(__cpp_lib_chrono) && __cpp_lib_chrono >= 201907L
-        return SqlDateTime { std::chrono::system_clock::time_point { std::chrono::utc_clock::now().time_since_epoch() } };
-    #else
+        // `std::chrono::system_clock` already represents Unix time (UTC, no leap seconds) and is what
+        // `SqlDateTime` stores, so it yields the correct UTC value directly and identically on every
+        // platform. We deliberately avoid `utc_clock::now().time_since_epoch()` here: it counts leap
+        // seconds, so reinterpreting that duration as a `system_clock::time_point` would shift the value
+        // ~27s into the future, and `utc_clock` is unavailable on libc++ without a built-in tz database
+        // (the Homebrew toolchain on macOS) — both branches would otherwise disagree.
         return SqlDateTime { std::chrono::system_clock::now() };
-    #endif
     }
 #endif
 

--- a/src/Lightweight/DataBinder/SqlDateTime.hpp
+++ b/src/Lightweight/DataBinder/SqlDateTime.hpp
@@ -38,7 +38,16 @@ struct SqlDateTime
     /// Return the current date and time in UTC.
     [[nodiscard]] static LIGHTWEIGHT_FORCE_INLINE SqlDateTime NowUTC() noexcept
     {
+        // `std::chrono::utc_clock` is part of the C++20 chrono extensions and is only available when the
+        // standard library reports `__cpp_lib_chrono >= 201907` (e.g. libc++ disables it when its time-zone
+        // database is not built in, which is the case for the Homebrew toolchain on macOS). `system_clock`
+        // already represents Unix time (UTC, no leap seconds), so it is the correct portable fallback for the
+        // `SqlDateTime` value, which is itself a `system_clock::time_point`.
+    #if defined(__cpp_lib_chrono) && __cpp_lib_chrono >= 201907L
         return SqlDateTime { std::chrono::system_clock::time_point { std::chrono::utc_clock::now().time_since_epoch() } };
+    #else
+        return SqlDateTime { std::chrono::system_clock::now() };
+    #endif
     }
 #endif
 

--- a/src/Lightweight/DataBinder/SqlDynamicBinary.hpp
+++ b/src/Lightweight/DataBinder/SqlDynamicBinary.hpp
@@ -8,6 +8,7 @@
 
 #include <cassert>
 #include <format>
+#include <span>
 #include <string>
 
 namespace Lightweight
@@ -72,14 +73,18 @@ class SqlDynamicBinary final
     {
     }
 #if !defined(LIGHTWEIGHT_CXX26_REFLECTION)
-    /// Constructs a fixed-size string from a string view.
-    LIGHTWEIGHT_FORCE_INLINE constexpr SqlDynamicBinary(std::basic_string_view<value_type> s) noexcept:
-        _base { static_cast<uint8_t const*>(s.data()), static_cast<uint8_t const*>(s.data() + s.size()) }
+    /// Constructs the binary payload from a contiguous span of bytes.
+    ///
+    /// @note `std::span` is used in place of `std::basic_string_view<value_type>` because the latter is
+    /// ill-formed for `uint8_t` on conforming standard libraries (libc++): `std::char_traits` is only
+    /// specialised for the character types, not `unsigned char`.
+    LIGHTWEIGHT_FORCE_INLINE constexpr SqlDynamicBinary(std::span<value_type const> s) noexcept:
+        _base { s.data(), s.data() + s.size() }
     {
     }
 
-    /// Retrieves a string view of the string.
-    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr std::basic_string_view<value_type> ToStringView() const noexcept
+    /// Retrieves a read-only span over the stored bytes.
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr std::span<value_type const> ToStringView() const noexcept
     {
         return { _base.data(), _base.size() };
     }

--- a/src/Lightweight/DataBinder/SqlGuid.cpp
+++ b/src/Lightweight/DataBinder/SqlGuid.cpp
@@ -47,7 +47,14 @@ SqlGuid SqlGuid::Create() noexcept
 #elif __has_include(<uuid/uuid.h>)
 
     uuid_t uuid {};
+    // `uuid_generate_time_safe` is a libuuid (util-linux) extension that additionally reports whether a
+    // synchronized, collision-safe source was used; macOS' `<uuid/uuid.h>` only ships `uuid_generate_time`.
+    // The generated UUID is equally valid either way, and the caller does not consume the safety result.
+    #if defined(__APPLE__)
+    uuid_generate_time(uuid);
+    #else
     uuid_generate_time_safe(uuid);
+    #endif
     std::memcpy(guid.data, uuid, sizeof(uuid));
 
 #else

--- a/src/Lightweight/DataBinder/StdOptional.hpp
+++ b/src/Lightweight/DataBinder/StdOptional.hpp
@@ -6,7 +6,6 @@
 #include "SqlNullValue.hpp"
 
 #include <cstddef>
-#include <cstdint>
 #include <memory>
 #include <optional>
 #include <ranges>
@@ -85,14 +84,8 @@ struct SqlDataBinder<std::optional<T>>
         }
         else
         {
-            // Offset of the contained value within std::optional<T> (0 on all known standard libraries,
-            // but computed robustly so the address arithmetic below does not bake in that assumption).
-            // Derived from the integer addresses rather than via pointer subtraction: the contained value
-            // and the optional are distinct objects, so `byte* - byte*` would be undefined behaviour, whereas
-            // subtracting their `std::uintptr_t` addresses is well-defined here.
-            OptionalValue const probe { T {} };
-            auto const valueOffset = reinterpret_cast<std::uintptr_t>(std::addressof(*probe))
-                                     - reinterpret_cast<std::uintptr_t>(std::addressof(probe));
+            // Offset of the contained value within std::optional<T> (see detail::OptionalValueOffset).
+            auto const valueOffset = detail::OptionalValueOffset<T>();
 
             // Row-strided indicator buffer: ODBC reads the indicator for row i at base + i*rowStride. The
             // optionals themselves are embedded in the row structs, so they are also addressed at

--- a/src/Lightweight/DataBinder/StdOptional.hpp
+++ b/src/Lightweight/DataBinder/StdOptional.hpp
@@ -6,6 +6,7 @@
 #include "SqlNullValue.hpp"
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <ranges>
@@ -86,9 +87,12 @@ struct SqlDataBinder<std::optional<T>>
         {
             // Offset of the contained value within std::optional<T> (0 on all known standard libraries,
             // but computed robustly so the address arithmetic below does not bake in that assumption).
+            // Derived from the integer addresses rather than via pointer subtraction: the contained value
+            // and the optional are distinct objects, so `byte* - byte*` would be undefined behaviour, whereas
+            // subtracting their `std::uintptr_t` addresses is well-defined here.
             OptionalValue const probe { T {} };
-            auto const valueOffset = static_cast<std::size_t>(reinterpret_cast<std::byte const*>(std::addressof(*probe))
-                                                              - reinterpret_cast<std::byte const*>(std::addressof(probe)));
+            auto const valueOffset = reinterpret_cast<std::uintptr_t>(std::addressof(*probe))
+                                     - reinterpret_cast<std::uintptr_t>(std::addressof(probe));
 
             // Row-strided indicator buffer: ODBC reads the indicator for row i at base + i*rowStride. The
             // optionals themselves are embedded in the row structs, so they are also addressed at

--- a/src/Lightweight/SqlBackup/BatchManager.cpp
+++ b/src/Lightweight/SqlBackup/BatchManager.cpp
@@ -8,14 +8,41 @@
 
 #include <algorithm>
 #include <charconv>
+#include <cstdlib>
 #include <cstring>
 #include <format>
+#include <string>
+#include <type_traits>
 #include <variant>
 
 namespace Lightweight::detail
 {
 
 using namespace SqlBackup;
+
+/// Parses a numeric value from [first, last) into @p out.
+/// @note Floating-point types use strtod (not std::from_chars, whose float overloads are unavailable
+/// before macOS 26 in libc++); integral types use std::from_chars.
+template <typename T>
+void ParseNumeric(char const* first, char const* last, T& out)
+{
+    if constexpr (std::is_floating_point_v<T>)
+    {
+        // strtod needs a NUL-terminated buffer; batch cells are not guaranteed to be.
+        auto const text = std::string(first, last);
+        char* end = nullptr;
+        if constexpr (std::is_same_v<T, float>)
+            out = std::strtof(text.c_str(), &end);
+        else if constexpr (std::is_same_v<T, long double>)
+            out = std::strtold(text.c_str(), &end);
+        else
+            out = static_cast<T>(std::strtod(text.c_str(), &end));
+    }
+    else
+    {
+        std::from_chars(first, last, out);
+    }
+}
 
 /// A column in a batch.
 struct BatchColumn
@@ -100,7 +127,7 @@ struct TypedBatchColumn: BatchColumn
                                 PushNull();
                             else
                             {
-                                std::from_chars(s.data(), s.data() + s.size(), v);
+                                ParseNumeric(s.data(), s.data() + s.size(), v);
                                 data.push_back(v);
                                 indicators.push_back(sizeof(T));
                             }
@@ -183,7 +210,7 @@ struct NumericBatchColumn: TypedBatchColumn<T, CType, SqlType>
                     else
                     {
                         T v {};
-                        std::from_chars(arg.data(), arg.data() + arg.size(), v);
+                        ParseNumeric(arg.data(), arg.data() + arg.size(), v);
                         this->data.push_back(v);
                         this->indicators.push_back(sizeof(T));
                     }

--- a/src/Lightweight/SqlBackup/BatchManager.cpp
+++ b/src/Lightweight/SqlBackup/BatchManager.cpp
@@ -4,13 +4,14 @@
 #include "../DataBinder/SqlGuid.hpp"
 #include "../DataBinder/SqlTime.hpp"
 #include "../SqlColumnTypeDefinitions.hpp"
+#include "../Utils.hpp"
 #include "BatchManager.hpp"
 
 #include <algorithm>
 #include <charconv>
-#include <cstdlib>
 #include <cstring>
 #include <format>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <variant>
@@ -20,23 +21,17 @@ namespace Lightweight::detail
 
 using namespace SqlBackup;
 
-/// Parses a numeric value from [first, last) into @p out.
-/// @note Floating-point types use strtod (not std::from_chars, whose float overloads are unavailable
-/// before macOS 26 in libc++); integral types use std::from_chars.
+/// Parses a numeric value from [first, last) into @p out, leaving @p out unchanged on a parse failure.
+/// @note Floating-point types use the locale-independent, error-reporting Lightweight::detail::ParseFloat
+/// helper (std::from_chars' float overloads are unavailable before macOS 26 in libc++); integral types use
+/// std::from_chars directly.
 template <typename T>
 void ParseNumeric(char const* first, char const* last, T& out)
 {
     if constexpr (std::is_floating_point_v<T>)
     {
-        // strtod needs a NUL-terminated buffer; batch cells are not guaranteed to be.
-        auto const text = std::string(first, last);
-        char* end = nullptr;
-        if constexpr (std::is_same_v<T, float>)
-            out = std::strtof(text.c_str(), &end);
-        else if constexpr (std::is_same_v<T, long double>)
-            out = std::strtold(text.c_str(), &end);
-        else
-            out = static_cast<T>(std::strtod(text.c_str(), &end));
+        if (auto const parsed = ParseFloat<T>(first, last))
+            out = *parsed;
     }
     else
     {

--- a/src/Lightweight/SqlMigration.cpp
+++ b/src/Lightweight/SqlMigration.cpp
@@ -1381,7 +1381,7 @@ size_t MigrationManager::ApplyPendingMigrations(ExecuteCallback const& feedbackC
 
 #if !defined(__cpp_lib_ranges_enumerate)
     int index { -1 };
-    for (auto& migration: pendingMigrations)
+    for (auto const& migration: pendingMigrations)
     {
         ++index;
 #else
@@ -1407,7 +1407,7 @@ size_t MigrationManager::ApplyPendingMigrationsUpTo(MigrationTimestamp targetInc
 
 #if !defined(__cpp_lib_ranges_enumerate)
     int index { -1 };
-    for (auto& migration: pendingMigrations)
+    for (auto const& migration: pendingMigrations)
     {
         ++index;
 #else

--- a/src/Lightweight/Tools/CxxModelPrinter.cpp
+++ b/src/Lightweight/Tools/CxxModelPrinter.cpp
@@ -405,11 +405,11 @@ void CxxModelPrinter::ResolveOrderAndPrintTable(std::vector<SqlSchema::Table> co
 {
     std::unordered_map<size_t, std::optional<int>> numberOfForeignKeys;
 #if !defined(__cpp_lib_ranges_enumerate)
-    int index { -1 };
+    size_t index = 0;
     for (auto const& table: tables)
     {
-        ++index;
         numberOfForeignKeys[index] = static_cast<int>(table.foreignKeys.size());
+        ++index;
     }
 #else
     for (auto const& [index, table]: std::views::enumerate(tables))
@@ -419,7 +419,7 @@ void CxxModelPrinter::ResolveOrderAndPrintTable(std::vector<SqlSchema::Table> co
     auto const updateForeignKeyCountAfterPrinted = [&](auto const& tablePrinted) {
 #if !defined(__cpp_lib_ranges_enumerate)
         int index { -1 };
-        for (auto const table: tables)
+        for (auto const& table: tables)
         {
             ++index;
             auto const idx = static_cast<size_t>(index);
@@ -452,7 +452,7 @@ void CxxModelPrinter::ResolveOrderAndPrintTable(std::vector<SqlSchema::Table> co
     {
 #if !defined(__cpp_lib_ranges_enumerate)
         int index { -1 };
-        for (auto const table: tables)
+        for (auto const& table: tables)
         {
             ++index;
             auto const idx = static_cast<size_t>(index);
@@ -473,17 +473,8 @@ void CxxModelPrinter::ResolveOrderAndPrintTable(std::vector<SqlSchema::Table> co
                 // if we do NOT have them, we need to print this table anyway since
                 // there is some circular dependency that we cannot resolve
                 bool found = false;
-#if !defined(__cpp_lib_ranges_enumerate)
-                int otherIndex { -1 };
-                for (auto const& otherTable: tables)
+                for (auto const otherIdx: std::views::iota(static_cast<size_t>(0), tables.size()))
                 {
-                    ++otherIndex;
-                    auto const otherIdx = static_cast<size_t>(otherIndex);
-#else
-                for (auto const [otherIndex, otherTable]: std::views::enumerate(tables))
-                {
-                    auto const otherIdx = static_cast<size_t>(otherIndex);
-#endif
                     if (numberOfForeignKeys[otherIdx] == 0)
                         found = true;
                 }

--- a/src/Lightweight/Tools/CxxModelPrinter.cpp
+++ b/src/Lightweight/Tools/CxxModelPrinter.cpp
@@ -404,30 +404,13 @@ std::optional<std::string> CxxModelPrinter::MapColumnNameOverride(SqlSchema::Ful
 void CxxModelPrinter::ResolveOrderAndPrintTable(std::vector<SqlSchema::Table> const& tables)
 {
     std::unordered_map<size_t, std::optional<int>> numberOfForeignKeys;
-#if !defined(__cpp_lib_ranges_enumerate)
-    size_t index = 0;
-    for (auto const& table: tables)
-    {
-        numberOfForeignKeys[index] = static_cast<int>(table.foreignKeys.size());
-        ++index;
-    }
-#else
-    for (auto const& [index, table]: std::views::enumerate(tables))
-        numberOfForeignKeys[static_cast<size_t>(index)] = static_cast<int>(table.foreignKeys.size());
-#endif
+    for (auto const idx: std::views::iota(static_cast<size_t>(0), tables.size()))
+        numberOfForeignKeys[idx] = static_cast<int>(tables[idx].foreignKeys.size());
 
     auto const updateForeignKeyCountAfterPrinted = [&](auto const& tablePrinted) {
-#if !defined(__cpp_lib_ranges_enumerate)
-        int index { -1 };
-        for (auto const& table: tables)
+        for (auto const idx: std::views::iota(static_cast<size_t>(0), tables.size()))
         {
-            ++index;
-            auto const idx = static_cast<size_t>(index);
-#else
-        for (auto const [index, table]: std::views::enumerate(tables))
-        {
-            auto const idx = static_cast<size_t>(index);
-#endif
+            auto const& table = tables[idx];
             if (table.name == tablePrinted.name)
                 numberOfForeignKeys[idx] = std::nullopt;
 
@@ -450,17 +433,9 @@ void CxxModelPrinter::ResolveOrderAndPrintTable(std::vector<SqlSchema::Table> co
 
     while (numberOfPrintedTables < tables.size())
     {
-#if !defined(__cpp_lib_ranges_enumerate)
-        int index { -1 };
-        for (auto const& table: tables)
+        for (auto const idx: std::views::iota(static_cast<size_t>(0), tables.size()))
         {
-            ++index;
-            auto const idx = static_cast<size_t>(index);
-#else
-        for (auto const [index, table]: std::views::enumerate(tables))
-        {
-            auto const idx = static_cast<size_t>(index);
-#endif
+            auto const& table = tables[idx];
             if (!numberOfForeignKeys[idx]) // NOLINT(bugprone-unchecked-optional-access)
                 continue;
             if (numberOfForeignKeys[idx].value() == 0) //  NOLINT(bugprone-unchecked-optional-access)

--- a/src/Lightweight/Tools/CxxModelPrinter.hpp
+++ b/src/Lightweight/Tools/CxxModelPrinter.hpp
@@ -39,9 +39,9 @@ class CxxModelPrinter
 
     std::string ToString(std::string_view modelNamespace);
 
-    std::string TableIncludes() const;
+    [[nodiscard]] std::string TableIncludes() const;
 
-    std::string AliasTableName(std::string_view name) const;
+    [[nodiscard]] std::string AliasTableName(std::string_view name) const;
 
     [[nodiscard]] std::expected<void, std::string> PrintCumulativeHeaderFile(
         std::filesystem::path const& outputDirectory, std::filesystem::path const& cumulativeHeaderFile);
@@ -50,7 +50,7 @@ class CxxModelPrinter
 
     std::string HeaderFileForTheTable(std::string_view modelNamespace, std::string const& tableName);
 
-    std::string Example(SqlSchema::Table const& table) const;
+    [[nodiscard]] std::string Example(SqlSchema::Table const& table) const;
 
     auto StripSuffix(std::string name) -> std::string;
 
@@ -67,8 +67,8 @@ class CxxModelPrinter
                                 UnicodeTextColumnOverrides const& unicodeTextColumnOverrides,
                                 size_t sqlFixedStringMaxSize);
 
-    std::optional<std::string> MapColumnNameOverride(SqlSchema::FullyQualifiedTableName const& tableName,
-                                                     std::string const& columnName) const;
+    [[nodiscard]] std::optional<std::string> MapColumnNameOverride(SqlSchema::FullyQualifiedTableName const& tableName,
+                                                                   std::string const& columnName) const;
 
     void ResolveOrderAndPrintTable(std::vector<SqlSchema::Table> const& tables);
 

--- a/src/Lightweight/Utils.hpp
+++ b/src/Lightweight/Utils.hpp
@@ -7,12 +7,30 @@
 #include <reflection-cpp/reflection.hpp>
 
 #include <algorithm>
+#include <array>
+#include <cerrno>
+#include <charconv>
+#include <cstdlib>
+#include <optional>
 #include <ranges>
 #include <source_location>
+#include <string>
 #include <string_view>
+#include <system_error>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
+
+// libc++ exposes the locale-aware strtod_l / newlocale family via <xlocale.h>; glibc declares them in
+// <stdlib.h>/<locale.h>. We only need them on the fallback path below (no float std::from_chars).
+#if !(defined(__cpp_lib_to_chars) && __cpp_lib_to_chars >= 201611L)
+    #include <clocale>
+    #if defined(__APPLE__)
+        #include <xlocale.h>
+    #else
+        #include <locale.h>
+    #endif
+#endif
 
 #include <sql.h>
 
@@ -44,6 +62,69 @@ namespace detail
             }
         };
         return Finally { std::forward<decltype(cleanupRoutine)>(cleanupRoutine) };
+    }
+
+    /// Parses a floating-point value from the character range @c [first, last) in a locale-independent way.
+    ///
+    /// This is the single, shared replacement for @c std::from_chars on floating-point types, which is
+    /// unavailable on libc++ before macOS 26. Unlike a bare @c std::strtod it neither depends on the active
+    /// @c LC_NUMERIC locale nor silently accepts trailing garbage, so it round-trips the @c '.' decimal point
+    /// the library always emits regardless of the host locale.
+    ///
+    /// @tparam T A floating-point type (@c float, @c double, or @c long double).
+    /// @param first Pointer to the first character of the numeric text.
+    /// @param last Pointer one past the last character of the numeric text.
+    /// @return The parsed value, or @c std::nullopt if the text is not a complete, in-range number.
+    template <typename T>
+        requires std::is_floating_point_v<T>
+    [[nodiscard]] inline std::optional<T> ParseFloat(char const* first, char const* last) noexcept
+    {
+        if (first == last)
+            return std::nullopt;
+#if defined(__cpp_lib_to_chars) && __cpp_lib_to_chars >= 201611L
+        // std::from_chars is locale-independent, allocation-free, and reports both partial parses (ptr) and
+        // range errors (ec) — the preferred path wherever the float overloads exist.
+        T value {};
+        auto const [ptr, ec] = std::from_chars(first, last, value);
+        if (ec != std::errc {} || ptr != last)
+            return std::nullopt;
+        return value;
+#else
+        // libc++ fallback: strtod_l with a persistent "C" locale gives locale-independent parsing; from_chars
+        // float overloads are unavailable here. Copy into a NUL-terminated buffer (the range need not be) and
+        // require the parse to consume all of it (mirrors the from_chars ptr==last check). On-stack for the
+        // common short numeric text; only the rare over-long token allocates.
+        static ::locale_t const cLocale = ::newlocale(LC_NUMERIC_MASK, "C", static_cast<::locale_t>(nullptr));
+        auto const length = static_cast<std::size_t>(last - first);
+        std::array<char, 64> stackBuffer {};
+        std::string heapBuffer;
+        char const* text = nullptr;
+        if (length < stackBuffer.size())
+        {
+            std::ranges::copy(first, last, stackBuffer.begin());
+            stackBuffer[length] = '\0';
+            text = stackBuffer.data();
+        }
+        else
+        {
+            heapBuffer.assign(first, last);
+            text = heapBuffer.c_str();
+        }
+
+        char* parseEnd = nullptr;
+        errno = 0;
+        T value {};
+        if constexpr (std::is_same_v<T, float>)
+            value = ::strtof_l(text, &parseEnd, cLocale);
+        else if constexpr (std::is_same_v<T, long double>)
+            value = ::strtold_l(text, &parseEnd, cLocale);
+        else
+            value = static_cast<T>(::strtod_l(text, &parseEnd, cLocale));
+
+        if (errno == ERANGE || parseEnd != text + length)
+            return std::nullopt;
+        return value;
+#endif
     }
 
     // is_specialization_of<> is inspired by:

--- a/src/tests/LargeTestDatabase/DataGenerator.cpp
+++ b/src/tests/LargeTestDatabase/DataGenerator.cpp
@@ -318,7 +318,7 @@ void PopulateDatabase(Light::DataMapper& dm,
     // 1. Create Users
     for (size_t i = 0; i < config.userCount; ++i)
     {
-        auto const userId = static_cast<int64_t>(i + 1);
+        auto const userId = static_cast<int64_t>(i) + 1;
         auto const firstNameStr = std::string(FirstNames[i % FirstNames.size()]);
         auto const lastNameStr = std::string(LastNames[(i / FirstNames.size()) % LastNames.size()]);
 
@@ -378,7 +378,7 @@ void PopulateDatabase(Light::DataMapper& dm,
 
     for (size_t i = 0; i < config.productCount; ++i)
     {
-        auto const categoryId = static_cast<uint64_t>((i % config.categoryCount) + 1);
+        auto const categoryId = static_cast<uint64_t>(i % config.categoryCount) + 1;
         auto const productName = rng.GenerateProductName(static_cast<int64_t>(i));
 
         // Create a minimal category record just to satisfy BelongsTo
@@ -433,7 +433,7 @@ void PopulateDatabase(Light::DataMapper& dm,
     for (size_t i = 0; i < config.productTagCount; ++i)
     {
         auto const productId = productIds[i % productIds.size()];
-        auto const tagId = static_cast<uint64_t>((i % config.tagCount) + 1);
+        auto const tagId = static_cast<uint64_t>(i % config.tagCount) + 1;
 
         LargeDb_Product prodRef;
         prodRef.id = productId;
@@ -455,7 +455,7 @@ void PopulateDatabase(Light::DataMapper& dm,
 
     for (size_t i = 0; i < config.orderCount; ++i)
     {
-        auto const userId = static_cast<uint64_t>((i % config.userCount) + 1);
+        auto const userId = static_cast<uint64_t>(i % config.userCount) + 1;
 
         LargeDb_User userRef;
         userRef.id = userId;
@@ -519,7 +519,7 @@ void PopulateDatabase(Light::DataMapper& dm,
     // 9. Create Reviews
     for (size_t i = 0; i < config.reviewCount; ++i)
     {
-        auto const userId = static_cast<uint64_t>((i % config.userCount) + 1);
+        auto const userId = static_cast<uint64_t>(i % config.userCount) + 1;
         auto const productId = productIds[i % productIds.size()];
 
         LargeDb_User userRef;
@@ -566,7 +566,7 @@ void PopulateDatabase(Light::DataMapper& dm,
         // Assign to a user (with some anonymous activities)
         if (rng.NextBool(0.9))
         {
-            auto const userId = static_cast<uint64_t>((i % config.userCount) + 1);
+            auto const userId = static_cast<uint64_t>(i % config.userCount) + 1;
             LargeDb_User userRef;
             userRef.id = userId;
             log.user = userRef;
@@ -597,7 +597,7 @@ void PopulateDatabase(Light::DataMapper& dm,
     // 12. Create Articles
     for (size_t i = 0; i < config.articleCount; ++i)
     {
-        auto const userId = static_cast<uint64_t>((i % config.userCount) + 1);
+        auto const userId = static_cast<uint64_t>(i % config.userCount) + 1;
 
         LargeDb_User userRef;
         userRef.id = userId;

--- a/src/tests/Utils.hpp
+++ b/src/tests/Utils.hpp
@@ -906,8 +906,8 @@ inline bool IsGithubActions()
     return getenv_s(&requiredCount, envBuffer, sizeof(envBuffer), "GITHUB_ACTIONS") == 0
            && std::string_view(envBuffer) == "true" == 0;
 #else
-    return std::getenv("GITHUB_ACTIONS") != nullptr
-           && std::string_view(std::getenv("GITHUB_ACTIONS")) == "true"; // NOLINT(clang-analyzer-core.NonNullParamChecker)
+    auto const* const githubActions = std::getenv("GITHUB_ACTIONS");
+    return githubActions != nullptr && std::string_view(githubActions) == "true";
 #endif
 }
 

--- a/src/tests/Utils.hpp
+++ b/src/tests/Utils.hpp
@@ -904,7 +904,7 @@ inline bool IsGithubActions()
     char envBuffer[32] {};
     size_t requiredCount = 0;
     return getenv_s(&requiredCount, envBuffer, sizeof(envBuffer), "GITHUB_ACTIONS") == 0
-           && std::string_view(envBuffer) == "true" == 0;
+           && std::string_view(envBuffer) == "true";
 #else
     auto const* const githubActions = std::getenv("GITHUB_ACTIONS");
     return githubActions != nullptr && std::string_view(githubActions) == "true";

--- a/src/tests/UtilsTests.cpp
+++ b/src/tests/UtilsTests.cpp
@@ -13,9 +13,12 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <chrono>
+#include <clocale>
 #include <filesystem>
 #include <format>
 #include <limits>
+#include <optional>
+#include <string_view>
 #include <type_traits>
 #include <variant>
 
@@ -765,4 +768,56 @@ TEST_CASE("SqlLogger::NullLogger swallows all events without writing", "[SqlLogg
     logger.SetLoggingSink();
     // The null logger ignores all events, even with a sink installed — it never calls into the sink.
     CHECK(captured.empty());
+}
+
+namespace
+{
+/// Convenience wrapper to call detail::ParseFloat on a string_view.
+template <typename T>
+std::optional<T> ParseFloatSv(std::string_view text)
+{
+    return Lightweight::detail::ParseFloat<T>(text.data(), text.data() + text.size());
+}
+} // namespace
+
+TEST_CASE("detail::ParseFloat parses valid finite values", "[Utils][ParseFloat]")
+{
+    CHECK(ParseFloatSv<double>("3.14") == 3.14);
+    CHECK(ParseFloatSv<double>("-2.5") == -2.5);
+    CHECK(ParseFloatSv<double>("0") == 0.0);
+    CHECK(ParseFloatSv<double>("42") == 42.0);
+    CHECK(ParseFloatSv<float>("1.5") == 1.5F);
+    CHECK(ParseFloatSv<double>("1e3") == 1000.0);
+}
+
+TEST_CASE("detail::ParseFloat rejects malformed and partial input", "[Utils][ParseFloat]")
+{
+    // Whole-token requirement: trailing garbage is rejected (mirrors std::from_chars' ptr==last check),
+    // unlike a bare std::strtod which would silently accept the leading numeric prefix.
+    CHECK(ParseFloatSv<double>("abc") == std::nullopt);
+    CHECK(ParseFloatSv<double>("12abc") == std::nullopt);
+    CHECK(ParseFloatSv<double>("") == std::nullopt);
+    CHECK(ParseFloatSv<double>("1.2.3") == std::nullopt);
+}
+
+TEST_CASE("detail::ParseFloat reports out-of-range values as failure", "[Utils][ParseFloat]")
+{
+    // A value that overflows the target type must NOT be silently turned into +inf; the helper reports
+    // failure so the caller can leave its value untouched.
+    CHECK(ParseFloatSv<double>("1e99999") == std::nullopt);
+    CHECK(ParseFloatSv<float>("1e99999") == std::nullopt);
+}
+
+TEST_CASE("detail::ParseFloat is locale-independent", "[Utils][ParseFloat]")
+{
+    // The decimal point is always '.', regardless of the active LC_NUMERIC. Try to switch to a
+    // comma-decimal locale; if it is installed on the host, parsing of "1.5" must still yield 1.5.
+    if (std::setlocale(LC_NUMERIC, "de_DE.UTF-8") != nullptr || std::setlocale(LC_NUMERIC, "de_DE") != nullptr)
+    {
+        CHECK(ParseFloatSv<double>("1.5") == 1.5);
+        CHECK(ParseFloatSv<double>("1234.5") == 1234.5);
+        std::setlocale(LC_NUMERIC, "C");
+    }
+    else
+        SUCCEED("comma-decimal locale not installed on this host; skipping");
 }

--- a/src/tools/dbtool/main.cpp
+++ b/src/tools/dbtool/main.cpp
@@ -10,11 +10,11 @@
 #include <Lightweight/SqlMigration.hpp>
 #include <Lightweight/SqlSchema.hpp>
 #include <Lightweight/SqlScopedLock.hpp>
+#include <Lightweight/Utils.hpp>
 
 #include <algorithm>
 #include <array>
 #include <cctype>
-#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <expected>
@@ -1756,14 +1756,13 @@ std::expected<std::size_t, std::string> ParseSizeWithSuffix(std::string_view siz
     if (numEnd == 0)
         return std::unexpected { std::format("Invalid size '{}': must start with a number", sizeStr) };
 
-    // strtod, not std::from_chars: the latter's float overloads are unavailable before macOS 26 in libc++.
-    // Copy to a NUL-terminated string; `end` must reach the string end (mirrors the from_chars ptr/ec check).
-    auto const numPart = std::string { sizeStr.substr(0, numEnd) };
-    char* end = nullptr;
-    errno = 0;
-    double const value = std::strtod(numPart.c_str(), &end);
-    if (end != numPart.c_str() + numPart.size() || errno == ERANGE)
+    // Locale-independent, error-reporting float parse (std::from_chars' float overloads are unavailable
+    // before macOS 26 in libc++); see Lightweight::detail::ParseFloat.
+    auto const numPart = sizeStr.substr(0, numEnd);
+    auto const parsed = Lightweight::detail::ParseFloat<double>(numPart.data(), numPart.data() + numPart.size());
+    if (!parsed)
         return std::unexpected { std::format("Invalid size '{}': invalid number", sizeStr) };
+    double const value = *parsed;
 
     // Parse suffix
     std::string suffix(sizeStr.substr(numEnd));

--- a/src/tools/dbtool/main.cpp
+++ b/src/tools/dbtool/main.cpp
@@ -14,7 +14,9 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cerrno>
 #include <cstdio>
+#include <cstdlib>
 #include <expected>
 #include <filesystem>
 #include <fstream>
@@ -1754,10 +1756,13 @@ std::expected<std::size_t, std::string> ParseSizeWithSuffix(std::string_view siz
     if (numEnd == 0)
         return std::unexpected { std::format("Invalid size '{}': must start with a number", sizeStr) };
 
-    double value = 0;
-    auto const numPart = sizeStr.substr(0, numEnd);
-    auto const [ptr, ec] = std::from_chars(numPart.data(), numPart.data() + numPart.size(), value);
-    if (ec != std::errc {} || ptr != numPart.data() + numPart.size())
+    // strtod, not std::from_chars: the latter's float overloads are unavailable before macOS 26 in libc++.
+    // Copy to a NUL-terminated string; `end` must reach the string end (mirrors the from_chars ptr/ec check).
+    auto const numPart = std::string { sizeStr.substr(0, numEnd) };
+    char* end = nullptr;
+    errno = 0;
+    double const value = std::strtod(numPart.c_str(), &end);
+    if (end != numPart.c_str() + numPart.size() || errno == ERANGE)
         return std::unexpected { std::format("Invalid size '{}': invalid number", sizeStr) };
 
     // Parse suffix


### PR DESCRIPTION
macOS was an officially supported dev platform (README + AGENT.md document the Homebrew setup) but had no CI coverage, so a batch of macOS-only breakages on the Homebrew-LLVM / libc++ toolchain went undetected. This PR fixes the build under libc++ and adds a CI job so it stays fixed. Every source change is feature-macro/`__APPLE__`-gated, libc++-specific, or a semantics-preserving refactor, so no other platform is affected; the full suite passes locally on macOS (Homebrew LLVM 22, arm64) with 1069 passed / 1 skipped.

## Changes

- **`SqlDateTime::NowUTC`** — guard `std::chrono::utc_clock` behind `__cpp_lib_chrono >= 201907L` (libc++ disables it when its time-zone database isn't built in) and fall back to `system_clock::now()`, which is already Unix time / UTC.
- **`SqlDynamicBinary`** — replace `std::basic_string_view<uint8_t>` (ill-formed on conforming libc++ — `std::char_traits` isn't specialised for `unsigned char`) with `std::span<value_type const>`; no external callers used the old form.
- **`SqlGuid::Create`** — use `uuid_generate_time` on `__APPLE__` (`uuid_generate_time_safe` is a libuuid/util-linux extension absent on macOS).
- **`Primitives.hpp`** — the `__APPLE__`-only `SqlDataBinder<std::size_t>` was missing one of the four `SqlSimpleDataBinder` template args; add `SQL_BIGINT`.
- **`CMakeLists.txt`** — only link `stdc++exp` (a libstdc++-specific `<stacktrace>`/`std::print` library) when it actually exists; the blanket "GNU or Clang" link failed under libc++ with `library 'stdc++exp' not found`. Probe with `check_cxx_source_compiles`.
- **`BasicStringBinder` / `StdOptional`** — compute the optional's contained-value offset via `std::uintptr_t` address subtraction instead of `byte*` pointer subtraction (UB across distinct objects; flagged by `clang-analyzer-security.PointerSub`).
- **`CxxModelPrinter`, `SqlMigration`, `DataGenerator`, `tests/Utils.hpp`** — fix the clang-tidy findings that only surface where libc++ lacks `std::views::enumerate` and compiles the fallback branches (qualified-auto, for-range-copy, unused-variable, sign-conversion, misplaced-widening-cast, missing-`[[nodiscard]]`, and a double `std::getenv` that tripped the nullability analyzer). Fixed at the source — no `NOLINT`.
- **`AGENT.md`** — document the one-time SQLite ODBC driver registration the default test connection string needs on macOS.
- **CI** — new standalone `macos` job (`macos-14`). Reuses the Darwin-capable `clang-debug` preset and disables clang-tidy + sanitizers + pedantic-werror via `-D` overrides (all already covered by the Linux jobs) rather than adding a new preset, and pins `llvm@22` (matching `CLANG_TOOLS_VERSION`) so libc++/C++23 behaviour matches local dev rather than the runner's AppleClang. GitHub's macOS runners can't run Docker, so only SQLite is tested here; MSSQL/PostgreSQL stay covered by the Linux/Windows matrices.