### PR TITLE
[SqlQuery] Remove unused WhereColumn()

### DIFF
--- a/src/Lightweight/SqlQuery/Core.hpp
+++ b/src/Lightweight/SqlQuery/Core.hpp
@@ -306,10 +306,6 @@ class [[nodiscard]] SqlWhereClauseBuilder
     template <typename ColumnName>
     [[nodiscard]] Derived& WhereFalse(ColumnName const& columnName);
 
-    /// Construts or extends a WHERE clause to test for a binary operation between two columns.
-    template <typename LeftColumn, typename RightColumn>
-    [[nodiscard]] Derived& WhereColumn(LeftColumn const& left, std::string_view binaryOp, RightColumn const& right);
-
     /// Constructs an INNER JOIN clause.
     ///
     /// @param joinTable The table's name to join with. This can be a string, a string_view, or an AliasedTableName.
@@ -756,24 +752,6 @@ template <typename ColumnName>
 inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlWhereClauseBuilder<Derived>::WhereFalse(ColumnName const& columnName)
 {
     return Where(columnName, "=", false);
-}
-
-/// Constructs or extends a WHERE clause to compare two columns.
-template <typename Derived>
-template <typename LeftColumn, typename RightColumn>
-inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlWhereClauseBuilder<Derived>::WhereColumn(LeftColumn const& left,
-                                                                                     std::string_view binaryOp,
-                                                                                     RightColumn const& right)
-{
-    AppendWhereJunctor();
-
-    AppendColumnName(left);
-    SearchCondition().condition += ' ';
-    SearchCondition().condition += binaryOp;
-    SearchCondition().condition += ' ';
-    AppendColumnName(right);
-
-    return static_cast<Derived&>(*this);
 }
 
 template <typename T>

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -933,16 +933,6 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.Lambda", "[SqlQueryBuild
                                   WHERE "a" = 1 OR ("b" = 2 AND "c" = 3))"));
 }
 
-TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereColumn", "[SqlQueryBuilder]")
-{
-    CheckSqlQueryBuilder(
-        [](SqlQueryBuilder& q) {
-            return q.FromTable("That").Select().Field("foo").WhereColumn("left", "=", "right").All();
-        },
-        QueryExpectations::All(R"(SELECT "foo" FROM "That"
-                                  WHERE "left" = "right")"));
-}
-
 TEST_CASE_METHOD(SqlTestFixture,
                  "Where: SqlQualifiedTableColumnName OP SqlQualifiedTableColumnName",
                  "[SqlQueryBuilder]")


### PR DESCRIPTION
Closes #494.

## Summary
`WhereColumn(left, op, right)` constructed a column-to-column comparison from two unqualified column names (e.g. `WhereColumn("left", "=", "right")` → `WHERE "left" = "right"`). Per #494 it is unused and unneeded — the same column-vs-column comparison is already expressible through the existing `Where(col, op, col)` overload (e.g. with `SqlQualifiedTableColumnName` operands, covered by the *"Where: SqlQualifiedTableColumnName OP SqlQualifiedTableColumnName"* test).

## Changes
- **`SqlQuery/Core.hpp`** — removed the `WhereColumn` declaration and its out-of-line definition from `SqlWhereClauseBuilder<Derived>`.
- **`tests/QueryBuilderTests.cpp`** — removed the obsolete `SqlQueryBuilder.WhereColumn` test case.

No documentation referenced `WhereColumn`, and there were no internal callers (the unrelated `IsBatchUpdateWhereColumn` trait in `DataMapper.hpp` is a different identifier and is untouched).

## Risk assessment
- **API**: breaking change for any external caller using `WhereColumn` — appropriate for the issue's intent. Migration: use `Where(left, op, right)` with `SqlQualifiedTableColumnName` operands for column-vs-column comparisons.
- **Behavior**: no change to any other query-building path.
- **Per-DBMS**: none — pure DSL surface removal, no SQL-generation differences.
- **Performance**: none.

## Databases tested
- `sqlite3` — `[SqlQueryBuilder]` green (395 assertions / 76 cases); full suite green (1196 passed, 1 skipped).
- `mssql2022` (Docker, 16.00.4250) — `[SqlQueryBuilder]` green (396 assertions / 76 cases).
- `postgres` — **skipped**: no PostgreSQL ODBC driver available in this environment. Low risk given the change is database-agnostic.

Built via the `gcc-release` preset. Note: the `clang-debug` preset (clang-tidy + `-Werror`) currently fails on pre-existing findings in `master`'s recently-merged prefetch / ALTER-COLUMN commits (`SqlStatement.hpp`, `DataMapper.hpp`) that are unrelated to and untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)