### PR TITLE
[SqlQuery] Remove unused SqlSelectQueryBuilder::Varying()

### DIFF
--- a/docs/sqlquery.md
+++ b/docs/sqlquery.md
@@ -163,8 +163,8 @@ interface. Here we present a compressed list of functions that can be used to cr
 > the wildcard. `Fields("*")` and `Fields({"*"})` quote the literal and produce
 > `SELECT "*" FROM ...`, which is not what you want.
 >
-> `Distinct()` and `Varying()` are exposed on the starter as state-preserving
-> overrides (they return `SqlSelectQueryStarter&`), so chains like
+> `Distinct()` is exposed on the starter as a state-preserving override (it
+> returns `SqlSelectQueryStarter&`), so chains like
 > `Select().Distinct().Fields(...).All()` keep working while
 > `Select().Distinct().All()` is still a compile error. `Where`, `OrderBy`,
 > `GroupBy`, and the join family (`InnerJoin`, `LeftOuterJoin`, etc.) are

--- a/src/Lightweight/Lightweight.cppm
+++ b/src/Lightweight/Lightweight.cppm
@@ -173,7 +173,6 @@ using Lightweight::SqlOutputColumnBinder;
 using Lightweight::SqlPrimaryKeyType;
 using Lightweight::SqlQualifiedTableColumnName;
 using Lightweight::SqlQueryBuilder;
-using Lightweight::SqlQueryBuilderMode;
 using Lightweight::SqlQueryExecutionMode;
 using Lightweight::SqlQueryFormatter;
 using Lightweight::SqlQueryObject;

--- a/src/Lightweight/SqlQuery/Select.cpp
+++ b/src/Lightweight/SqlQuery/Select.cpp
@@ -162,32 +162,20 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::Fields(std::span<SqlQualifiedTable
 SqlSelectQueryBuilder::ComposedQuery SqlSelectQueryBuilder::Count()
 {
     _query.selectType = SelectType::Count;
-
-    if (_mode == SqlQueryBuilderMode::Fluent)
-        return std::move(_query);
-    else
-        return _query;
+    return std::move(_query);
 }
 
 SqlSelectQueryBuilder::ComposedQuery SqlSelectQueryBuilder::All()
 {
     _query.selectType = SelectType::All;
-
-    if (_mode == SqlQueryBuilderMode::Fluent)
-        return std::move(_query);
-    else
-        return _query;
+    return std::move(_query);
 }
 
 SqlSelectQueryBuilder::ComposedQuery SqlSelectQueryBuilder::First(size_t count)
 {
     _query.selectType = SelectType::First;
     _query.limit = count;
-
-    if (_mode == SqlQueryBuilderMode::Fluent)
-        return std::move(_query);
-    else
-        return _query;
+    return std::move(_query);
 }
 
 SqlSelectQueryBuilder::ComposedQuery SqlSelectQueryBuilder::Range(std::size_t offset, std::size_t limit)
@@ -195,11 +183,7 @@ SqlSelectQueryBuilder::ComposedQuery SqlSelectQueryBuilder::Range(std::size_t of
     _query.selectType = SelectType::Range;
     _query.offset = offset;
     _query.limit = limit;
-
-    if (_mode == SqlQueryBuilderMode::Fluent)
-        return std::move(_query);
-    else
-        return _query;
+    return std::move(_query);
 }
 
 // ---- const overloads ---------------------------------------------------------

--- a/src/Lightweight/SqlQuery/Select.hpp
+++ b/src/Lightweight/SqlQuery/Select.hpp
@@ -14,12 +14,6 @@
 namespace Lightweight
 {
 
-enum class SqlQueryBuilderMode : uint8_t
-{
-    Fluent,
-    Varying
-};
-
 struct [[nodiscard]] SqlFieldExpression final
 {
     std::string expression;
@@ -110,13 +104,6 @@ class [[nodiscard]] SqlSelectQueryBuilder: public SqlBasicSelectQueryBuilder<Sql
         _query.searchCondition.tableName = std::move(table);
         _query.searchCondition.tableAlias = std::move(tableAlias);
         _query.fields.reserve(256);
-    }
-
-    /// Sets the builder mode to Varying, allowing varying final query types.
-    constexpr LIGHTWEIGHT_FORCE_INLINE SqlSelectQueryBuilder& Varying() noexcept
-    {
-        _mode = SqlQueryBuilderMode::Varying;
-        return *this;
     }
 
     /// Adds a sequence of columns to the SELECT clause.
@@ -256,7 +243,6 @@ class [[nodiscard]] SqlSelectQueryBuilder: public SqlBasicSelectQueryBuilder<Sql
 
   private:
     SqlQueryFormatter const& _formatter;
-    SqlQueryBuilderMode _mode = SqlQueryBuilderMode::Fluent;
     // mutable: see the note on _query in SqlBasicSelectQueryBuilder — the alias
     // flag is part of the projection accumulator, so it follows _query's policy.
     // Marked mutable so the const-qualified Field/Fields/As overloads above can
@@ -348,9 +334,9 @@ namespace detail
 ///   - @c Count is intentionally not overridden — `SELECT COUNT(*) FROM ...`
 ///     is well-formed without an explicit column list, so the inherited
 ///     @c Count remains directly callable.
-///   - @c Distinct and @c Varying are overridden via deducing this so they
-///     return @c Self&& and the starter identity survives them. That keeps
-///     the gate intact for `Select().Distinct().All()` while still allowing
+///   - @c Distinct is overridden via deducing this so it returns @c Self&& and
+///     the starter identity survives it. That keeps the gate intact for
+///     `Select().Distinct().All()` while still allowing
 ///     `Select().Distinct().Fields(...).All()`.
 ///
 /// Methods that conceptually follow the column list (@c Where, @c OrderBy,
@@ -431,14 +417,6 @@ class [[nodiscard]] SqlSelectQueryStarter final: public SqlSelectQueryBuilder
     LIGHTWEIGHT_FORCE_INLINE auto&& Distinct(this Self&& self) noexcept
     {
         self.SqlSelectQueryBuilder::Distinct();
-        return std::forward<Self>(self);
-    }
-
-    /// State-preserving override; see @ref Distinct.
-    template <typename Self>
-    LIGHTWEIGHT_FORCE_INLINE auto&& Varying(this Self&& self) noexcept
-    {
-        self.SqlSelectQueryBuilder::Varying();
         return std::forward<Self>(self);
     }
 };

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -990,26 +990,6 @@ TEST_CASE_METHOD(SqlTestFixture, "Where: left IS NULL", "[SqlQueryBuilder]")
                                   WHERE "Left1" IS NOT NULL OR "Left2" IS NOT NULL)"));
 }
 
-TEST_CASE_METHOD(SqlTestFixture, "Varying: multiple varying final query types", "[SqlQueryBuilder]")
-{
-    auto const& sqliteFormatter = SqlQueryFormatter::Sqlite();
-
-    auto queryBuilder = SqlQueryBuilder { sqliteFormatter }
-                            .FromTable("Table")
-                            .Select()
-                            .Varying()
-                            .Fields({ "foo", "bar", "baz" })
-                            .Where("condition", 42);
-
-    auto const countQuery = EraseLinefeeds(queryBuilder.Count().ToSql());
-    auto const allQuery = EraseLinefeeds(queryBuilder.All().ToSql());
-    auto const firstQuery = EraseLinefeeds(queryBuilder.First().ToSql());
-
-    CHECK(countQuery == R"(SELECT COUNT(*) FROM "Table" WHERE "condition" = 42)");
-    CHECK(allQuery == R"(SELECT "foo", "bar", "baz" FROM "Table" WHERE "condition" = 42)");
-    CHECK(firstQuery == R"(SELECT "foo", "bar", "baz" FROM "Table" WHERE "condition" = 42 LIMIT 1)");
-}
-
 TEST_CASE_METHOD(SqlTestFixture, "Use SqlQueryBuilder for SqlStatement.ExecuteDirct", "[SqlQueryBuilder]")
 {
     auto stmt = SqlStatement {};


### PR DESCRIPTION
Closes #495.

## Summary
`Varying()` flipped the SELECT builder into a mode where the finalizers (`Count`/`All`/`First`/`Range`) returned a *copy* of the internal query instead of moving it out, so a single builder could be finalized into multiple query types. The default "Fluent" mode moves. Per #495 this feature is unused and unneeded, so it is removed.

## Changes
- **`SqlQuery/Select.hpp`** — removed the `SqlQueryBuilderMode` enum, the `Varying()` method, the `_mode` member, and the `Varying()` deducing-this override on `SqlSelectQueryStarter`; updated the gate doc comment to reference only `Distinct`.
- **`SqlQuery/Select.cpp`** — the four finalizers now unconditionally `std::move(_query)` (the former Fluent path; the `if (_mode == ...)` branches are gone).
- **`Lightweight.cppm`** — dropped the `SqlQueryBuilderMode` re-export.
- **`docs/sqlquery.md`** — removed `Varying()` from the starter documentation.
- **`tests/QueryBuilderTests.cpp`** — removed the now-obsolete "Varying" test case.

## Risk assessment
- **API**: breaking change for any external caller using `Varying()` / `SqlQueryBuilderMode` — appropriate for the issue's intent.
- **Behavior**: no change for existing default (Fluent) usage. Const finalizer overloads are unaffected (a truly-const builder always had Fluent mode, since `Varying()` was non-const).
- **Per-DBMS**: none — the change is purely about C++ move-vs-copy of the builder object and touches no DBMS-specific SQL generation.
- **Performance**: removes one per-finalize branch; negligible.

## Databases tested
- `sqlite3` — full suite green (1173 passed, 1 skipped).
- `mssql2022` (Docker, 16.00.4250) — full suite green (1171 passed, 3 skipped).
- `postgres` — **skipped**: no PostgreSQL ODBC driver available in this environment. Low risk given the change is database-agnostic.

Built with the `clang-debug` preset (PEDANTIC + ASan/UBSan + clang-tidy), no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)