### PR TITLE
Fix PostgreSQL auto-increment keys silently narrowing to 32-bit

### DIFF
--- a/.agent/databases.md
+++ b/.agent/databases.md
@@ -37,6 +37,7 @@ Lightweight is exercised against three databases in CI (`.github/workflows/build
   - **Newline translation**: `psqlODBC` defaults to LF↔CRLF translation. The project's test connection strings disable it explicitly (commit `f311cb9f`); preserve that in any new test-env entry, or character-data round-trips with embedded newlines will silently mutate.
   - **Unicode round-trip**: `SQL_C_WCHAR` (UTF-16) is the binding type that round-trips reliably across all DataBinder paths (commit `894c67c7`); avoid `SQL_C_CHAR` for non-ASCII strings unless you've validated the driver actually transcodes.
   - `SERIAL` columns: detect via `nextval(` in the captured default value (see `PostgreSqlFormatter::BuildColumnDefinition`); restored backups carry the sequence default rather than `AUTO_INCREMENT`.
+  - Serial width follows the declared type (`PostgreSqlFormatter::SerialColumnType`): `Bigint` → `BIGSERIAL`, `Integer` → `SERIAL`, `Smallint`/`Tinyint` → `SMALLSERIAL`. PostgreSQL derives the underlying integer width from the serial spelling, so a hard-coded `SERIAL` silently caps a 64-bit key at 2^31-1 (issue #521).
   - Identifier quoting uses `"`. Folding to lowercase happens for unquoted identifiers — the formatter quotes everything to keep behaviour consistent.
   - `SELECT lastval();` retrieves the last inserted id (formatter override). Race-prone if multiple clients insert into different sequences simultaneously — call it inside the same session right after the insert.
 

--- a/docs/dbtool.md
+++ b/docs/dbtool.md
@@ -510,10 +510,26 @@ dbtool restore --input backup.zip --jobs 4
 
 ### Checksum Mismatches
 
-If `dbtool status` reports checksum mismatches:
-- A migration was modified after it was applied
-- This may indicate the database schema is out of sync with the code
-- Review the changes and consider creating a new migration instead
+If `dbtool status` reports checksum mismatches, there are two quite different causes — check the
+second one first, because it is benign and easy to mistake for the first.
+
+**1. You upgraded Lightweight and the generated SQL changed.** The checksum is computed over the SQL
+text that the *formatter* renders for a migration, not over your C++ source. So a library release that
+changes emitted DDL re-hashes every already-applied migration that uses the affected construct, even
+though nobody touched the migration. Example: the PostgreSQL formatter now emits `BIGSERIAL` instead of
+`SERIAL` for a `Bigint` auto-increment key, so every PostgreSQL migration using
+`PrimaryKeyWithAutoIncrement` reports a mismatch after upgrading past that change. Nothing is out of
+sync and nothing
+breaks — mismatches are reported, not enforced. Confirm the mismatching migrations are exactly the ones
+touched by the release, then re-baseline:
+
+```bash
+dbtool rewrite-checksums          # rewrites schema_migrations.checksum to match current code
+```
+
+**2. A migration really was modified after it was applied.** Then the database schema may genuinely be
+out of sync with the code. Review the change and create a new migration instead of editing the old one;
+do **not** run `rewrite-checksums`, which would erase the evidence.
 
 ### Lock Acquisition Failed
 

--- a/docs/sqlquery.md
+++ b/docs/sqlquery.md
@@ -13,6 +13,10 @@ Available functions:
   - `PrimaryKeyWithAutoIncrement( std::string columnName, SqlColumnTypeDefinition columnType )`
     + create primary key column in the database with automatic indexing 
     + Second parameter has a default value `SqlColumnTypeDefinitions::Bigint`
+    + The declared integer width is preserved per DBMS: SQL Server emits `<type> IDENTITY(1,1)` and
+      PostgreSQL emits the matching serial pseudo-type (`Bigint` → `BIGSERIAL`, `Integer` → `SERIAL`,
+      `Smallint`/`Tinyint` → `SMALLSERIAL`). SQLite is the exception — `AUTOINCREMENT` is only valid on
+      an `INTEGER PRIMARY KEY`, which is a 64-bit rowid alias there, so the column is always `INTEGER`.
   - `Column(std::string columnName, SqlColumnTypeDefinition columnType)`, `Column(SqlColumnDeclaration column)`
     + create a column specified by a name and type
     + for precise control on the column specification `SqlColumnDeclaration` can be used as an argument. 

--- a/docs/sqlquery.md
+++ b/docs/sqlquery.md
@@ -17,6 +17,12 @@ Available functions:
       PostgreSQL emits the matching serial pseudo-type (`Bigint` → `BIGSERIAL`, `Integer` → `SERIAL`,
       `Smallint`/`Tinyint` → `SMALLSERIAL`). SQLite is the exception — `AUTOINCREMENT` is only valid on
       an `INTEGER PRIMARY KEY`, which is a 64-bit rowid alias there, so the column is always `INTEGER`.
+    + Because the width now follows the declaration, a narrow declared type buys a narrow key space:
+      `Smallint`/`Tinyint` cap at 32767 rows on both PostgreSQL (`smallserial`) and SQL Server
+      (`SMALLINT IDENTITY`). Declare `Bigint` (the default) unless you specifically want that limit.
+    + Upgrading to a Lightweight version that changes the emitted DDL text also changes the checksum
+      stored for migrations that were already applied — see
+      [dbtool: Checksum Mismatches](dbtool.md#checksum-mismatches).
   - `Column(std::string columnName, SqlColumnTypeDefinition columnType)`, `Column(SqlColumnDeclaration column)`
     + create a column specified by a name and type
     + for precise control on the column specification `SqlColumnDeclaration` can be used as an argument. 

--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -790,7 +790,7 @@ namespace detail
     }
 
     template <typename Record, std::size_t... Is>
-    constexpr bool CanRowWiseFetchRecordImpl(std::index_sequence<Is...>)
+    constexpr bool CanRowWiseFetchRecordImpl(std::index_sequence<Is...> /*indices*/)
     {
         // The row-strided indicator slots are addressed at i * sizeof(Record); they must stay SQLLEN
         // aligned, so sizeof(Record) must be a multiple of alignof(SQLLEN) (mirrors the write-side
@@ -855,7 +855,7 @@ namespace detail
     }
 
     template <typename Record, std::size_t... Is>
-    constexpr bool RecordHasNarrowFixedStringColumnImpl(std::index_sequence<Is...>)
+    constexpr bool RecordHasNarrowFixedStringColumnImpl(std::index_sequence<Is...> /*indices*/)
     {
         return (ColumnIsNarrowFixedString<RecordMemberTypeOf<Is, Record>>() || ...);
     }
@@ -899,7 +899,8 @@ namespace detail
     };
 
     template <typename First, typename Second, std::size_t... Fs, std::size_t... Ss>
-    constexpr bool CanRowWiseFetchTupleImpl(std::index_sequence<Fs...>, std::index_sequence<Ss...>)
+    constexpr bool CanRowWiseFetchTupleImpl(std::index_sequence<Fs...> /*firstIndices*/,
+                                            std::index_sequence<Ss...> /*secondIndices*/)
     {
         return (sizeof(std::tuple<First, Second>) % alignof(SQLLEN) == 0)
                && (RowWiseColumnAcceptable<RecordMemberTypeOf<Fs, First>>() && ...)

--- a/src/Lightweight/QueryFormatter/PostgreSqlFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/PostgreSqlFormatter.hpp
@@ -112,6 +112,14 @@ class PostgreSqlFormatter final: public SQLiteQueryFormatter
     /// a 32-bit `integer` column that caps at 2^31-1 and no longer matches `BIGINT` foreign keys
     /// referencing it.
     ///
+    /// @note `Smallint` and `Tinyint` map onto `SMALLSERIAL`, whose underlying `smallint` caps at
+    ///       32767 — declaring a narrow auto-increment key buys a correspondingly narrow key space.
+    /// @note A declared type with no integer equivalent at all (`Guid`, `Varchar`, `Decimal`, ...)
+    ///       falls through to `SERIAL`, i.e. it is silently coerced to a 32-bit integer column.
+    ///       PostgreSQL accepts that DDL, so the mismatch only surfaces later when reading the
+    ///       column back into the declared C++ type. Auto-increment is only meaningful on an
+    ///       integer key; prefer rejecting such records at the call site.
+    ///
     /// @param type The declared column type.
     /// @return The serial pseudo-type to emit; `SERIAL` for any type without a narrower or wider
     ///         serial equivalent.

--- a/src/Lightweight/QueryFormatter/PostgreSqlFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/PostgreSqlFormatter.hpp
@@ -83,7 +83,7 @@ class PostgreSqlFormatter final: public SQLiteQueryFormatter
         bool const isAutoIncrement = column.primaryKey == SqlPrimaryKeyType::AUTO_INCREMENT || isAutoIncrementViaDefault;
 
         if (isAutoIncrement)
-            sqlQueryString << "SERIAL";
+            sqlQueryString << SerialColumnType(column.type);
         else
             sqlQueryString << ColumnType(column.type);
 
@@ -103,6 +103,31 @@ class PostgreSqlFormatter final: public SQLiteQueryFormatter
             sqlQueryString << " DEFAULT " << column.defaultValue;
 
         return sqlQueryString.str();
+    }
+
+    /// Maps a declared integer column type onto the matching PostgreSQL auto-increment pseudo-type.
+    ///
+    /// PostgreSQL picks the underlying integer width from the serial spelling, so the width must
+    /// follow the declared type. Emitting a plain `SERIAL` for a `Bigint` key would silently create
+    /// a 32-bit `integer` column that caps at 2^31-1 and no longer matches `BIGINT` foreign keys
+    /// referencing it.
+    ///
+    /// @param type The declared column type.
+    /// @return The serial pseudo-type to emit; `SERIAL` for any type without a narrower or wider
+    ///         serial equivalent.
+    [[nodiscard]] static std::string_view SerialColumnType(SqlColumnTypeDefinition const& type)
+    {
+        using namespace SqlColumnTypeDefinitions;
+
+        return std::visit(detail::overloaded {
+                              [](Bigint const&) -> std::string_view { return "BIGSERIAL"; },
+                              [](Smallint const&) -> std::string_view { return "SMALLSERIAL"; },
+                              // NB: PostgreSQL has no 1-byte integer type, so the narrowest
+                              // available serial is used here, matching ColumnType(Tinyint).
+                              [](Tinyint const&) -> std::string_view { return "SMALLSERIAL"; },
+                              [](auto const&) -> std::string_view { return "SERIAL"; },
+                          },
+                          type);
     }
 
     [[nodiscard]] std::string ColumnType(SqlColumnTypeDefinition const& type) const override

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -1481,7 +1481,7 @@ SQLLEN* SqlStatement::BindRowWiseOutputColumn(SQLUSMALLINT column, void* base0, 
 
     if constexpr (SqlIsStdOptional<ValueType>)
     {
-        using Inner = typename ValueType::value_type;
+        using Inner = ValueType::value_type;
         auto* const optBytes = static_cast<std::byte*>(base0);
         // Pre-engage every row's optional so its contained storage is valid to bind into; rows that come
         // back NULL are reset to std::nullopt in FinalizeRowWiseOutputColumn.
@@ -1511,7 +1511,7 @@ void SqlStatement::FinalizeRowWiseOutputColumn(void* base0,
 
     if constexpr (SqlIsStdOptional<ValueType>)
     {
-        using Inner = typename ValueType::value_type;
+        using Inner = ValueType::value_type;
         auto* const optBytes = static_cast<std::byte*>(base0);
         for (auto const i: std::views::iota(std::size_t { 0 }, rowCount))
         {
@@ -1519,8 +1519,14 @@ void SqlStatement::FinalizeRowWiseOutputColumn(void* base0,
             if (indicatorAt(i) == SQL_NULL_DATA)
                 optional->reset();
             else if constexpr (IsSqlFixedString<Inner>)
+            {
                 // Engaged char fixed string: set its length and trim, matching the single-row binder.
-                SqlBasicStringOperations<Inner>::PostProcessOutputColumn(std::addressof(**optional), indicatorAt(i));
+                // BindRowWiseOutputColumn pre-engages every row and only the NULL branch above ever
+                // disengages one, so this holds unconditionally — tested anyway to keep the access
+                // provably safe rather than invariant-dependent.
+                if (optional->has_value())
+                    SqlBasicStringOperations<Inner>::PostProcessOutputColumn(std::addressof(**optional), indicatorAt(i));
+            }
             // Engaged fixed-width inner: already materialized in place, nothing more to do.
         }
     }

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -1325,8 +1325,10 @@ TEST_CASE_METHOD(SqlTestFixture, "CreateTable with PrimaryKeyWithAutoIncrement",
                                 "pk" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT
                             );
                            )sql",
+            // PrimaryKeyWithAutoIncrement defaults to Bigint, so PostgreSQL must emit the 64-bit
+            // BIGSERIAL — plain SERIAL would silently cap the key at 2^31-1 (issue #521).
             .postgres = R"sql(CREATE TABLE "Test" (
-                                "pk" SERIAL NOT NULL PRIMARY KEY
+                                "pk" BIGSERIAL NOT NULL PRIMARY KEY
                             );
                            )sql",
             .sqlServer = R"sql(CREATE TABLE "Test" (
@@ -1334,6 +1336,65 @@ TEST_CASE_METHOD(SqlTestFixture, "CreateTable with PrimaryKeyWithAutoIncrement",
                             );
                            )sql",
         });
+}
+
+TEST_CASE_METHOD(SqlTestFixture,
+                 "CreateTable with PrimaryKeyWithAutoIncrement honours the declared integer width",
+                 "[SqlQueryBuilder][Migration]")
+{
+    using namespace SqlColumnTypeDefinitions;
+
+    // The auto-increment column type must track the declared C++ field width on every DBMS.
+    // SQLite is the documented exception: AUTOINCREMENT is only valid on an INTEGER PRIMARY KEY,
+    // which is a 64-bit rowid alias there anyway.
+    auto const check =
+        [](SqlColumnTypeDefinition columnType, std::string_view postgresType, std::string_view sqlServerType) {
+            auto const postgres = std::format(R"sql(CREATE TABLE "Test" (
+                                                        "pk" {} NOT NULL PRIMARY KEY
+                                                    );
+                                              )sql",
+                                              postgresType);
+            auto const sqlServer = std::format(R"sql(CREATE TABLE "Test" (
+                                                         "pk" {} NOT NULL IDENTITY(1,1) PRIMARY KEY
+                                                     );
+                                               )sql",
+                                               sqlServerType);
+            CheckSqlQueryBuilder(
+                [columnType](SqlQueryBuilder& q) {
+                    auto migration = q.Migration();
+                    migration.CreateTable("Test").PrimaryKeyWithAutoIncrement("pk", columnType);
+                    return migration.GetPlan();
+                },
+                QueryExpectations {
+                    .sqlite = R"sql(CREATE TABLE "Test" (
+                                        "pk" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT
+                                    );
+                                   )sql",
+                    .postgres = postgres,
+                    .sqlServer = sqlServer,
+                });
+        };
+
+    SECTION("Bigint")
+    {
+        check(Bigint {}, "BIGSERIAL", "BIGINT");
+    }
+
+    SECTION("Integer")
+    {
+        check(Integer {}, "SERIAL", "INTEGER");
+    }
+
+    SECTION("Smallint")
+    {
+        check(Smallint {}, "SMALLSERIAL", "SMALLINT");
+    }
+
+    SECTION("Tinyint")
+    {
+        // PostgreSQL has no 1-byte integer type; SMALLSERIAL is the narrowest serial available.
+        check(Tinyint {}, "SMALLSERIAL", "TINYINT");
+    }
 }
 
 TEST_CASE_METHOD(SqlTestFixture, "CreateTable with Index", "[SqlQueryBuilder][Migration]")
@@ -1410,7 +1471,7 @@ TEST_CASE_METHOD(SqlTestFixture, "CreateTable complex demo", "[SqlQueryBuilder][
                 )sql",
             .postgres = R"sql(
                     CREATE TABLE "Test" (
-                        "a" SERIAL NOT NULL PRIMARY KEY,
+                        "a" BIGSERIAL NOT NULL PRIMARY KEY,
                         "b" VARCHAR(32) NOT NULL UNIQUE,
                         "c" TIMESTAMP,
                         "d" VARCHAR(255)

--- a/src/tests/SqlBackup/EncodingRoundTripTests.cpp
+++ b/src/tests/SqlBackup/EncodingRoundTripTests.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include "../Utils.hpp"
 #include "TestHelpers.hpp"
 
 #include <Lightweight/SqlBackup.hpp>
@@ -50,7 +51,13 @@ std::u16string const WideValue = u"Grüße — café 😀"; // U+1F600 is a surr
 //   - ASCII text in a narrow Varchar column,
 //   - non-ASCII / code-page bytes in a narrow Varchar column (byte-exact), and
 //   - Unicode (incl. a supplementary-plane code point) in a wide NVarchar column.
-TEST_CASE("SqlBackup: round-trip preserves ASCII / code-page / Unicode text", "[SqlBackup][Encoding]")
+// Derives from SqlTestFixture so the database contains nothing but this test's own table: Backup()
+// captures the *whole* database, and the fixture drops every table in its constructor. Without it
+// the backup also picks up whatever tables previously-run tests left behind — including ones that
+// deliberately hold values wider than their declared column width (legal on SQLite/PostgreSQL,
+// which use character semantics), which RowArrayCursor rejects when the driver-reported column size
+// is smaller than the stored value.
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: round-trip preserves ASCII / code-page / Unicode text", "[SqlBackup][Encoding]")
 {
     using namespace SqlColumnTypeDefinitions;
 

--- a/src/tests/SqlSchemaDbTests.cpp
+++ b/src/tests/SqlSchemaDbTests.cpp
@@ -182,6 +182,87 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlSchema::MakeCreateTablePlan (TableList) pro
 }
 
 // ================================================================================================
+// Auto-increment primary keys must keep the integer width the record declared.
+//
+// Regression guard for issue #521: the PostgreSQL formatter used to emit a hard-coded SERIAL
+// (32-bit) for every auto-increment column, so a Field<int64_t, PrimaryKey::ServerSideAutoIncrement>
+// silently became an `integer` column. The SQL-generation tests could not catch that on their own
+// because they asserted the generated text; this one reads the type back out of the live catalog.
+// ================================================================================================
+
+namespace
+{
+
+/// Reads the live type of a single column back from the database catalog.
+SqlColumnTypeDefinition LiveColumnType(SqlStatement& stmt, std::string_view tableName, std::string_view columnName)
+{
+    auto const tables = SqlSchema::ReadAllTables(stmt, stmt.Connection().DatabaseName(), /*schema=*/"");
+    auto const table = std::ranges::find_if(tables, [&](SqlSchema::Table const& t) { return t.name == tableName; });
+    REQUIRE(table != tables.end());
+
+    auto const column =
+        std::ranges::find_if(table->columns, [&](SqlSchema::Column const& c) { return c.name == columnName; });
+    REQUIRE(column != table->columns.end());
+    CHECK(column->isPrimaryKey);
+    return column->type;
+}
+
+/// Asserts the live column type is the 64-bit integer the caller declared.
+///
+/// SQLite is the one exception: AUTOINCREMENT is only valid on an INTEGER PRIMARY KEY, which is a
+/// 64-bit rowid alias there, so the narrower-looking type name carries no loss of range.
+void CheckIsSixtyFourBitKey(SqlServerType serverType, SqlColumnTypeDefinition const& type)
+{
+    using namespace SqlColumnTypeDefinitions;
+
+    if (serverType == SqlServerType::SQLITE)
+        CHECK(std::holds_alternative<Integer>(type));
+    else
+        CHECK(std::holds_alternative<Bigint>(type));
+}
+
+} // namespace
+
+// NB: Reflected record types must have external linkage, so this one cannot live in the anonymous
+// namespace above.
+struct WideKeyedRecord
+{
+    static constexpr std::string_view TableName = "WideKeyed";
+
+    Field<int64_t, PrimaryKey::ServerSideAutoIncrement> id;
+    Field<SqlAnsiString<32>> name;
+};
+
+TEST_CASE_METHOD(SqlTestFixture,
+                 "SqlSchema: auto-increment primary key keeps its declared integer width",
+                 "[SqlSchema][Migration]")
+{
+    using namespace SqlColumnTypeDefinitions;
+
+    auto stmt = SqlStatement {};
+    stmt.MigrateDirect([](auto& migration) {
+        migration.CreateTable("WideKeyed")
+            .PrimaryKeyWithAutoIncrement("id", Bigint {})
+            .RequiredColumn("name", Varchar { 32 });
+    });
+
+    CheckIsSixtyFourBitKey(stmt.Connection().ServerType(), LiveColumnType(stmt, "WideKeyed", "id"));
+}
+
+TEST_CASE_METHOD(SqlTestFixture,
+                 "SqlSchema: DataMapper-created auto-increment primary key keeps its declared integer width",
+                 "[SqlSchema][DataMapper][Migration]")
+{
+    // The reproduction from issue #521: the record declares a 64-bit key, so the created column
+    // must be 64-bit wide as well.
+    auto dm = DataMapper {};
+    dm.CreateTable<WideKeyedRecord>();
+
+    auto stmt = SqlStatement {};
+    CheckIsSixtyFourBitKey(stmt.Connection().ServerType(), LiveColumnType(stmt, "WideKeyed", "id"));
+}
+
+// ================================================================================================
 // MakeColumnTypeFromMssqlSysType — pure-function mapping (no DB connection required)
 //
 // Verifies the batched MSSQL schema reader maps sys.types.name (+ max_length/precision/scale


### PR DESCRIPTION
`PostgreSqlFormatter::BuildColumnDefinition` discarded the declared column type for auto-increment columns and emitted a hard-coded `SERIAL`. PostgreSQL derives the underlying integer width from the serial spelling, so every auto-increment primary key was created as a 32-bit `integer` — including the default case, since `PrimaryKeyWithAutoIncrement` defaults to `Bigint`. A record declaring `Field<int64_t, PrimaryKey::ServerSideAutoIncrement>` silently capped at 2^31-1 and no longer type-matched the `BIGINT` foreign keys referencing it.

The bug survived because the test suite asserted it: the Postgres expectations in `QueryBuilderTests` hard-coded `SERIAL`, and `CreateTable complex demo` declared `Bigint{}` while expecting `SERIAL` on Postgres right next to `BIGINT IDENTITY(1,1)` on SQL Server. All DDL coverage compared generated SQL text, so a formatter generating consistently wrong text always agreed with itself — nothing ever read a column type back out of the live catalog.

Fixes #521

## Changes

- `SerialColumnType()` maps the declared type onto the matching serial pseudo-type: `Bigint` → `BIGSERIAL`, `Smallint`/`Tinyint` → `SMALLSERIAL`, everything else → `SERIAL` as before.
- Kept the serial family rather than moving to `GENERATED BY DEFAULT AS IDENTITY`: the backup path identifies PostgreSQL auto-increment columns by `nextval(` in the captured default value, and identity columns would break that detection. Restore benefits as a side effect — a backed-up `bigserial` column previously came back narrowed to `serial`.
- New parameterised `QueryBuilderTests` case covering `Bigint`/`Integer`/`Smallint`/`Tinyint` across all three formatters, plus corrections to the two expectations that encoded the bug.
- Two DB-backed `SqlSchemaDbTests` that create the table (once via the migration builder, once via `DataMapper::CreateTable` with the record from the issue) and read the type back through `SqlSchema::ReadAllTables`, closing the coverage gap generically.
- Separate commit fixing four clang-tidy findings that broke the `clang-debug` preset under clang-tidy 22 (`readability-redundant-typename`, `readability-named-parameter` ×3, `bugprone-unchecked-optional-access`) — all at the source, no `NOLINT`.