### PR TITLE
Fix dbtool-gui Windows launch failure from malformed Qt manifest

### DIFF
--- a/src/tools/dbtool-gui/CMakeLists.txt
+++ b/src/tools/dbtool-gui/CMakeLists.txt
@@ -133,6 +133,15 @@ qt_add_executable(dbtool-gui
     main.cpp
 )
 
+# Windows: supply our own application manifest instead of the one Qt's
+# `qt_add_executable` auto-generates. Qt 6.11.x emits `requestedExecutionLevel`
+# under a prefixed `asm.v2` namespace, which the Windows activation-context
+# loader rejects ("side-by-side configuration is incorrect"). Handing the
+# linker a valid manifest overrides Qt's broken default. No-op elsewhere.
+if(WIN32)
+    target_sources(dbtool-gui PRIVATE dbtool-gui.manifest)
+endif()
+
 target_link_libraries(dbtool-gui PRIVATE
     dbtool-gui-lib
     dbtool-gui-libplugin

--- a/src/tools/dbtool-gui/dbtool-gui.manifest
+++ b/src/tools/dbtool-gui/dbtool-gui.manifest
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Application manifest for dbtool-gui.
+
+  This file exists to override the manifest that Qt's `qt_add_executable`
+  generates automatically. Qt 6.11.x emits the `requestedExecutionLevel`
+  element under a *prefixed* `asm.v2` namespace (`ms_asmv2:level=...`), which
+  the Windows activation-context loader rejects with:
+
+      "The required attribute level is missing from element
+       requestedExecutionLevel."
+
+  The visible symptom is a launch failure: "The application has failed to
+  start because its side-by-side configuration is incorrect." The DLLs are
+  fine; the manifest is malformed. Supplying our own valid manifest (plain,
+  unprefixed `level` attribute) restores a launchable binary and is immune to
+  the upstream Qt regression.
+-->
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 / 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <ws2:longPathAware>true</ws2:longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
## Summary

- `dbtool-gui.exe` fails to start on Windows with *"the application has failed to start because its side-by-side configuration is incorrect."*
- **Root cause (not a missing DLL):** Qt 6.11.x's auto-generated application manifest (from `qt_add_executable`) declares the `trustInfo`/`requestedPrivileges` block with nested `asm.v2`/`asm.v3` namespaces. After the linker merges manifests, the `requestedExecutionLevel` element ends up with a *namespace-prefixed* `ms_asmv2:level` attribute instead of a plain `level`. The Windows activation-context loader rejects this — the event log reports *"The required attribute `level` is missing from element `requestedExecutionLevel`"* — and the process cannot start. All runtime DLLs are present and correct; only the manifest is malformed. This is an upstream Qt regression, not project code.
- **Fix:** Add a hand-authored `src/tools/dbtool-gui/dbtool-gui.manifest` with a clean, flat structure and a plain `level="asInvoker"` attribute, and attach it to the target under `if(WIN32)` via `target_sources`. Qt's `_qt_internal_finalize_windows_app` explicitly skips its own manifest generation when the target already carries a `*.manifest` source (see `QtPublicWindowsHelpers.cmake`), so this is the supported override hook and is immune to the upstream bug. No-op on macOS/Linux.

## Testing

- Rebuilt `dbtool-gui` with the `clangcl-release` preset; extracted the embedded manifest with `mt.exe` and confirmed it now contains `<requestedExecutionLevel level="asInvoker" uiAccess="false"/>` — no `ms_asmv2:` prefix.
- Re-ran `cmake --install`; verified the installed `out\install\clangcl-release\bin\dbtool-gui.exe` carries the corrected manifest.
- Launched the installed binary: it now starts and runs cleanly, and no new SideBySide error is logged in the Windows Application event log. Before the fix it failed instantly.

## Manual test checklist

- [ ] Confirm `dbtool-gui.exe` launches from a fresh `clangcl-release` install on a clean Windows machine.
- [ ] (Optional, follow-up) The Qt manifest warning still fires for the `dbtool-gui-tests` / `dbtool-gui-qmltest` targets, which retain Qt's default manifest. If those also fail to launch, the same manifest can be applied to them — out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)