### PR TITLE
Fix ddl2cpp duplicate includes and money/alias column mapping; bound SqlNumeric precision by what it can carry

### DIFF
--- a/docs/data-binder.md
+++ b/docs/data-binder.md
@@ -147,10 +147,17 @@ ODBC struct could hold, not what this implementation delivers. Two things narrow
   `-922337203685477.5808`, sign flipped.
 - **The readable width.** Every accessor except `ToUnscaledValue()` divides through
   `long double`, so no more digits can be *read back* than that type's significand
-  holds — 19 on the 80-bit x87 `long double`. A fetched `SqlNumeric<20, 0>` holding
-  `99999999999999999999` already prints as `100000000000000000000`.
+  holds. The widest `long double` in use is the 80-bit x87 one, whose 64-bit
+  significand gives 19 digits; past that, `ToString()` is wrong on every platform — a
+  fetched `SqlNumeric<20, 0>` holding `99999999999999999999` prints as
+  `100000000000000000000`.
 
 A column wider than the bound must be read as a string.
+
+Note that 19 is the point past which nothing is readable *anywhere*; it is not a
+promise that every platform renders all 19. Where `long double` is a `double`, only 15
+digits render — see the table below — and `ToUnscaledValue()` is the only way to see
+the rest.
 
 ### What each accessor delivers
 
@@ -174,7 +181,9 @@ Declaring a wide `Precision` does not by itself guarantee that every digit is
 
 - **Up to `std::numeric_limits<double>::digits10` (15) significant decimal digits:
   exact everywhere.** Every backend and driver combination round-trips such a value
-  unchanged.
+  unchanged. Beyond that, note that narrowing to 15 significant digits can round *into*
+  the integral part — `123456789012345.6789` becomes `123456789012346` — so a wide
+  value is not merely "right up to the decimal point".
 - **Beyond 15 significant digits: only on the native `SQL_C_NUMERIC` path.** Two
   independent things can narrow the value to a `double` (≈15 significant digits):
   - The binder deliberately falls back to `SQL_C_DOUBLE` for SQLite and MS SQL Server,

--- a/docs/data-binder.md
+++ b/docs/data-binder.md
@@ -155,9 +155,12 @@ ODBC struct could hold, not what this implementation delivers. Two things narrow
 A column wider than the bound must be read as a string.
 
 Note that 19 is the point past which nothing is readable *anywhere*; it is not a
-promise that every platform renders all 19. Where `long double` is a `double`, only 15
-digits render — see the table below — and `ToUnscaledValue()` is the only way to see
-the rest.
+promise that any given platform renders 19. How many digits `ToString()` delivers
+depends both on the width of `long double` (53 bits on MSVC and on Clang for Apple
+Silicon) and on the standard library's formatter, which narrows to `double` on some
+toolchains even where the type is wider. The only width guaranteed everywhere is
+`std::numeric_limits<double>::digits10` (15); above it, `ToUnscaledValue()` is the only
+accessor you can rely on.
 
 ### What each accessor delivers
 
@@ -167,12 +170,13 @@ value obtained by fetching (i.e. one whose mantissa arrived intact):
 | Accessor | Significant digits | Notes |
 |----------|--------------------|-------|
 | `ToUnscaledValue()` | up to `Precision` | The only accessor that does not go through a floating-point type. |
-| `ToString()`, `ToLongDouble()` | bounded by `long double` | 19 with the x87 80-bit `long double` (Linux/GCC/Clang on x86-64); **15 where `long double` is a `double`** — MSVC, and Clang on Apple Silicon. |
+| `ToString()`, `ToLongDouble()` | 15 guaranteed; up to 19 in practice | Bounded by `long double` *and* by the standard library's formatter for it. At most 19 (x87 80-bit); **15 where `long double` is a `double`** (MSVC, Clang on Apple Silicon) and on toolchains whose formatter narrows to `double`. Treat anything above 15 as a bonus, not a contract. |
 | `ToDouble()`, `operator<=>` | 15 | `std::numeric_limits<double>::digits10`. |
 | `ToFloat()`, `operator==` | **7** | `std::numeric_limits<float>::digits10`. `operator==` compares via `ToFloat()`, so `SqlNumeric<19, 4>` values `1234567890.1234` and `1234567890.9999` compare **equal**. Compare `ToUnscaledValue()` if you need exactness. |
 
 So on MSVC, `SqlNumeric<18, 2>` is accepted and `ToUnscaledValue()` returns all 18
-digits, but `ToString()` renders only the leading 15 correctly.
+digits, but `ToString()` renders only the leading 15 correctly. If you need more than 15
+digits out of a `SqlNumeric`, read `ToUnscaledValue()` and scale it yourself.
 
 ### How many of those digits survive a round-trip
 

--- a/docs/data-binder.md
+++ b/docs/data-binder.md
@@ -118,6 +118,24 @@ The `Inspect()` function is used to provide a human-readable representation of t
 
 This function should be used purely for debugging purposes.
 
+## `SqlNumeric<Precision, Scale>` precision limits
+
+`Precision` is a count of **decimal digits** and may be at most
+`Lightweight::SqlMaxNumericPrecision` (38) — the number of decimal digits that fit
+into the 16-byte mantissa of ODBC's `SQL_NUMERIC_STRUCT`. This covers the widest
+`DECIMAL`/`NUMERIC` MS SQL Server and PostgreSQL accept, and in particular MS SQL
+Server's `money` (`DECIMAL(19, 4)`), which `ddl2cpp` emits as
+`Light::SqlNumeric<19, 4>`.
+
+Note that `SQL_MAX_NUMERIC_LEN` (16) is a *byte* count, not a digit count — do not
+use it as a precision bound.
+
+The value itself is only carried at full width where the driver supports
+`SQL_C_NUMERIC`. Against SQLite and MS SQL Server the binder falls back to
+`SQL_C_DOUBLE` (see `NativeNumericSupportIsBroken`), which preserves roughly 15
+significant decimal digits regardless of the declared precision. Assigning from a
+`float`/`double` is likewise limited by that floating-point type.
+
 ## How `SqlVariant` decides which alternative to fill
 
 `SqlDataBinder<SqlVariant>::GetColumn` queries the driver for

--- a/docs/data-binder.md
+++ b/docs/data-binder.md
@@ -127,14 +127,41 @@ into the 16-byte mantissa of ODBC's `SQL_NUMERIC_STRUCT`. This covers the widest
 Server's `money` (`DECIMAL(19, 4)`), which `ddl2cpp` emits as
 `Light::SqlNumeric<19, 4>`.
 
+`Scale` counts the digits after the decimal point and may be anywhere in
+`[0, Precision]`. `Scale == Precision` is the purely fractional case: `SqlNumeric<4, 4>`
+is SQL's `DECIMAL(4, 4)` and covers `[0.0000, 0.9999]`.
+
 Note that `SQL_MAX_NUMERIC_LEN` (16) is a *byte* count, not a digit count — do not
 use it as a precision bound.
 
-The value itself is only carried at full width where the driver supports
-`SQL_C_NUMERIC`. Against SQLite and MS SQL Server the binder falls back to
-`SQL_C_DOUBLE` (see `NativeNumericSupportIsBroken`), which preserves roughly 15
-significant decimal digits regardless of the declared precision. Assigning from a
-`float`/`double` is likewise limited by that floating-point type.
+### How many of those digits actually survive a round-trip
+
+Declaring a wide `Precision` does not by itself guarantee that every digit is
+transferred. What you can rely on:
+
+- **Up to `std::numeric_limits<double>::digits10` (15) significant decimal digits:
+  exact everywhere.** Every backend and driver combination round-trips such a value
+  unchanged.
+- **Beyond 15 significant digits: only on the native `SQL_C_NUMERIC` path.** Two
+  independent things can narrow the value to a `double` (≈15 significant digits):
+  - The binder deliberately falls back to `SQL_C_DOUBLE` for SQLite and MS SQL Server,
+    whose drivers do not handle `SQL_NUMERIC_STRUCT` usably (see
+    `NativeNumericSupportIsBroken`).
+  - Some driver *builds* narrow internally even on the native path. The psqlODBC that
+    ships for Windows converts through a `double` before filling `SQL_NUMERIC_STRUCT`,
+    so a 19-digit value comes back as the mantissa of its nearest `double`; the Linux
+    build of the same driver transfers the mantissa verbatim.
+
+  In practice, PostgreSQL on Linux is the combination where the full 38-digit width is
+  carried today.
+
+Two further limits are independent of the driver: assigning from a `float`/`double`
+(the only value-setting API besides fetching) is bounded by that floating-point type,
+and on toolchains without `__int128` (notably MSVC) the unscaled value is handled as
+`int64_t`, capping it at 63 bits (~18-19 digits).
+
+If you need exactness above 15 digits on an arbitrary backend, read the column as a
+string instead.
 
 ## How `SqlVariant` decides which alternative to fill
 

--- a/docs/data-binder.md
+++ b/docs/data-binder.md
@@ -120,24 +120,57 @@ This function should be used purely for debugging purposes.
 
 ## `SqlNumeric<Precision, Scale>` precision limits
 
-`Precision` is a count of **decimal digits** and may be at most
-`Lightweight::SqlMaxNumericPrecision` (38) — the number of decimal digits that fit
-into the 16-byte mantissa of ODBC's `SQL_NUMERIC_STRUCT`. This covers the widest
-`DECIMAL`/`NUMERIC` MS SQL Server and PostgreSQL accept, and in particular MS SQL
-Server's `money` (`DECIMAL(19, 4)`), which `ddl2cpp` emits as
-`Light::SqlNumeric<19, 4>`.
+`Precision` is a count of **decimal digits**. It may be at most
+`Lightweight::SqlMaxNumericPrecision`, which is **19** where the toolchain provides a
+128-bit integer type and **18** where it does not (MSVC and clang-cl):
+
+| Toolchain | `SqlMaxNumericPrecision` | Widest column |
+|-----------|--------------------------|---------------|
+| GCC / Clang (`__int128` available) | 19 | `DECIMAL(19, s)` — including MS SQL Server's `money` |
+| MSVC, clang-cl (no `__int128`)     | 18 | `DECIMAL(18, s)` |
 
 `Scale` counts the digits after the decimal point and may be anywhere in
 `[0, Precision]`. `Scale == Precision` is the purely fractional case: `SqlNumeric<4, 4>`
 is SQL's `DECIMAL(4, 4)` and covers `[0.0000, 0.9999]`.
 
-Note that `SQL_MAX_NUMERIC_LEN` (16) is a *byte* count, not a digit count — do not
-use it as a precision bound.
+Note that `SQL_MAX_NUMERIC_LEN` (16) is a *byte* count, not a digit count — do not use
+it as a precision bound. It is the size of `SQL_NUMERIC_STRUCT::val`, a 128-bit
+mantissa, which is 38 decimal digits. **38 is not the bound either**: it is what the
+ODBC struct could hold, not what this implementation delivers. Two things narrow it:
 
-### How many of those digits actually survive a round-trip
+- **The unscaled carrier.** `assign()` and `ToUnscaledValue()` keep `value * 10^Scale`
+  in a `__int128` where one exists and in an `int64_t` otherwise. A signed 64-bit
+  carrier holds 18 digits. At `Precision == 19` it overflows — `money`'s maximum
+  `922337203685477.5807` has the unscaled value `9223372036854775808`, one past
+  `INT64_MAX` — and the out-of-range floating-to-integer conversion is undefined
+  behaviour, which on x86-64 yields `INT64_MIN` and renders as
+  `-922337203685477.5808`, sign flipped.
+- **The readable width.** Every accessor except `ToUnscaledValue()` divides through
+  `long double`, so no more digits can be *read back* than that type's significand
+  holds — 19 on the 80-bit x87 `long double`. A fetched `SqlNumeric<20, 0>` holding
+  `99999999999999999999` already prints as `100000000000000000000`.
+
+A column wider than the bound must be read as a string.
+
+### What each accessor delivers
+
+Even inside the bound the accessors do not all carry the same number of digits. For a
+value obtained by fetching (i.e. one whose mantissa arrived intact):
+
+| Accessor | Significant digits | Notes |
+|----------|--------------------|-------|
+| `ToUnscaledValue()` | up to `Precision` | The only accessor that does not go through a floating-point type. |
+| `ToString()`, `ToLongDouble()` | bounded by `long double` | 19 with the x87 80-bit `long double` (Linux/GCC/Clang on x86-64); **15 where `long double` is a `double`** — MSVC, and Clang on Apple Silicon. |
+| `ToDouble()`, `operator<=>` | 15 | `std::numeric_limits<double>::digits10`. |
+| `ToFloat()`, `operator==` | **7** | `std::numeric_limits<float>::digits10`. `operator==` compares via `ToFloat()`, so `SqlNumeric<19, 4>` values `1234567890.1234` and `1234567890.9999` compare **equal**. Compare `ToUnscaledValue()` if you need exactness. |
+
+So on MSVC, `SqlNumeric<18, 2>` is accepted and `ToUnscaledValue()` returns all 18
+digits, but `ToString()` renders only the leading 15 correctly.
+
+### How many of those digits survive a round-trip
 
 Declaring a wide `Precision` does not by itself guarantee that every digit is
-transferred. What you can rely on:
+*transferred*. What you can rely on:
 
 - **Up to `std::numeric_limits<double>::digits10` (15) significant decimal digits:
   exact everywhere.** Every backend and driver combination round-trips such a value
@@ -146,19 +179,21 @@ transferred. What you can rely on:
   independent things can narrow the value to a `double` (≈15 significant digits):
   - The binder deliberately falls back to `SQL_C_DOUBLE` for SQLite and MS SQL Server,
     whose drivers do not handle `SQL_NUMERIC_STRUCT` usably (see
-    `NativeNumericSupportIsBroken`).
+    `NativeNumericSupportIsBroken`). This is why MS SQL Server's own `money` loses
+    precision on MS SQL Server: its maximum `922337203685477.5807` reads back as
+    `922337203685477.6250`.
   - Some driver *builds* narrow internally even on the native path. The psqlODBC that
     ships for Windows converts through a `double` before filling `SQL_NUMERIC_STRUCT`,
     so a 19-digit value comes back as the mantissa of its nearest `double`; the Linux
     build of the same driver transfers the mantissa verbatim.
 
-  In practice, PostgreSQL on Linux is the combination where the full 38-digit width is
-  carried today.
+  PostgreSQL on Linux is therefore the only combination that carries a full 19-digit
+  value end to end today.
 
-Two further limits are independent of the driver: assigning from a `float`/`double`
-(the only value-setting API besides fetching) is bounded by that floating-point type,
-and on toolchains without `__int128` (notably MSVC) the unscaled value is handled as
-`int64_t`, capping it at 63 bits (~18-19 digits).
+One further limit is independent of the driver: assigning from a `float`/`double` — the
+only value-setting API besides fetching — is bounded by that floating-point type, so
+`SqlNumeric<19, 4> { 922337203685477.5807 }` already holds `922337203685477.6250`
+before any database is involved.
 
 If you need exactness above 15 digits on an arbitrary backend, read the column as a
 string instead.

--- a/docs/data-binder.md
+++ b/docs/data-binder.md
@@ -121,13 +121,18 @@ This function should be used purely for debugging purposes.
 ## `SqlNumeric<Precision, Scale>` precision limits
 
 `Precision` is a count of **decimal digits**. It may be at most
-`Lightweight::SqlMaxNumericPrecision`, which is **19** where the toolchain provides a
-128-bit integer type and **18** where it does not (MSVC and clang-cl):
+`Lightweight::SqlMaxNumericPrecision`, which is **19 on every supported toolchain**:
 
 | Toolchain | `SqlMaxNumericPrecision` | Widest column |
 |-----------|--------------------------|---------------|
-| GCC / Clang (`__int128` available) | 19 | `DECIMAL(19, s)` — including MS SQL Server's `money` |
-| MSVC, clang-cl (no `__int128`)     | 18 | `DECIMAL(18, s)` |
+| GCC / Clang (native `__int128`)         | 19 | `DECIMAL(19, s)` — including MS SQL Server's `money` |
+| MSVC, clang-cl (software `Int128Soft`)  | 19 | `DECIMAL(19, s)` — including MS SQL Server's `money` |
+
+The bound is deliberately toolchain-independent. A column's precision comes from the
+database schema, so a `ddl2cpp`-generated record has to compile wherever it is consumed —
+a header that builds under GCC and fails under MSVC would make the generator useless.
+`Lightweight::Int128`, the type that carries the unscaled value, is `__int128_t` where the
+compiler has one and a software stand-in (`detail::Int128Soft`) where it does not.
 
 `Scale` counts the digits after the decimal point and may be anywhere in
 `[0, Precision]`. `Scale == Precision` is the purely fractional case: `SqlNumeric<4, 4>`
@@ -136,31 +141,15 @@ is SQL's `DECIMAL(4, 4)` and covers `[0.0000, 0.9999]`.
 Note that `SQL_MAX_NUMERIC_LEN` (16) is a *byte* count, not a digit count — do not use
 it as a precision bound. It is the size of `SQL_NUMERIC_STRUCT::val`, a 128-bit
 mantissa, which is 38 decimal digits. **38 is not the bound either**: it is what the
-ODBC struct could hold, not what this implementation delivers. Two things narrow it:
-
-- **The unscaled carrier.** `assign()` and `ToUnscaledValue()` keep `value * 10^Scale`
-  in a `__int128` where one exists and in an `int64_t` otherwise. A signed 64-bit
-  carrier holds 18 digits. At `Precision == 19` it overflows — `money`'s maximum
-  `922337203685477.5807` has the unscaled value `9223372036854775808`, one past
-  `INT64_MAX` — and the out-of-range floating-to-integer conversion is undefined
-  behaviour, which on x86-64 yields `INT64_MIN` and renders as
-  `-922337203685477.5808`, sign flipped.
-- **The readable width.** Every accessor except `ToUnscaledValue()` divides through
-  `long double`, so no more digits can be *read back* than that type's significand
-  holds. The widest `long double` in use is the 80-bit x87 one, whose 64-bit
-  significand gives 19 digits; past that, `ToString()` is wrong on every platform — a
-  fetched `SqlNumeric<20, 0>` holding `99999999999999999999` prints as
-  `100000000000000000000`.
+ODBC struct could hold, not what this implementation can read back. What narrows it is
+the **readable width** — every accessor except `ToUnscaledValue()` and `ToString()`
+divides through `long double`, so no more digits can be read back through those than that
+type's significand holds. The widest `long double` in use is the 80-bit x87 one, whose
+64-bit significand gives 19 digits; past that nothing is readable on any platform — a
+fetched `SqlNumeric<20, 0>` holding `99999999999999999999` would come back as
+`100000000000000000000`.
 
 A column wider than the bound must be read as a string.
-
-Note that 19 is the point past which nothing is readable *anywhere*; it is not a
-promise that any given platform renders 19. How many digits `ToString()` delivers
-depends both on the width of `long double` (53 bits on MSVC and on Clang for Apple
-Silicon) and on the standard library's formatter, which narrows to `double` on some
-toolchains even where the type is wider. The only width guaranteed everywhere is
-`std::numeric_limits<double>::digits10` (15); above it, `ToUnscaledValue()` is the only
-accessor you can rely on.
 
 ### What each accessor delivers
 
@@ -169,14 +158,19 @@ value obtained by fetching (i.e. one whose mantissa arrived intact):
 
 | Accessor | Significant digits | Notes |
 |----------|--------------------|-------|
-| `ToUnscaledValue()` | up to `Precision` | The only accessor that does not go through a floating-point type. |
-| `ToString()`, `ToLongDouble()` | 15 guaranteed; up to 19 in practice | Bounded by `long double` *and* by the standard library's formatter for it. At most 19 (x87 80-bit); **15 where `long double` is a `double`** (MSVC, Clang on Apple Silicon) and on toolchains whose formatter narrows to `double`. Treat anything above 15 as a bonus, not a contract. |
+| `ToUnscaledValue()` | up to `Precision` | Returns `Lightweight::Int128`. The only accessor that yields the raw integer. |
+| `ToString()` | up to `Precision` | Rendered from the unscaled integer, not by formatting a `long double`, so every digit survives on every toolchain. |
+| `ToLongDouble()` | 15 guaranteed; up to 19 in practice | Bounded by `long double`: at most 19 (x87 80-bit); **15 where `long double` is a `double`** (MSVC, Clang on Apple Silicon). |
 | `ToDouble()`, `operator<=>` | 15 | `std::numeric_limits<double>::digits10`. |
 | `ToFloat()`, `operator==` | **7** | `std::numeric_limits<float>::digits10`. `operator==` compares via `ToFloat()`, so `SqlNumeric<19, 4>` values `1234567890.1234` and `1234567890.9999` compare **equal**. Compare `ToUnscaledValue()` if you need exactness. |
 
-So on MSVC, `SqlNumeric<18, 2>` is accepted and `ToUnscaledValue()` returns all 18
-digits, but `ToString()` renders only the leading 15 correctly. If you need more than 15
-digits out of a `SqlNumeric`, read `ToUnscaledValue()` and scale it yourself.
+So `ToUnscaledValue()` and `ToString()` are exact to the declared precision everywhere,
+including MSVC; the floating-point accessors are not. If you need more than 15 digits out
+of a `SqlNumeric`, use one of those two rather than `ToDouble()`.
+
+Neither `Int128` implementation is formattable by `std::format` (the native `__int128_t`
+is not either), so render an unscaled value with
+`Lightweight::detail::Int128ToString(value.ToUnscaledValue())`, or just use `ToString()`.
 
 ### How many of those digits survive a round-trip
 

--- a/src/Lightweight/CMakeLists.txt
+++ b/src/Lightweight/CMakeLists.txt
@@ -38,6 +38,7 @@ endif()
 set(HEADER_FILES
     DataBinder/BasicStringBinder.hpp
     DataBinder/Core.hpp
+    DataBinder/Int128.hpp
     DataBinder/Primitives.hpp
     DataBinder/SqlDate.hpp
     DataBinder/SqlDateTime.hpp

--- a/src/Lightweight/DataBinder/Int128.hpp
+++ b/src/Lightweight/DataBinder/Int128.hpp
@@ -33,6 +33,8 @@ namespace detail
     /// `money` column (`DECIMAL(19, 4)`) would compile under GCC/Clang and fail under MSVC. A schema is a
     /// property of the database, not of the compiler that happens to build the client.
     ///
+    /// @see Int128, SqlMaxNumericPrecision
+    ///
     /// The operation set is deliberately minimal — construction from and conversion to the floating-point
     /// types, negation, comparison, and decimal rendering — because that is all `SqlNumeric` needs. It is
     /// not a general-purpose big integer: there is no multiplication, no division by another `Int128Soft`,
@@ -80,8 +82,8 @@ namespace detail
         ///
         /// Values whose magnitude is at or beyond 2^127 saturate to the corresponding extreme rather than
         /// invoking the undefined behaviour an out-of-range `static_cast` to an integer type would. That
-        /// is the whole point of routing through this type: the `int64_t` fallback it replaces silently
-        /// flipped the sign of `money`'s maximum on x86-64.
+        /// is a large part of the point of routing through this type: a narrower carrier makes the
+        /// conversion of `money`'s maximum out of range, and on x86-64 that silently flips its sign.
         ///
         /// @param value Value to truncate. Must be finite; NaN yields zero.
         template <std::floating_point T>

--- a/src/Lightweight/DataBinder/Int128.hpp
+++ b/src/Lightweight/DataBinder/Int128.hpp
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <compare>
+#include <concepts>
+#include <cstdint>
+#include <string>
+
+namespace Lightweight
+{
+
+// clang-cl doesn't support __int128_t but defines __SIZEOF_INT128__
+// and also since it pretends to be MSVC, it also defines _MSC_VER
+// clang-format off
+#if defined(__SIZEOF_INT128__) && !defined(_MSC_VER)
+    #define LIGHTWEIGHT_HAVE_NATIVE_INT128 1
+#endif
+// clang-format on
+
+namespace detail
+{
+
+    /// Signed 128-bit integer with just enough arithmetic to carry a fixed-point unscaled value.
+    ///
+    /// This exists so that `SqlNumeric`'s unscaled carrier is 128 bits wide on *every* toolchain. Where
+    /// the compiler offers `__int128_t` that type is used directly (see `Int128` below); MSVC and
+    /// clang-cl have no such type, and this software implementation stands in for it there. Without it
+    /// the carrier would fall back to `int64_t`, which holds only 18 decimal digits, and the widest
+    /// declarable precision would differ between toolchains — meaning a `ddl2cpp`-generated record for a
+    /// `money` column (`DECIMAL(19, 4)`) would compile under GCC/Clang and fail under MSVC. A schema is a
+    /// property of the database, not of the compiler that happens to build the client.
+    ///
+    /// The operation set is deliberately minimal — construction from and conversion to the floating-point
+    /// types, negation, comparison, and decimal rendering — because that is all `SqlNumeric` needs. It is
+    /// not a general-purpose big integer: there is no multiplication, no division by another `Int128Soft`,
+    /// and no bitwise interface beyond what the conversions require.
+    ///
+    /// Representation is sign-magnitude-free two's complement across a low/high pair, matching the
+    /// little-endian layout of `SQL_NUMERIC_STRUCT::val` so that a `std::memcpy` in either direction is a
+    /// faithful round-trip.
+    struct Int128Soft
+    {
+        /// Low 64 bits of the two's-complement magnitude.
+        std::uint64_t low {};
+
+        /// High 64 bits of the two's-complement magnitude, including the sign bit.
+        std::uint64_t high {};
+
+        /// Default-constructs a zero value.
+        constexpr Int128Soft() noexcept = default;
+
+        /// Constructs from a signed 64-bit integer, sign-extending into the high word.
+        /// @param value Value to widen.
+        constexpr Int128Soft(std::int64_t value) noexcept: // NOLINT(google-explicit-constructor)
+            low { static_cast<std::uint64_t>(value) },
+            high { value < 0 ? ~std::uint64_t { 0 } : std::uint64_t { 0 } }
+        {
+        }
+
+        /// Constructs from an unsigned 64-bit integer, zero-extending into the high word.
+        /// @param value Value to widen.
+        constexpr Int128Soft(std::uint64_t value) noexcept: // NOLINT(google-explicit-constructor)
+            low { value }
+        {
+        }
+
+        /// Constructs from an explicit low/high word pair.
+        /// @param lowWord Low 64 bits.
+        /// @param highWord High 64 bits, including the sign bit.
+        constexpr Int128Soft(std::uint64_t lowWord, std::uint64_t highWord) noexcept:
+            low { lowWord },
+            high { highWord }
+        {
+        }
+
+        /// Constructs from a floating-point value by truncation toward zero.
+        ///
+        /// Values whose magnitude is at or beyond 2^127 saturate to the corresponding extreme rather than
+        /// invoking the undefined behaviour an out-of-range `static_cast` to an integer type would. That
+        /// is the whole point of routing through this type: the `int64_t` fallback it replaces silently
+        /// flipped the sign of `money`'s maximum on x86-64.
+        ///
+        /// @param value Value to truncate. Must be finite; NaN yields zero.
+        template <std::floating_point T>
+        constexpr explicit Int128Soft(T value) noexcept
+        {
+            if (!(value == value)) // NaN — no meaningful integer image.
+                return;
+
+            auto const negative = value < T { 0 };
+            auto magnitude = negative ? -value : value;
+
+            // 2^127, the first magnitude a signed 128-bit integer cannot represent. Computed by repeated
+            // doubling so it stays exact in every floating-point format (2^127 is a power of two, hence
+            // representable in all of them, but a literal would depend on the type's width).
+            auto limit = T { 1 };
+            for (auto bit = 0; bit != 127; ++bit)
+                limit *= T { 2 };
+
+            if (magnitude >= limit)
+            {
+                // Saturate: -2^127 .. 2^127-1.
+                low = negative ? std::uint64_t { 0 } : ~std::uint64_t { 0 };
+                high = negative ? (std::uint64_t { 1 } << 63) : (~std::uint64_t { 0 } >> 1);
+                return;
+            }
+
+            // Split into two 64-bit halves. `magnitude / 2^64` truncated is the high word; the remainder
+            // is the low word. Both subexpressions are exact: the quotient is < 2^63 and the remainder is
+            // recovered by subtraction rather than by a second division.
+            auto divisor = T { 1 };
+            for (auto bit = 0; bit != 64; ++bit)
+                divisor *= T { 2 };
+
+            auto const highPart = std::trunc(magnitude / divisor);
+            auto const lowPart = std::trunc(magnitude - (highPart * divisor));
+
+            low = static_cast<std::uint64_t>(lowPart);
+            high = static_cast<std::uint64_t>(highPart);
+
+            if (negative)
+                *this = -*this;
+        }
+
+        /// @return `true` if the value is negative.
+        [[nodiscard]] constexpr bool IsNegative() const noexcept
+        {
+            return (high >> 63) != 0;
+        }
+
+        /// Negates the value (two's complement).
+        /// @return The additive inverse. `-(-2^127)` saturates to itself, as it does for every two's-complement type.
+        [[nodiscard]] constexpr Int128Soft operator-() const noexcept
+        {
+            auto const invertedLow = ~low;
+            auto const invertedHigh = ~high;
+            auto const carriedLow = invertedLow + 1;
+            auto const carriedHigh = invertedHigh + (carriedLow < invertedLow ? 1 : 0);
+            return { carriedLow, carriedHigh };
+        }
+
+        /// @return The value unchanged (provided for symmetry with `operator-`).
+        [[nodiscard]] constexpr Int128Soft operator+() const noexcept
+        {
+            return *this;
+        }
+
+        /// Converts to a floating-point type.
+        ///
+        /// Precision is bounded by the target type's significand, exactly as it is for the native
+        /// `__int128_t` this stands in for.
+        ///
+        /// @tparam T Target floating-point type.
+        /// @return The value as `T`, rounded to that type's precision.
+        template <std::floating_point T>
+        [[nodiscard]] constexpr T To() const noexcept
+        {
+            auto const negative = IsNegative();
+            auto const magnitude = negative ? -*this : *this;
+
+            auto scale = T { 1 };
+            for (auto bit = 0; bit != 64; ++bit)
+                scale *= T { 2 };
+
+            auto const result = (static_cast<T>(magnitude.high) * scale) + static_cast<T>(magnitude.low);
+            return negative ? -result : result;
+        }
+
+        /// @return The value as a `float`.
+        [[nodiscard]] constexpr explicit operator float() const noexcept
+        {
+            return To<float>();
+        }
+
+        /// @return The value as a `double`.
+        [[nodiscard]] constexpr explicit operator double() const noexcept
+        {
+            return To<double>();
+        }
+
+        /// @return The value as a `long double`.
+        [[nodiscard]] constexpr explicit operator long double() const noexcept
+        {
+            return To<long double>();
+        }
+
+        /// Narrows to a signed 64-bit integer, truncating the high word.
+        /// @return The low 64 bits reinterpreted as signed, matching `static_cast<int64_t>` on a native `__int128_t`.
+        [[nodiscard]] constexpr explicit operator std::int64_t() const noexcept
+        {
+            return static_cast<std::int64_t>(low);
+        }
+
+        /// Narrows to an unsigned 64-bit integer, truncating the high word.
+        /// @return The low 64 bits, matching `static_cast<uint64_t>` on a native `__int128_t`.
+        [[nodiscard]] constexpr explicit operator std::uint64_t() const noexcept
+        {
+            return low;
+        }
+
+        /// Narrows to a signed 32-bit integer, truncating.
+        [[nodiscard]] constexpr explicit operator std::int32_t() const noexcept
+        {
+            return static_cast<std::int32_t>(low);
+        }
+
+        /// Equality comparison.
+        [[nodiscard]] constexpr bool operator==(Int128Soft const& other) const noexcept = default;
+
+        /// Three-way comparison, signed.
+        /// @param other Value to compare against.
+        /// @return The ordering of `*this` relative to `other`.
+        [[nodiscard]] constexpr std::strong_ordering operator<=>(Int128Soft const& other) const noexcept
+        {
+            if (auto const negative = IsNegative(); negative != other.IsNegative())
+                return negative ? std::strong_ordering::less : std::strong_ordering::greater;
+
+            if (high != other.high)
+                return high <=> other.high;
+
+            return low <=> other.low;
+        }
+    };
+
+    /// Renders a software 128-bit integer in base 10.
+    ///
+    /// `std::format` has no support for 128-bit integers — not even for the native `__int128_t` — so
+    /// decimal rendering is done here by schoolbook long division over 32-bit limbs.
+    ///
+    /// @param value Value to render.
+    /// @return Decimal representation, with a leading '-' for negative values.
+    [[nodiscard]] inline std::string ToDecimalString(Int128Soft value) noexcept
+    {
+        if (value == Int128Soft {})
+            return "0";
+
+        auto const negative = value.IsNegative();
+
+        // Work on the magnitude as an unsigned 128-bit pair. Negating the most-negative value overflows
+        // back to itself, but its two's-complement bit pattern is exactly the unsigned magnitude 2^127,
+        // so treating the words as unsigned below is correct for it too.
+        auto const magnitude = negative ? -value : value;
+        auto low = magnitude.low;
+        auto high = magnitude.high;
+
+        // Divide repeatedly by 10^9, peeling off nine digits per pass. The divisor has to stay below
+        // 2^32: each step of the long division forms `(remainder << 32) | limb`, and that only fits a
+        // std::uint64_t while `remainder < divisor <= 2^32`. (10^19 would be the largest power of ten a
+        // std::uint64_t *holds*, but its remainders overflow that shift — the digits then come out
+        // scrambled, which is exactly what the round-trip tests catch.)
+        constexpr auto chunkDivisor = std::uint64_t { 1'000'000'000ULL };
+        constexpr auto chunkDigits = 9;
+
+        auto chunks = std::string {};
+
+        while (high != 0 || low != 0)
+        {
+            auto remainder = std::uint64_t { 0 };
+
+            auto const limbs = std::array<std::uint32_t, 4> {
+                static_cast<std::uint32_t>(high >> 32),
+                static_cast<std::uint32_t>(high & 0xFFFF'FFFFULL),
+                static_cast<std::uint32_t>(low >> 32),
+                static_cast<std::uint32_t>(low & 0xFFFF'FFFFULL),
+            };
+
+            auto quotientLimbs = std::array<std::uint32_t, 4> {};
+
+            for (auto index = std::size_t { 0 }; index != limbs.size(); ++index)
+            {
+                // `remainder < 10^9 < 2^32`, so `(remainder << 32) | limb` stays within 64 bits.
+                auto const dividend = (remainder << 32) | limbs[index];
+                quotientLimbs[index] = static_cast<std::uint32_t>(dividend / chunkDivisor);
+                remainder = dividend % chunkDivisor;
+            }
+
+            high = (static_cast<std::uint64_t>(quotientLimbs[0]) << 32) | quotientLimbs[1];
+            low = (static_cast<std::uint64_t>(quotientLimbs[2]) << 32) | quotientLimbs[3];
+
+            // Emit this chunk's digits least-significant first; they are zero-padded unless this was the
+            // final (most significant) chunk, whose padding is trimmed after the loop.
+            for (auto digit = 0; digit != chunkDigits; ++digit)
+            {
+                chunks.push_back(static_cast<char>('0' + static_cast<char>(remainder % 10)));
+                remainder /= 10;
+            }
+        }
+
+        // Drop the zero padding of the most significant chunk, then reverse into print order.
+        while (chunks.size() > 1 && chunks.back() == '0')
+            chunks.pop_back();
+
+        if (negative)
+            chunks.push_back('-');
+
+        return std::string { chunks.rbegin(), chunks.rend() };
+    }
+
+} // namespace detail
+
+/// The unscaled carrier `SqlNumeric` keeps `value * 10^Scale` in: a signed 128-bit integer on every
+/// supported toolchain.
+///
+/// Where the compiler provides `__int128_t` that is used directly, so nothing changes for GCC and
+/// Clang. MSVC and clang-cl get `detail::Int128Soft`, a software stand-in with the same width and the
+/// same conversion behaviour. Both are 16 bytes and little-endian, matching `SQL_NUMERIC_STRUCT::val`
+/// byte for byte.
+#if defined(LIGHTWEIGHT_HAVE_NATIVE_INT128)
+using Int128 = __int128_t;
+#else
+using Int128 = detail::Int128Soft;
+#endif
+
+static_assert(sizeof(Int128) == 16, "The unscaled carrier must be exactly as wide as SQL_NUMERIC_STRUCT::val.");
+
+namespace detail
+{
+
+    /// Renders the unscaled carrier in base 10, whichever of the two implementations it is.
+    ///
+    /// `std::format` supports neither `__int128_t` nor `Int128Soft`, so both paths are handled here.
+    ///
+    /// @param value Value to render.
+    /// @return Decimal representation, with a leading '-' for negative values.
+    [[nodiscard]] inline std::string Int128ToString(Int128 value) noexcept
+    {
+#if defined(LIGHTWEIGHT_HAVE_NATIVE_INT128)
+        auto const negative = value < 0;
+        auto magnitude = static_cast<__uint128_t>(negative ? -value : value);
+
+        if (magnitude == 0)
+            return "0";
+
+        auto reversed = std::string {};
+        while (magnitude != 0)
+        {
+            reversed.push_back(static_cast<char>('0' + static_cast<char>(magnitude % 10)));
+            magnitude /= 10;
+        }
+        if (negative)
+            reversed.push_back('-');
+
+        return std::string { reversed.rbegin(), reversed.rend() };
+#else
+        return ToDecimalString(value);
+#endif
+    }
+
+} // namespace detail
+
+} // namespace Lightweight

--- a/src/Lightweight/DataBinder/SqlNumeric.hpp
+++ b/src/Lightweight/DataBinder/SqlNumeric.hpp
@@ -26,18 +26,61 @@ namespace Lightweight
 #endif
 // clang-format on
 
-/// Number of decimal digits that fit into the mantissa of an ODBC `SQL_NUMERIC_STRUCT`.
+namespace detail
+{
+
+    /// Number of whole decimal digits that fit into a binary magnitude of `bits` bits.
+    ///
+    /// `floor(bits * log10(2))`, evaluated with integer arithmetic (`log10(2) ~= 0.30103`) so that
+    /// it stays usable in a constant expression without pulling in `<cmath>` at compile time.
+    ///
+    /// @param bits Width of the binary magnitude, excluding any sign bit.
+    /// @return Number of decimal digits that magnitude represents without loss.
+    [[nodiscard]] constexpr std::size_t DecimalDigitsForBits(std::size_t bits) noexcept
+    {
+        return (bits * 30103) / 100'000;
+    }
+
+} // namespace detail
+
+/// Widest `Precision` a `SqlNumeric` may declare, in decimal digits.
 ///
-/// `SQL_MAX_NUMERIC_LEN` is the size *in bytes* of `SQL_NUMERIC_STRUCT::val` (16 bytes, i.e. a
-/// 128-bit unsigned mantissa) — it is not a maximum decimal precision. The number of decimal
-/// digits that can be stored is `floor(bits * log10(2))`, computed here with integer arithmetic
-/// (`log10(2) ~= 0.30103`) so it stays usable in a constant expression: 128 bits -> 38 digits,
-/// which is also the maximum `DECIMAL`/`NUMERIC` precision of MS SQL Server and PostgreSQL.
+/// This is deliberately *not* derived from `SQL_MAX_NUMERIC_LEN`. That macro is the size **in
+/// bytes** of `SQL_NUMERIC_STRUCT::val` (16, i.e. a 128-bit mantissa), not a decimal precision, so
+/// the historical `static_assert(Precision <= SQL_MAX_NUMERIC_LEN)` was a category error that
+/// rejected perfectly ordinary columns such as `DECIMAL(18, 2)`.
+///
+/// Bounding by the mantissa's theoretical capacity instead (128 bits -> 38 digits) would be the
+/// same category error in the other direction: 38 is what the ODBC *struct* could hold, not what
+/// this implementation can carry. Two things narrow it:
+///
+/// - **The unscaled carrier.** `assign()` and `ToUnscaledValue()` keep `value * 10^Scale` in a
+///   `LIGHTWEIGHT_INT128_T` where the toolchain offers a 128-bit integer, and in an `int64_t`
+///   otherwise — MSVC and clang-cl both take the latter path. A signed 64-bit carrier holds
+///   `DecimalDigitsForBits(63)` == 18 digits. At `Precision == 19` the conversion overflows:
+///   MS SQL Server's `money` maximum 922337203685477.5807 has the unscaled value
+///   9223372036854775808, one past `INT64_MAX`, so the `static_cast<int64_t>` of that
+///   floating-point value is an out-of-range conversion — undefined behaviour, which on x86-64
+///   yields `INT64_MIN` and renders as -922337203685477.5808, sign flipped.
+/// - **The readable width.** Every accessor except `ToUnscaledValue()` — `ToFloat`, `ToDouble`,
+///   `ToLongDouble` and therefore `ToString` — divides through `long double`, so no more digits can
+///   be read back than that type's significand holds. On the 80-bit x87 `long double` that is
+///   `DecimalDigitsForBits(64)` == 19; a fetched `SqlNumeric<20, 0>` holding 99999999999999999999
+///   already prints as 100000000000000000000.
+///
+/// Hence 18 without a 128-bit carrier and 19 with one. `DECIMAL(18, s)` compiles everywhere and
+/// `money` (`DECIMAL(19, 4)`) compiles wherever `__int128` exists; a wider column must be read as a
+/// string. `docs/data-binder.md` tabulates what each accessor delivers below that bound.
 ///
 /// NB: `inline` is load-bearing. At namespace scope `constexpr` implies `const`, hence internal
 /// linkage, and an exported template in the module interface (`SqlNumeric`, via its static_assert)
 /// may not reference an internal-linkage entity.
-inline constexpr std::size_t SqlMaxNumericPrecision = (std::size_t { SQL_MAX_NUMERIC_LEN } * 8 * 30103) / 100'000;
+inline constexpr std::size_t SqlMaxNumericPrecision =
+#if defined(LIGHTWEIGHT_INT128_T)
+    detail::DecimalDigitsForBits(64); // 19 — bounded by the `long double` significand every accessor divides through
+#else
+    detail::DecimalDigitsForBits(63); // 18 — bounded by the `int64_t` magnitude that carries the unscaled value
+#endif
 
 /// Represents a fixed-point number with a given precision and scale.
 ///
@@ -62,8 +105,15 @@ struct SqlNumeric
     static constexpr auto ColumnType = SqlColumnTypeDefinitions::Decimal { .precision = Precision, .scale = TheScale };
 
     static_assert(Precision > 0, "A fixed-point number must have at least one digit.");
+    // NB: This bound is 19 where the toolchain has a 128-bit integer and 18 where it does not
+    // (MSVC, clang-cl), so `SqlNumeric<19, 4>` — what ddl2cpp emits for MS SQL Server's `money` —
+    // is a compile error on those toolchains. That asymmetry is deliberate: on an `int64_t`
+    // carrier a 19-digit unscaled value overflows, and the resulting out-of-range conversion is
+    // undefined behaviour that silently flips the sign of the value. Failing to build is the
+    // strictly better of the two. See SqlMaxNumericPrecision for the derivation.
     static_assert(Precision <= SqlMaxNumericPrecision,
-                  "Precision is a count of decimal digits and must fit into the SQL_NUMERIC_STRUCT mantissa.");
+                  "Precision exceeds the number of decimal digits this implementation can carry. Read the column as a "
+                  "string instead, or narrow the column.");
     // `DECIMAL(p, s)` requires 0 <= s <= p; `s == p` denotes a purely fractional number (e.g.
     // DECIMAL(4, 4) holds [0, 1) with four fractional digits) and is legal in every supported
     // backend. No conversion path here needs an integral digit: the value is kept as the unscaled

--- a/src/Lightweight/DataBinder/SqlNumeric.hpp
+++ b/src/Lightweight/DataBinder/SqlNumeric.hpp
@@ -26,6 +26,15 @@ namespace Lightweight
 #endif
 // clang-format on
 
+/// Number of decimal digits that fit into the mantissa of an ODBC `SQL_NUMERIC_STRUCT`.
+///
+/// `SQL_MAX_NUMERIC_LEN` is the size *in bytes* of `SQL_NUMERIC_STRUCT::val` (16 bytes, i.e. a
+/// 128-bit unsigned mantissa) — it is not a maximum decimal precision. The number of decimal
+/// digits that can be stored is `floor(bits * log10(2))`, computed here with integer arithmetic
+/// (`log10(2) ~= 0.30103`) so it stays usable in a constant expression: 128 bits -> 38 digits,
+/// which is also the maximum `DECIMAL`/`NUMERIC` precision of MS SQL Server and PostgreSQL.
+constexpr std::size_t SqlMaxNumericPrecision = (std::size_t { SQL_MAX_NUMERIC_LEN } * 8 * 30103) / 100'000;
+
 /// Represents a fixed-point number with a given precision and scale.
 ///
 /// Precision is *exactly* the total number of digits in the number,
@@ -46,7 +55,8 @@ struct SqlNumeric
     /// The SQL column type definition for this numeric type.
     static constexpr auto ColumnType = SqlColumnTypeDefinitions::Decimal { .precision = Precision, .scale = TheScale };
 
-    static_assert(Precision <= SQL_MAX_NUMERIC_LEN);
+    static_assert(Precision <= SqlMaxNumericPrecision,
+                  "Precision is a count of decimal digits and must fit into the SQL_NUMERIC_STRUCT mantissa.");
     static_assert(Scale < Precision);
 
     /// The SQL numeric struct for ODBC binding.

--- a/src/Lightweight/DataBinder/SqlNumeric.hpp
+++ b/src/Lightweight/DataBinder/SqlNumeric.hpp
@@ -64,13 +64,19 @@ namespace detail
 ///   yields `INT64_MIN` and renders as -922337203685477.5808, sign flipped.
 /// - **The readable width.** Every accessor except `ToUnscaledValue()` — `ToFloat`, `ToDouble`,
 ///   `ToLongDouble` and therefore `ToString` — divides through `long double`, so no more digits can
-///   be read back than that type's significand holds. On the 80-bit x87 `long double` that is
-///   `DecimalDigitsForBits(64)` == 19; a fetched `SqlNumeric<20, 0>` holding 99999999999999999999
-///   already prints as 100000000000000000000.
+///   be read back than that type's significand holds. The widest `long double` in use is the 80-bit
+///   x87 one, whose 64-bit significand gives `DecimalDigitsForBits(64)` == 19; beyond that
+///   `ToString()` is wrong on *every* platform, e.g. a fetched `SqlNumeric<20, 0>` holding
+///   99999999999999999999 prints as 100000000000000000000.
 ///
 /// Hence 18 without a 128-bit carrier and 19 with one. `DECIMAL(18, s)` compiles everywhere and
 /// `money` (`DECIMAL(19, 4)`) compiles wherever `__int128` exists; a wider column must be read as a
-/// string. `docs/data-binder.md` tabulates what each accessor delivers below that bound.
+/// string.
+///
+/// NB: 19 is the point beyond which nothing is readable anywhere; it is not a promise that every
+/// platform renders all 19. Where `long double` is a `double` (MSVC, and Clang on Apple Silicon)
+/// `ToString()` carries only 15 digits, and `ToUnscaledValue()` is the only way to see the rest.
+/// `docs/data-binder.md` tabulates what each accessor delivers.
 ///
 /// NB: `inline` is load-bearing. At namespace scope `constexpr` implies `const`, hence internal
 /// linkage, and an exported template in the module interface (`SqlNumeric`, via its static_assert)

--- a/src/Lightweight/DataBinder/SqlNumeric.hpp
+++ b/src/Lightweight/DataBinder/SqlNumeric.hpp
@@ -4,27 +4,23 @@
 
 #include "../SqlColumnTypeDefinitions.hpp"
 #include "../SqlError.hpp"
+#include "Int128.hpp"
 #include "Primitives.hpp"
 
-#include <algorithm>
 #include <bit>
 #include <cmath>
 #include <compare>
 #include <concepts>
+#include <cstddef>
 #include <cstring>
+#include <format>
 #include <source_location>
+#include <string>
 
 namespace Lightweight
 {
 
-// clang-cl doesn't support __int128_t but defines __SIZEOF_INT128__
-// and also since it pretends to be MSVC, it also defines _MSC_VER
-// clang-format off
-#if defined(__SIZEOF_INT128__) && !defined(_MSC_VER)
-    #define LIGHTWEIGHT_INT128_T __int128_t
-    static_assert(sizeof(__int128_t) == sizeof(SQL_NUMERIC_STRUCT::val));
-#endif
-// clang-format on
+static_assert(sizeof(Int128) == sizeof(SQL_NUMERIC_STRUCT::val));
 
 namespace detail
 {
@@ -45,51 +41,44 @@ namespace detail
 
 /// Widest `Precision` a `SqlNumeric` may declare, in decimal digits.
 ///
-/// This is deliberately *not* derived from `SQL_MAX_NUMERIC_LEN`. That macro is the size **in
+/// **This is the same value on every toolchain.** A column's precision is a property of the
+/// database schema, so the type that maps it must not depend on which compiler builds the client:
+/// a `ddl2cpp`-generated record has to compile everywhere or the generator is useless. `Int128`
+/// exists to make that true — it is `__int128_t` where the compiler has one and a software
+/// stand-in (`detail::Int128Soft`) where it does not, so the unscaled carrier is 128 bits wide
+/// under MSVC and clang-cl as well.
+///
+/// The bound is deliberately *not* derived from `SQL_MAX_NUMERIC_LEN`. That macro is the size **in
 /// bytes** of `SQL_NUMERIC_STRUCT::val` (16, i.e. a 128-bit mantissa), not a decimal precision, so
 /// the historical `static_assert(Precision <= SQL_MAX_NUMERIC_LEN)` was a category error that
 /// rejected perfectly ordinary columns such as `DECIMAL(18, 2)`.
 ///
 /// Bounding by the mantissa's theoretical capacity instead (128 bits -> 38 digits) would be the
 /// same category error in the other direction: 38 is what the ODBC *struct* could hold, not what
-/// this implementation can carry. Two things narrow it:
+/// this implementation can read back. What narrows it is the **readable width**: every accessor
+/// except `ToUnscaledValue()` — `ToFloat`, `ToDouble`, `ToLongDouble` and therefore `ToString` —
+/// divides through `long double`, so no more digits can be read back than that type's significand
+/// holds. The widest one in use is the 80-bit x87 `long double`, whose 64-bit significand gives
+/// `DecimalDigitsForBits(64)` == 19; beyond that nothing is readable on *any* platform, e.g. a
+/// fetched `SqlNumeric<20, 0>` holding 99999999999999999999 prints as 100000000000000000000.
 ///
-/// - **The unscaled carrier.** `assign()` and `ToUnscaledValue()` keep `value * 10^Scale` in a
-///   `LIGHTWEIGHT_INT128_T` where the toolchain offers a 128-bit integer, and in an `int64_t`
-///   otherwise — MSVC and clang-cl both take the latter path. A signed 64-bit carrier holds
-///   `DecimalDigitsForBits(63)` == 18 digits. At `Precision == 19` the conversion overflows:
-///   MS SQL Server's `money` maximum 922337203685477.5807 has the unscaled value
-///   9223372036854775808, one past `INT64_MAX`, so the `static_cast<int64_t>` of that
-///   floating-point value is an out-of-range conversion — undefined behaviour, which on x86-64
-///   yields `INT64_MIN` and renders as -922337203685477.5808, sign flipped.
-/// - **The readable width.** Every accessor except `ToUnscaledValue()` — `ToFloat`, `ToDouble`,
-///   `ToLongDouble` and therefore `ToString` — divides through `long double`, so no more digits can
-///   be read back than that type's significand holds. The widest one in use is the 80-bit x87
-///   `long double`, whose 64-bit significand gives `DecimalDigitsForBits(64)` == 19; beyond that
-///   nothing is readable on *any* platform, e.g. a fetched `SqlNumeric<20, 0>` holding
-///   99999999999999999999 prints as 100000000000000000000.
-///
-/// Hence 18 without a 128-bit carrier and 19 with one. `DECIMAL(18, s)` compiles everywhere and
-/// `money` (`DECIMAL(19, 4)`) compiles wherever `__int128` exists; a wider column must be read as a
-/// string.
+/// Hence 19, everywhere. `DECIMAL(18, s)` and MS SQL Server's `money` (`DECIMAL(19, 4)`) both
+/// compile on every supported toolchain; a wider column must be read as a string.
 ///
 /// NB: 19 is the point past which nothing is readable *anywhere*. It is emphatically not a promise
-/// that any given platform renders 19: how many digits `ToString()` delivers depends both on the
-/// width of `long double` (53 bits on MSVC and on Clang for Apple Silicon) and on the standard
-/// library's formatter, which narrows to `double` on some toolchains even where the type is wider.
-/// The only width guaranteed everywhere is `std::numeric_limits<double>::digits10`; above it,
-/// `ToUnscaledValue()` is the only accessor that can be relied on. `docs/data-binder.md` tabulates
-/// what each accessor delivers.
+/// that any given platform renders 19 through the floating-point accessors: how many digits
+/// `ToString()` delivers depends both on the width of `long double` (53 bits on MSVC and on Clang
+/// for Apple Silicon) and on the standard library's formatter, which narrows to `double` on some
+/// toolchains even where the type is wider. The only width guaranteed everywhere is
+/// `std::numeric_limits<double>::digits10`; above it, `ToUnscaledValue()` is the only accessor that
+/// can be relied on — and it now carries all 19 digits on every toolchain, which it previously did
+/// not. `docs/data-binder.md` tabulates what each accessor delivers.
 ///
 /// NB: `inline` is load-bearing. At namespace scope `constexpr` implies `const`, hence internal
 /// linkage, and an exported template in the module interface (`SqlNumeric`, via its static_assert)
 /// may not reference an internal-linkage entity.
 inline constexpr std::size_t SqlMaxNumericPrecision =
-#if defined(LIGHTWEIGHT_INT128_T)
     detail::DecimalDigitsForBits(64); // 19 — bounded by the `long double` significand every accessor divides through
-#else
-    detail::DecimalDigitsForBits(63); // 18 — bounded by the `int64_t` magnitude that carries the unscaled value
-#endif
 
 /// Represents a fixed-point number with a given precision and scale.
 ///
@@ -114,12 +103,10 @@ struct SqlNumeric
     static constexpr auto ColumnType = SqlColumnTypeDefinitions::Decimal { .precision = Precision, .scale = TheScale };
 
     static_assert(Precision > 0, "A fixed-point number must have at least one digit.");
-    // NB: This bound is 19 where the toolchain has a 128-bit integer and 18 where it does not
-    // (MSVC, clang-cl), so `SqlNumeric<19, 4>` — what ddl2cpp emits for MS SQL Server's `money` —
-    // is a compile error on those toolchains. That asymmetry is deliberate: on an `int64_t`
-    // carrier a 19-digit unscaled value overflows, and the resulting out-of-range conversion is
-    // undefined behaviour that silently flips the sign of the value. Failing to build is the
-    // strictly better of the two. See SqlMaxNumericPrecision for the derivation.
+    // NB: This bound is 19 on every toolchain, so `SqlNumeric<19, 4>` — what ddl2cpp emits for MS
+    // SQL Server's `money` — compiles everywhere. It is the same value under MSVC and clang-cl
+    // because `Int128` supplies a software 128-bit carrier where the compiler has no native one;
+    // see SqlMaxNumericPrecision for the derivation.
     static_assert(Precision <= SqlMaxNumericPrecision,
                   "Precision exceeds the number of decimal digits this implementation can carry. Read the column as a "
                   "string instead, or narrow the column.");
@@ -173,13 +160,12 @@ struct SqlNumeric
         sqlValue.scale = static_cast<SQLSCHAR>(Scale);
 
         auto const unscaledValue = std::roundl(static_cast<long double>(std::abs(inputValue) * std::powl(10.0L, Scale)));
-#if defined(LIGHTWEIGHT_INT128_T)
-        auto const num = static_cast<LIGHTWEIGHT_INT128_T>(unscaledValue);
+
+        // `Int128` is 128 bits wide on every toolchain, so the unscaled value of even the widest
+        // declarable precision fits without the out-of-range conversion the old `int64_t` fallback
+        // performed. `sqlValue.val` is little-endian and exactly this wide (asserted above).
+        auto const num = static_cast<Int128>(unscaledValue);
         std::memcpy(sqlValue.val, &num, sizeof(num));
-#else
-        auto const num = static_cast<int64_t>(unscaledValue);
-        std::memcpy(sqlValue.val, &num, sizeof(num));
-#endif
     }
 
     /// Assigns a floating point value to the numeric.
@@ -190,66 +176,89 @@ struct SqlNumeric
     }
 
     /// Converts the numeric to an unscaled integer value.
-    [[nodiscard]] constexpr LIGHTWEIGHT_FORCE_INLINE auto ToUnscaledValue() const noexcept
+    ///
+    /// This is the only accessor that does not divide through a floating-point type, and therefore
+    /// the only one that carries every digit up to `SqlMaxNumericPrecision` on every toolchain.
+    ///
+    /// @return `value * 10^Scale` as a signed 128-bit integer.
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE Int128 ToUnscaledValue() const noexcept
     {
         if (nativeValue != 0.0)
-        {
-            auto const unscaledValue = std::roundl(nativeValue * std::powl(10.0L, Scale));
-#if defined(LIGHTWEIGHT_INT128_T)
-            return static_cast<LIGHTWEIGHT_INT128_T>(unscaledValue);
-#else
-            return static_cast<int64_t>(unscaledValue);
-#endif
-        }
+            return static_cast<Int128>(std::roundl(nativeValue * std::powl(10.0L, Scale)));
 
-        auto const sign = sqlValue.sign ? 1 : -1;
-#if defined(LIGHTWEIGHT_INT128_T)
-        return sign * *reinterpret_cast<LIGHTWEIGHT_INT128_T const*>(sqlValue.val);
-#else
-        return sign * *reinterpret_cast<int64_t const*>(sqlValue.val);
-#endif
+        // `sqlValue.val` sits at offset 3 of a 1-aligned struct, so it cannot be dereferenced
+        // through a 128-bit pointer without a misaligned load; copy it out instead. Both `Int128`
+        // implementations are little-endian 16-byte two's complement, matching the field's layout.
+        auto magnitude = Int128 {};
+        std::memcpy(&magnitude, sqlValue.val, sizeof(magnitude));
+
+        return sqlValue.sign ? magnitude : -magnitude;
     }
 
     /// Converts the numeric to a floating point value.
-    [[nodiscard]] constexpr LIGHTWEIGHT_FORCE_INLINE float ToFloat() const noexcept
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE float ToFloat() const noexcept
     {
         return static_cast<float>(ToUnscaledValue()) / std::powf(10, sqlValue.scale);
     }
 
     /// Converts the numeric to a double precision floating point value.
-    [[nodiscard]] constexpr LIGHTWEIGHT_FORCE_INLINE double ToDouble() const noexcept
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE double ToDouble() const noexcept
     {
         return static_cast<double>(ToUnscaledValue()) / std::pow(10, sqlValue.scale);
     }
 
     /// Converts the numeric to a long double precision floating point value.
-    [[nodiscard]] constexpr LIGHTWEIGHT_FORCE_INLINE long double ToLongDouble() const noexcept
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE long double ToLongDouble() const noexcept
     {
         return static_cast<long double>(ToUnscaledValue()) / std::pow(10, sqlValue.scale);
     }
 
     /// Converts the numeric to a floating point value.
-    [[nodiscard]] constexpr LIGHTWEIGHT_FORCE_INLINE explicit operator float() const noexcept
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE explicit operator float() const noexcept
     {
         return ToFloat();
     }
 
     /// Converts the numeric to a double precision floating point value.
-    [[nodiscard]] constexpr LIGHTWEIGHT_FORCE_INLINE explicit operator double() const noexcept
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE explicit operator double() const noexcept
     {
         return ToDouble();
     }
 
     /// Converts the numeric to a long double precision floating point value.
-    [[nodiscard]] constexpr LIGHTWEIGHT_FORCE_INLINE explicit operator long double() const noexcept
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE explicit operator long double() const noexcept
     {
         return ToLongDouble();
     }
 
-    /// Converts the numeric to a string.
+    /// Converts the numeric to a string, exactly.
+    ///
+    /// Rendered from the unscaled integer rather than by formatting `ToLongDouble()`, so every digit
+    /// the carrier holds survives on every toolchain. Formatting through `long double` used to drop
+    /// the low digits wherever that type is narrow (53 bits on MSVC and on Clang for Apple Silicon)
+    /// or wherever the standard library's formatter narrows to `double` regardless.
+    ///
+    /// @return The value in plain decimal notation with exactly `Scale` fractional digits.
     [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE std::string ToString() const
     {
-        return std::format("{:.{}f}", ToLongDouble(), Scale);
+        auto const unscaled = ToUnscaledValue();
+        auto digits = detail::Int128ToString(unscaled);
+
+        auto const negative = !digits.empty() && digits.front() == '-';
+        if (negative)
+            digits.erase(digits.begin());
+
+        if constexpr (Scale == 0)
+            return negative ? "-" + digits : digits;
+
+        // Left-pad so there is at least one integral digit to the left of the point, which is what a
+        // purely fractional type (Scale == Precision, e.g. DECIMAL(4, 4)) always needs.
+        if (digits.size() <= Scale)
+            digits.insert(digits.begin(), Scale + 1 - digits.size(), '0');
+
+        digits.insert(digits.size() - Scale, 1, '.');
+
+        return negative ? "-" + digits : digits;
     }
 
     /// Three-way comparison operator.
@@ -257,15 +266,14 @@ struct SqlNumeric
     /// Comparing two `SqlNumeric` values yields `std::partial_ordering` because the
     /// underlying conversion to `double` admits NaN inputs. In practice every value
     /// produced by this type is finite, so the result is totally ordered.
-    [[nodiscard]] constexpr LIGHTWEIGHT_FORCE_INLINE std::partial_ordering operator<=>(
-        SqlNumeric const& other) const noexcept
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE std::partial_ordering operator<=>(SqlNumeric const& other) const noexcept
     {
         return ToDouble() <=> other.ToDouble();
     }
 
     /// Equality comparison operator.
     template <std::size_t OtherPrecision, std::size_t OtherScale>
-    [[nodiscard]] constexpr LIGHTWEIGHT_FORCE_INLINE bool operator==(
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE bool operator==(
         SqlNumeric<OtherPrecision, OtherScale> const& other) const noexcept
     {
         return ToFloat() == other.ToFloat();

--- a/src/Lightweight/DataBinder/SqlNumeric.hpp
+++ b/src/Lightweight/DataBinder/SqlNumeric.hpp
@@ -33,7 +33,11 @@ namespace Lightweight
 /// digits that can be stored is `floor(bits * log10(2))`, computed here with integer arithmetic
 /// (`log10(2) ~= 0.30103`) so it stays usable in a constant expression: 128 bits -> 38 digits,
 /// which is also the maximum `DECIMAL`/`NUMERIC` precision of MS SQL Server and PostgreSQL.
-constexpr std::size_t SqlMaxNumericPrecision = (std::size_t { SQL_MAX_NUMERIC_LEN } * 8 * 30103) / 100'000;
+///
+/// NB: `inline` is load-bearing. At namespace scope `constexpr` implies `const`, hence internal
+/// linkage, and an exported template in the module interface (`SqlNumeric`, via its static_assert)
+/// may not reference an internal-linkage entity.
+inline constexpr std::size_t SqlMaxNumericPrecision = (std::size_t { SQL_MAX_NUMERIC_LEN } * 8 * 30103) / 100'000;
 
 /// Represents a fixed-point number with a given precision and scale.
 ///

--- a/src/Lightweight/DataBinder/SqlNumeric.hpp
+++ b/src/Lightweight/DataBinder/SqlNumeric.hpp
@@ -40,7 +40,9 @@ constexpr std::size_t SqlMaxNumericPrecision = (std::size_t { SQL_MAX_NUMERIC_LE
 /// Precision is *exactly* the total number of digits in the number,
 /// including the digits after the decimal point.
 ///
-/// Scale is the number of digits after the decimal point.
+/// Scale is the number of digits after the decimal point, and may be anywhere in `[0, Precision]`.
+/// `Scale == Precision` denotes a purely fractional number, e.g. `SqlNumeric<4, 4>` covers
+/// `[0.0000, 0.9999]` — the C++ equivalent of SQL's `DECIMAL(4, 4)`.
 ///
 /// @ingroup DataTypes
 template <std::size_t ThePrecision, std::size_t TheScale>
@@ -55,9 +57,14 @@ struct SqlNumeric
     /// The SQL column type definition for this numeric type.
     static constexpr auto ColumnType = SqlColumnTypeDefinitions::Decimal { .precision = Precision, .scale = TheScale };
 
+    static_assert(Precision > 0, "A fixed-point number must have at least one digit.");
     static_assert(Precision <= SqlMaxNumericPrecision,
                   "Precision is a count of decimal digits and must fit into the SQL_NUMERIC_STRUCT mantissa.");
-    static_assert(Scale < Precision);
+    // `DECIMAL(p, s)` requires 0 <= s <= p; `s == p` denotes a purely fractional number (e.g.
+    // DECIMAL(4, 4) holds [0, 1) with four fractional digits) and is legal in every supported
+    // backend. No conversion path here needs an integral digit: the value is kept as the unscaled
+    // integer `value * 10^Scale`, and every accessor divides that by `10^Scale` again.
+    static_assert(Scale <= Precision, "Scale counts digits after the decimal point and cannot exceed Precision.");
 
     /// The SQL numeric struct for ODBC binding.
     SQL_NUMERIC_STRUCT sqlValue {};

--- a/src/Lightweight/DataBinder/SqlNumeric.hpp
+++ b/src/Lightweight/DataBinder/SqlNumeric.hpp
@@ -64,19 +64,22 @@ namespace detail
 ///   yields `INT64_MIN` and renders as -922337203685477.5808, sign flipped.
 /// - **The readable width.** Every accessor except `ToUnscaledValue()` — `ToFloat`, `ToDouble`,
 ///   `ToLongDouble` and therefore `ToString` — divides through `long double`, so no more digits can
-///   be read back than that type's significand holds. The widest `long double` in use is the 80-bit
-///   x87 one, whose 64-bit significand gives `DecimalDigitsForBits(64)` == 19; beyond that
-///   `ToString()` is wrong on *every* platform, e.g. a fetched `SqlNumeric<20, 0>` holding
+///   be read back than that type's significand holds. The widest one in use is the 80-bit x87
+///   `long double`, whose 64-bit significand gives `DecimalDigitsForBits(64)` == 19; beyond that
+///   nothing is readable on *any* platform, e.g. a fetched `SqlNumeric<20, 0>` holding
 ///   99999999999999999999 prints as 100000000000000000000.
 ///
 /// Hence 18 without a 128-bit carrier and 19 with one. `DECIMAL(18, s)` compiles everywhere and
 /// `money` (`DECIMAL(19, 4)`) compiles wherever `__int128` exists; a wider column must be read as a
 /// string.
 ///
-/// NB: 19 is the point beyond which nothing is readable anywhere; it is not a promise that every
-/// platform renders all 19. Where `long double` is a `double` (MSVC, and Clang on Apple Silicon)
-/// `ToString()` carries only 15 digits, and `ToUnscaledValue()` is the only way to see the rest.
-/// `docs/data-binder.md` tabulates what each accessor delivers.
+/// NB: 19 is the point past which nothing is readable *anywhere*. It is emphatically not a promise
+/// that any given platform renders 19: how many digits `ToString()` delivers depends both on the
+/// width of `long double` (53 bits on MSVC and on Clang for Apple Silicon) and on the standard
+/// library's formatter, which narrows to `double` on some toolchains even where the type is wider.
+/// The only width guaranteed everywhere is `std::numeric_limits<double>::digits10`; above it,
+/// `ToUnscaledValue()` is the only accessor that can be relied on. `docs/data-binder.md` tabulates
+/// what each accessor delivers.
 ///
 /// NB: `inline` is load-bearing. At namespace scope `constexpr` implies `const`, hence internal
 /// linkage, and an exported template in the module interface (`SqlNumeric`, via its static_assert)

--- a/src/Lightweight/DataBinder/SqlNumeric.hpp
+++ b/src/Lightweight/DataBinder/SqlNumeric.hpp
@@ -49,30 +49,30 @@ namespace detail
 /// under MSVC and clang-cl as well.
 ///
 /// The bound is deliberately *not* derived from `SQL_MAX_NUMERIC_LEN`. That macro is the size **in
-/// bytes** of `SQL_NUMERIC_STRUCT::val` (16, i.e. a 128-bit mantissa), not a decimal precision, so
-/// the historical `static_assert(Precision <= SQL_MAX_NUMERIC_LEN)` was a category error that
-/// rejected perfectly ordinary columns such as `DECIMAL(18, 2)`.
+/// bytes** of `SQL_NUMERIC_STRUCT::val` (16, i.e. a 128-bit mantissa), not a decimal precision;
+/// comparing a digit count against it is a category error that rejects perfectly ordinary columns
+/// such as `DECIMAL(18, 2)`.
 ///
-/// Bounding by the mantissa's theoretical capacity instead (128 bits -> 38 digits) would be the
-/// same category error in the other direction: 38 is what the ODBC *struct* could hold, not what
-/// this implementation can read back. What narrows it is the **readable width**: every accessor
-/// except `ToUnscaledValue()` — `ToFloat`, `ToDouble`, `ToLongDouble` and therefore `ToString` —
-/// divides through `long double`, so no more digits can be read back than that type's significand
-/// holds. The widest one in use is the 80-bit x87 `long double`, whose 64-bit significand gives
-/// `DecimalDigitsForBits(64)` == 19; beyond that nothing is readable on *any* platform, e.g. a
-/// fetched `SqlNumeric<20, 0>` holding 99999999999999999999 prints as 100000000000000000000.
+/// Bounding by the mantissa's theoretical capacity instead (128 bits -> 38 digits) is the same
+/// category error in the other direction: 38 is what the ODBC *struct* can hold, not what this
+/// implementation can read back. What narrows it is the **readable width**: every accessor except
+/// `ToUnscaledValue()` and `ToString()` — that is, `ToFloat`, `ToDouble` and `ToLongDouble` —
+/// divides through `long double`, so no more digits can be read back through those than that
+/// type's significand holds. The widest one in use is the 80-bit x87 `long double`, whose 64-bit
+/// significand gives `DecimalDigitsForBits(64)` == 19; beyond that nothing is readable on *any*
+/// platform, e.g. a fetched `SqlNumeric<20, 0>` holding 99999999999999999999 reads back as
+/// 100000000000000000000.
 ///
 /// Hence 19, everywhere. `DECIMAL(18, s)` and MS SQL Server's `money` (`DECIMAL(19, 4)`) both
 /// compile on every supported toolchain; a wider column must be read as a string.
 ///
 /// NB: 19 is the point past which nothing is readable *anywhere*. It is emphatically not a promise
-/// that any given platform renders 19 through the floating-point accessors: how many digits
-/// `ToString()` delivers depends both on the width of `long double` (53 bits on MSVC and on Clang
-/// for Apple Silicon) and on the standard library's formatter, which narrows to `double` on some
-/// toolchains even where the type is wider. The only width guaranteed everywhere is
-/// `std::numeric_limits<double>::digits10`; above it, `ToUnscaledValue()` is the only accessor that
-/// can be relied on — and it now carries all 19 digits on every toolchain, which it previously did
-/// not. `docs/data-binder.md` tabulates what each accessor delivers.
+/// that any given platform delivers 19 digits through the *floating-point* accessors: those are
+/// bounded by the width of `long double`, which is 53 bits on MSVC and on Clang for Apple Silicon.
+/// The width they guarantee everywhere is `std::numeric_limits<double>::digits10`. Above that,
+/// `ToUnscaledValue()` and `ToString()` are the accessors to rely on: neither divides through a
+/// floating-point type, so both carry all 19 digits on every toolchain.
+/// `docs/data-binder.md` tabulates what each accessor delivers.
 ///
 /// NB: `inline` is load-bearing. At namespace scope `constexpr` implies `const`, hence internal
 /// linkage, and an exported template in the module interface (`SqlNumeric`, via its static_assert)
@@ -162,8 +162,8 @@ struct SqlNumeric
         auto const unscaledValue = std::roundl(static_cast<long double>(std::abs(inputValue) * std::powl(10.0L, Scale)));
 
         // `Int128` is 128 bits wide on every toolchain, so the unscaled value of even the widest
-        // declarable precision fits without the out-of-range conversion the old `int64_t` fallback
-        // performed. `sqlValue.val` is little-endian and exactly this wide (asserted above).
+        // declarable precision fits, and the conversion stays in range. `sqlValue.val` is
+        // little-endian and exactly this wide (asserted above).
         auto const num = static_cast<Int128>(unscaledValue);
         std::memcpy(sqlValue.val, &num, sizeof(num));
     }
@@ -177,8 +177,9 @@ struct SqlNumeric
 
     /// Converts the numeric to an unscaled integer value.
     ///
-    /// This is the only accessor that does not divide through a floating-point type, and therefore
-    /// the only one that carries every digit up to `SqlMaxNumericPrecision` on every toolchain.
+    /// Along with `ToString()`, which renders from this value, it is one of the two accessors that
+    /// do not divide through a floating-point type, and therefore carries every digit up to
+    /// `SqlMaxNumericPrecision` on every toolchain. The floating-point accessors do not.
     ///
     /// @return `value * 10^Scale` as a signed 128-bit integer.
     [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE Int128 ToUnscaledValue() const noexcept
@@ -234,7 +235,7 @@ struct SqlNumeric
     /// Converts the numeric to a string, exactly.
     ///
     /// Rendered from the unscaled integer rather than by formatting `ToLongDouble()`, so every digit
-    /// the carrier holds survives on every toolchain. Formatting through `long double` used to drop
+    /// the carrier holds survives on every toolchain. Formatting through `long double` would drop
     /// the low digits wherever that type is narrow (53 bits on MSVC and on Clang for Apple Silicon)
     /// or wherever the standard library's formatter narrows to `double` regardless.
     ///

--- a/src/Lightweight/Lightweight.cppm
+++ b/src/Lightweight/Lightweight.cppm
@@ -159,6 +159,7 @@ using Lightweight::SqlLockFailureReason;
 using Lightweight::SqlLogger;
 using Lightweight::SqlMaxDynamicAnsiString;
 using Lightweight::SqlMaxDynamicWideString;
+using Lightweight::SqlMaxNumericPrecision;
 using Lightweight::SqlMigrationDeleteBuilder;
 using Lightweight::SqlMigrationInsertBuilder;
 using Lightweight::SqlMigrationPlan;

--- a/src/Lightweight/Lightweight.cppm
+++ b/src/Lightweight/Lightweight.cppm
@@ -60,6 +60,7 @@ using Lightweight::HasManyThrough;
 using Lightweight::HasOneThrough;
 using Lightweight::HasPrimaryKey;
 using Lightweight::IndexType;
+using Lightweight::Int128; // the unscaled carrier in SqlNumeric::ToUnscaledValue()'s return type
 using Lightweight::Int64DataBinderHelper;
 using Lightweight::IsAutoIncrementPrimaryKey;
 using Lightweight::IsBelongsTo;

--- a/src/Lightweight/SqlSchema.cpp
+++ b/src/Lightweight/SqlSchema.cpp
@@ -1433,10 +1433,9 @@ namespace detail
                     // some special handling of weird types
                     // NB: `money` needs no fixup: the driver reports its true COLUMN_SIZE /
                     // DECIMAL_DIGITS (19 / 4 on MS SQL Server), which is exactly what
-                    // MakeColumnTypeFromNative turns into Decimal { 19, 4 } above. An older
-                    // revision overwrote the precision with SQL_MAX_NUMERIC_LEN to dodge a
-                    // (since corrected) SqlNumeric precision cap, at the cost of reporting a
-                    // wrong precision and scale to every consumer of SqlSchema::Column.
+                    // MakeColumnTypeFromNative turns into Decimal { 19, 4 } above. Overwriting
+                    // the precision here would report a wrong precision and scale to every
+                    // consumer of SqlSchema::Column.
                     if (column.dialectDependantTypeString == "float" || column.dialectDependantTypeString == "FLOAT"
                         || column.dialectDependantTypeString == "real" || column.dialectDependantTypeString == "REAL")
                     {

--- a/src/Lightweight/SqlSchema.cpp
+++ b/src/Lightweight/SqlSchema.cpp
@@ -671,6 +671,10 @@ namespace
     struct MssqlColumnRow
     {
         std::string name;
+        /// Name of the underlying *system* type. For a column declared with an alias type
+        /// (`CREATE TYPE ... FROM nvarchar(50)`) or with `sysname`, this is the base type
+        /// (`nvarchar`), not the alias name — the alias name carries no type information and
+        /// would otherwise fall into the unmapped-type fallback.
         std::string sysTypeName;
         int maxLength = 0;
         int precision = 0;
@@ -719,10 +723,17 @@ namespace
         auto const schemaFilter = !schema.empty()
                                       ? std::format("WHERE SCHEMA_NAME(t.schema_id) = '{}'", EscapeSqlLiteral(schema))
                                       : std::string {};
+        // COALESCE(baseType.name, userType.name): alias types (`CREATE TYPE ... FROM nvarchar(50)`,
+        // and the built-in `sysname`) have a user_type_id of their own but carry the type
+        // information of their base system type. Resolving them here keeps a column declared with
+        // an alias type mapped exactly like the same column declared with its base type — the
+        // legacy SQLColumns path sees the resolved ODBC type as well. The LEFT JOIN keeps
+        // exotic/CLR types (whose system_type_id has no sys.types row of its own) in the result,
+        // falling back to their own name.
         auto const sql = std::format(R"(SELECT c.object_id,
                                                c.column_id,
                                                c.name,
-                                               ty.name,
+                                               COALESCE(bt.name, ty.name),
                                                CAST(c.max_length AS int),
                                                CAST(c.precision AS int),
                                                CAST(c.scale AS int),
@@ -732,6 +743,7 @@ namespace
                                         FROM sys.columns c
                                         INNER JOIN sys.tables t ON c.object_id = t.object_id
                                         INNER JOIN sys.types ty ON c.user_type_id = ty.user_type_id
+                                        LEFT JOIN sys.types bt ON ty.system_type_id = bt.user_type_id
                                         LEFT JOIN sys.default_constraints dc
                                                ON dc.parent_object_id = c.object_id
                                               AND dc.parent_column_id = c.column_id
@@ -1419,15 +1431,14 @@ namespace detail
                 try
                 {
                     // some special handling of weird types
-                    if (column.dialectDependantTypeString == "money")
-                    {
-                        // 0.123 -> decimalDigits = 3 size = 4
-                        // 100.123 -> decimalDigits = 3  size = 6
-                        column.size = column.decimalDigits;
-                        column.decimalDigits = SQL_MAX_NUMERIC_LEN;
-                    }
-                    else if (column.dialectDependantTypeString == "float" || column.dialectDependantTypeString == "FLOAT"
-                             || column.dialectDependantTypeString == "real" || column.dialectDependantTypeString == "REAL")
+                    // NB: `money` needs no fixup: the driver reports its true COLUMN_SIZE /
+                    // DECIMAL_DIGITS (19 / 4 on MS SQL Server), which is exactly what
+                    // MakeColumnTypeFromNative turns into Decimal { 19, 4 } above. An older
+                    // revision overwrote the precision with SQL_MAX_NUMERIC_LEN to dodge a
+                    // (since corrected) SqlNumeric precision cap, at the cost of reporting a
+                    // wrong precision and scale to every consumer of SqlSchema::Column.
+                    if (column.dialectDependantTypeString == "float" || column.dialectDependantTypeString == "FLOAT"
+                        || column.dialectDependantTypeString == "real" || column.dialectDependantTypeString == "REAL")
                     {
                         column.type = SqlColumnTypeDefinitions::Real { .precision = 53 };
                         // column.size = 15; // Try letting it be default (from SQLColumns or 0)

--- a/src/Lightweight/Tools/CxxModelPrinter.cpp
+++ b/src/Lightweight/Tools/CxxModelPrinter.cpp
@@ -2,8 +2,12 @@
 
 #include "CxxModelPrinter.hpp"
 
+#include <Lightweight/DataBinder/SqlNumeric.hpp>
+
 #include <array>
 #include <fstream>
+#include <limits>
+#include <variant>
 
 using namespace std::string_view_literals;
 
@@ -386,6 +390,49 @@ SqlSchema::ForeignKeyConstraint const& CxxModelPrinter::GetForeignKey(
                     column.foreignKeyConstraint->foreignKey.table)); // NOLINT(bugprone-unchecked-optional-access)
 }
 
+std::string CxxModelPrinter::MakeDecimalPrecisionNote(SqlSchema::Column const& column)
+{
+    auto const* const decimal = std::get_if<SqlColumnTypeDefinitions::Decimal>(&column.type);
+    if (decimal == nullptr)
+        return {};
+
+    // Number of significant decimal digits an IEEE-754 double preserves. `SqlNumeric`'s binder
+    // deliberately routes SQLite and MS SQL Server through SQL_C_DOUBLE (see
+    // `NativeNumericSupportIsBroken`), so on those backends this is all a value carries — no
+    // matter how wide the column was declared.
+    constexpr auto fallbackDigits = static_cast<std::size_t>(std::numeric_limits<double>::digits10);
+
+    // Widest precision `SqlNumeric` accepts on a toolchain without a 128-bit integer (MSVC,
+    // clang-cl), where the unscaled value is carried by an `int64_t`. This is deliberately *not*
+    // `SqlMaxNumericPrecision`: that is the bound of whichever toolchain built ddl2cpp, while the
+    // generated header may well be compiled by another one.
+    constexpr auto portablePrecision = detail::DecimalDigitsForBits(63);
+
+    std::string note;
+
+    if (decimal->precision > fallbackDigits)
+        note += std::format("    // NOTE: DECIMAL({}, {}) declares {} digits, but SqlNumeric transfers this column through\n"
+                            "    //       SQL_C_DOUBLE on SQLite and MS SQL Server, which carries only {}. The low {}\n"
+                            "    //       digit(s) are lost silently there — e.g. MS SQL Server reads its own `money`\n"
+                            "    //       maximum 922337203685477.5807 back as 922337203685477.6250. Read the column as\n"
+                            "    //       a string if those digits matter. See docs/data-binder.md.\n",
+                            decimal->precision,
+                            decimal->scale,
+                            decimal->precision,
+                            fallbackDigits,
+                            decimal->precision - fallbackDigits);
+
+    if (decimal->precision > portablePrecision)
+        note += std::format("    // NOTE: SqlNumeric<{}, {}> requires a toolchain with a 128-bit integer type. It does\n"
+                            "    //       not compile with MSVC or clang-cl, whose {}-digit int64_t carrier cannot hold\n"
+                            "    //       the unscaled value.\n",
+                            decimal->precision,
+                            decimal->scale,
+                            portablePrecision);
+
+    return note;
+}
+
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 std::string CxxModelPrinter::MakeType(
     SqlSchema::Column const& column,
@@ -715,6 +762,7 @@ void CxxModelPrinter::PrintTable(SqlSchema::Table const& table)
         {
             auto const emittedName = uniqueMemberNameBuilder.DeclareName(memberName);
             definition.members.emplace_back(emittedName, column.name);
+            definition.text << MakeDecimalPrecisionNote(column);
             definition.text << std::format(
                 "    Light::Field<{}{}{}> {};", type, primaryKeyPart(), aliasName(column.name), emittedName);
             if (column.isForeignKey)
@@ -726,6 +774,7 @@ void CxxModelPrinter::PrintTable(SqlSchema::Table const& table)
         // Fallback: Handle the column as a regular field.
         auto const emittedName = uniqueMemberNameBuilder.DeclareName(memberName);
         definition.members.emplace_back(emittedName, column.name);
+        definition.text << MakeDecimalPrecisionNote(column);
         definition.text << std::format("    Light::Field<{}{}> {};", type, aliasName(column.name), emittedName);
         if (column.isForeignKey)
             definition.text << std::format(" // NB: This is also a foreign key");

--- a/src/Lightweight/Tools/CxxModelPrinter.cpp
+++ b/src/Lightweight/Tools/CxxModelPrinter.cpp
@@ -335,8 +335,7 @@ std::string CxxModelPrinter::HeaderFileForTheTable(std::string_view modelNamespa
     output << "#pragma once\n";
     output << "\n";
 
-    auto requiredTables = _definitions[tableName].requiredTables;
-    std::ranges::sort(requiredTables);
+    auto const& requiredTables = _definitions[tableName].requiredTables;
     for (auto const& requiredTable: requiredTables)
         output << std::format("#include \"{}.hpp\"\n", requiredTable);
     if (!std::empty(requiredTables))
@@ -705,7 +704,7 @@ void CxxModelPrinter::PrintTable(SqlSchema::Table const& table)
                     }(),
                     emittedName);
                 definition.members.emplace_back(emittedName, column.name);
-                definition.requiredTables.emplace_back(std::move(foreignTableName));
+                definition.requiredTables.emplace(std::move(foreignTableName));
                 ++_numberOfForeignKeysListed;
                 continue;
             }

--- a/src/Lightweight/Tools/CxxModelPrinter.cpp
+++ b/src/Lightweight/Tools/CxxModelPrinter.cpp
@@ -402,11 +402,10 @@ std::string CxxModelPrinter::MakeDecimalPrecisionNote(SqlSchema::Column const& c
     // matter how wide the column was declared.
     constexpr auto fallbackDigits = static_cast<std::size_t>(std::numeric_limits<double>::digits10);
 
-    // Widest precision `SqlNumeric` accepts on a toolchain without a 128-bit integer (MSVC,
-    // clang-cl), where the unscaled value is carried by an `int64_t`. This is deliberately *not*
-    // `SqlMaxNumericPrecision`: that is the bound of whichever toolchain built ddl2cpp, while the
-    // generated header may well be compiled by another one.
-    constexpr auto portablePrecision = detail::DecimalDigitsForBits(63);
+    // Widest precision `SqlNumeric` accepts. This is toolchain-independent — `Int128` supplies a
+    // software 128-bit carrier where the compiler has no native one — so it is equally the bound of
+    // whichever toolchain built ddl2cpp and of whichever one compiles the generated header.
+    constexpr auto maxPrecision = SqlMaxNumericPrecision;
 
     std::string note;
 
@@ -422,13 +421,13 @@ std::string CxxModelPrinter::MakeDecimalPrecisionNote(SqlSchema::Column const& c
                             fallbackDigits,
                             decimal->precision - fallbackDigits);
 
-    if (decimal->precision > portablePrecision)
-        note += std::format("    // NOTE: SqlNumeric<{}, {}> requires a toolchain with a 128-bit integer type. It does\n"
-                            "    //       not compile with MSVC or clang-cl, whose {}-digit int64_t carrier cannot hold\n"
-                            "    //       the unscaled value.\n",
+    if (decimal->precision > maxPrecision)
+        note += std::format("    // NOTE: SqlNumeric<{}, {}> does not compile: {} digits exceed the {} this implementation\n"
+                            "    //       can carry. Read this column as a string instead, or narrow it.\n",
                             decimal->precision,
                             decimal->scale,
-                            portablePrecision);
+                            decimal->precision,
+                            maxPrecision);
 
     return note;
 }

--- a/src/Lightweight/Tools/CxxModelPrinter.hpp
+++ b/src/Lightweight/Tools/CxxModelPrinter.hpp
@@ -9,6 +9,7 @@
 #include <expected>
 #include <filesystem>
 #include <map>
+#include <set>
 #include <string>
 #include <unordered_set>
 #include <utility>
@@ -92,7 +93,10 @@ class CxxModelPrinter
     struct TableInfo
     {
         std::stringstream text;
-        std::vector<std::string> requiredTables;
+        /// Headers this record depends on, one entry per *distinct* referenced table. A table with
+        /// several foreign-key columns pointing at the same target must still be included once, so
+        /// this is a set (which also gives the emitted `#include` block a stable, sorted order).
+        std::set<std::string> requiredTables;
         std::string structName;                                   //< C++ struct name (possibly aliased).
         std::vector<std::pair<std::string, std::string>> members; //< (emitted member id, SQL column name), in order.
     };

--- a/src/Lightweight/Tools/CxxModelPrinter.hpp
+++ b/src/Lightweight/Tools/CxxModelPrinter.hpp
@@ -77,6 +77,19 @@ class CxxModelPrinter
                                 UnicodeTextColumnOverrides const& unicodeTextColumnOverrides,
                                 size_t sqlFixedStringMaxSize);
 
+    /// Renders the `// NOTE:` comment block to emit above a generated member for a `DECIMAL`
+    /// column whose declared precision is wider than what `SqlDataBinder<SqlNumeric<P, S>>` can
+    /// actually deliver.
+    ///
+    /// The emitted `Light::SqlNumeric<P, S>` carries the column's declared precision, but the
+    /// transfer does not always carry the matching number of digits, and nothing at the call site
+    /// says so. Rather than silently generating a lossy record, state the limit where a ddl2cpp
+    /// consumer reads it — in the generated header itself.
+    ///
+    /// @param column Column to describe; non-`DECIMAL` columns and narrow ones yield no note.
+    /// @return The note, each line already indented and newline-terminated, or an empty string.
+    [[nodiscard]] static std::string MakeDecimalPrecisionNote(SqlSchema::Column const& column);
+
     [[nodiscard]] std::optional<std::string> MapColumnNameOverride(SqlSchema::FullyQualifiedTableName const& tableName,
                                                                    std::string const& columnName) const;
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ set(SOURCE_FILES
     DataMapper/BelongsToStateTests.cpp
     DataMapper/StateTests.cpp
     FieldTests.cpp
+    Int128Tests.cpp
     LargeTestDatabase/DataGenerator.cpp
     LargeTestDatabase/LargeTestDatabaseTests.cpp
     MigrationTests.cpp

--- a/src/tests/CxxModelPrinterTests.cpp
+++ b/src/tests/CxxModelPrinterTests.cpp
@@ -227,8 +227,8 @@ TEST_CASE("CxxModelPrinter::MakeType: money maps to a type SqlNumeric accepts", 
     using namespace Lightweight::SqlColumnTypeDefinitions;
 
     // MS SQL Server reports `money` as DECIMAL(19, 4) and `smallmoney` as DECIMAL(10, 4); the
-    // emitted type must carry those exact values (issue #519 hit a SqlNumeric static_assert that
-    // compared decimal digits against a byte count).
+    // emitted type must carry those exact values. Bounding Precision by a byte count rather than a
+    // digit count rejects both (issue #519).
     CHECK(CxxTypeName({ .name = "price", .type = Decimal { .precision = 19, .scale = 4 }, .isNullable = false })
           == "Light::SqlNumeric<19, 4>");
     CHECK(CxxTypeName({ .name = "price", .type = Decimal { .precision = 10, .scale = 4 }, .isNullable = false })
@@ -265,8 +265,8 @@ TEST_CASE("CxxModelPrinter::MakeDecimalPrecisionNote", "[CxxModelPrinter],[MakeT
     CHECK(wide.contains("DECIMAL(18, 2)"));
     CHECK(!wide.contains("does not compile"));
 
-    // `money` (DECIMAL(19, 4)) is at the bound, so only the transfer-precision note applies. It is
-    // instantiable on every toolchain, so no "does not compile" note is emitted for it any more.
+    // `money` (DECIMAL(19, 4)) is at the bound, so only the transfer-precision note applies: it is
+    // instantiable on every toolchain, so no "does not compile" note is emitted for it.
     auto const money = CxxModelPrinter::MakeDecimalPrecisionNote(
         { .name = "price", .type = Decimal { .precision = 19, .scale = 4 }, .isNullable = false });
     CHECK(money.contains("SQL_C_DOUBLE"));

--- a/src/tests/CxxModelPrinterTests.cpp
+++ b/src/tests/CxxModelPrinterTests.cpp
@@ -219,6 +219,25 @@ TEST_CASE("CxxModelPrinter::MakeType: decimal", "[CxxModelPrinter],[MakeType]")
           == "Light::SqlNumeric<10, 2>");
 }
 
+TEST_CASE("CxxModelPrinter::MakeType: money maps to a type SqlNumeric accepts", "[CxxModelPrinter],[MakeType]")
+{
+    using namespace Lightweight::SqlColumnTypeDefinitions;
+
+    // MS SQL Server reports `money` as DECIMAL(19, 4) and `smallmoney` as DECIMAL(10, 4); the
+    // emitted type must carry those exact values *and* be instantiable (issue #519 hit a
+    // SqlNumeric static_assert that compared decimal digits against a byte count).
+    CHECK(CxxTypeName({ .name = "price", .type = Decimal { .precision = 19, .scale = 4 }, .isNullable = false })
+          == "Light::SqlNumeric<19, 4>");
+    CHECK(CxxTypeName({ .name = "price", .type = Decimal { .precision = 10, .scale = 4 }, .isNullable = false })
+          == "Light::SqlNumeric<10, 4>");
+    STATIC_CHECK(Lightweight::SqlNumeric<19, 4>::Precision <= Lightweight::SqlMaxNumericPrecision);
+
+    // The widest DECIMAL MS SQL Server / PostgreSQL support is also representable.
+    CHECK(CxxTypeName({ .name = "huge", .type = Decimal { .precision = 38, .scale = 10 }, .isNullable = false })
+          == "Light::SqlNumeric<38, 10>");
+    STATIC_CHECK(Lightweight::SqlNumeric<38, 10>::Precision <= Lightweight::SqlMaxNumericPrecision);
+}
+
 TEST_CASE("CxxModelPrinter::MakeType: date/time/timestamp/guid/binary", "[CxxModelPrinter],[MakeType]")
 {
     using namespace Lightweight::SqlColumnTypeDefinitions;
@@ -404,6 +423,61 @@ TEST_CASE("CxxModelPrinter: emits Description for a keyed table with a relation"
     CHECK(output.contains("using Members = Lightweight::RecordMemberList<&Models::Orders::id, &Models::Orders::customer>;"));
     // ...and the resolved SQL column names, where the relation keeps its real foreign-key column name.
     CHECK(output.contains(R"(FieldNames = { "id", "customer_id" };)"));
+}
+
+// Counts the non-overlapping occurrences of `needle` in `haystack`.
+static std::size_t CountOccurrences(std::string_view haystack, std::string_view needle)
+{
+    if (needle.empty())
+        return 0;
+
+    std::size_t count = 0;
+    for (auto offset = haystack.find(needle); offset != std::string_view::npos;
+         offset = haystack.find(needle, offset + needle.size()))
+        ++count;
+    return count;
+}
+
+TEST_CASE("CxxModelPrinter: emits one #include per distinct foreign-key target", "[CxxModelPrinter]")
+{
+    // A table may reference the same target table from many foreign-key columns (e.g. several
+    // lookup references). The generated header must include the target's header exactly once.
+    using namespace Lightweight::SqlColumnTypeDefinitions;
+    CxxModelPrinter printer { CxxModelPrinter::Config {} };
+
+    auto const foreignKeyTo = [](std::string_view column, std::string_view target) {
+        return Lightweight::SqlSchema::ForeignKeyConstraint {
+            .foreignKey = { .table = { .catalog = "", .schema = "", .table = "orders" },
+                            .columns = { std::string { column } } },
+            .primaryKey = { .table = { .catalog = "", .schema = "", .table = std::string { target } }, .columns = { "id" } },
+        };
+    };
+
+    printer.PrintTable(Lightweight::SqlSchema::Table {
+        .schema = "",
+        .name = "orders",
+        .columns = { { .name = "id", .type = Integer {}, .isNullable = false, .isPrimaryKey = true },
+                     { .name = "lookup_a_id", .type = Integer {}, .isNullable = false, .isForeignKey = true },
+                     { .name = "lookup_b_id", .type = Integer {}, .isNullable = false, .isForeignKey = true },
+                     { .name = "lookup_c_id", .type = Integer {}, .isNullable = false, .isForeignKey = true },
+                     { .name = "customer_id", .type = Integer {}, .isNullable = false, .isForeignKey = true } },
+        .foreignKeys = { foreignKeyTo("lookup_a_id", "lookup"),
+                         foreignKeyTo("lookup_b_id", "lookup"),
+                         foreignKeyTo("lookup_c_id", "lookup"),
+                         foreignKeyTo("customer_id", "customers") },
+        .primaryKeys = { "id" },
+    });
+
+    auto const output = printer.HeaderFileForTheTable("Models", "orders");
+
+    CHECK(CountOccurrences(output, R"(#include "lookup.hpp")") == 1);
+    CHECK(CountOccurrences(output, R"(#include "customers.hpp")") == 1);
+
+    // All four relations are still emitted as members, each with its own name.
+    CHECK(output.contains("Light::BelongsTo<&lookup::id, std::nullopt> lookupA;"));
+    CHECK(output.contains("Light::BelongsTo<&lookup::id, std::nullopt> lookupB;"));
+    CHECK(output.contains("Light::BelongsTo<&lookup::id, std::nullopt> lookupC;"));
+    CHECK(output.contains("Light::BelongsTo<&customers::id, std::nullopt> customer;"));
 }
 
 TEST_CASE("CxxModelPrinter::ResolveOrderAndPrintTable: orders by foreign-key dependencies", "[CxxModelPrinter]")

--- a/src/tests/CxxModelPrinterTests.cpp
+++ b/src/tests/CxxModelPrinterTests.cpp
@@ -13,7 +13,10 @@
 
 #include <filesystem>
 #include <fstream>
+#include <ranges>
 #include <sstream>
+#include <string>
+#include <string_view>
 
 using Lightweight::Tools::CxxModelPrinter;
 
@@ -224,18 +227,86 @@ TEST_CASE("CxxModelPrinter::MakeType: money maps to a type SqlNumeric accepts", 
     using namespace Lightweight::SqlColumnTypeDefinitions;
 
     // MS SQL Server reports `money` as DECIMAL(19, 4) and `smallmoney` as DECIMAL(10, 4); the
-    // emitted type must carry those exact values *and* be instantiable (issue #519 hit a
-    // SqlNumeric static_assert that compared decimal digits against a byte count).
+    // emitted type must carry those exact values (issue #519 hit a SqlNumeric static_assert that
+    // compared decimal digits against a byte count).
     CHECK(CxxTypeName({ .name = "price", .type = Decimal { .precision = 19, .scale = 4 }, .isNullable = false })
           == "Light::SqlNumeric<19, 4>");
     CHECK(CxxTypeName({ .name = "price", .type = Decimal { .precision = 10, .scale = 4 }, .isNullable = false })
           == "Light::SqlNumeric<10, 4>");
-    STATIC_CHECK(Lightweight::SqlNumeric<19, 4>::Precision <= Lightweight::SqlMaxNumericPrecision);
 
-    // The widest DECIMAL MS SQL Server / PostgreSQL support is also representable.
+    // `money` is instantiable wherever the toolchain has a 128-bit integer type. Where it does not
+    // (MSVC, clang-cl) the emitted record is a compile error rather than a silently sign-flipped
+    // value — MakeDecimalPrecisionNote() says so in the generated header, see below.
+#if defined(LIGHTWEIGHT_INT128_T)
+    STATIC_CHECK(Lightweight::SqlNumeric<19, 4>::Precision <= Lightweight::SqlMaxNumericPrecision);
+#endif
+
+    // ddl2cpp still emits the column's declared precision verbatim, even where that is wider than
+    // SqlNumeric accepts: truncating it here would silently misdescribe the schema, and the note
+    // emitted alongside the member explains what the transfer actually delivers.
     CHECK(CxxTypeName({ .name = "huge", .type = Decimal { .precision = 38, .scale = 10 }, .isNullable = false })
           == "Light::SqlNumeric<38, 10>");
-    STATIC_CHECK(Lightweight::SqlNumeric<38, 10>::Precision <= Lightweight::SqlMaxNumericPrecision);
+}
+
+TEST_CASE("CxxModelPrinter::MakeDecimalPrecisionNote", "[CxxModelPrinter],[MakeType]")
+{
+    using namespace Lightweight::SqlColumnTypeDefinitions;
+
+    // Anything a double carries losslessly needs no note.
+    CHECK(CxxModelPrinter::MakeDecimalPrecisionNote(
+              { .name = "amount", .type = Decimal { .precision = 15, .scale = 2 }, .isNullable = false })
+              .empty());
+    // Non-decimal columns are none of this function's business.
+    CHECK(CxxModelPrinter::MakeDecimalPrecisionNote({ .name = "id", .type = Integer {}, .isNullable = false }).empty());
+
+    // 16..18 digits: the SQL_C_DOUBLE fallback loses the low digits on SQLite and MS SQL Server,
+    // but the type itself is instantiable everywhere — one note, not two.
+    auto const wide = CxxModelPrinter::MakeDecimalPrecisionNote(
+        { .name = "amount", .type = Decimal { .precision = 18, .scale = 2 }, .isNullable = false });
+    CHECK(wide.contains("SQL_C_DOUBLE"));
+    CHECK(wide.contains("DECIMAL(18, 2)"));
+    CHECK(!wide.contains("128-bit"));
+
+    // `money`: both hazards apply.
+    auto const money = CxxModelPrinter::MakeDecimalPrecisionNote(
+        { .name = "price", .type = Decimal { .precision = 19, .scale = 4 }, .isNullable = false });
+    CHECK(money.contains("SQL_C_DOUBLE"));
+    CHECK(money.contains("922337203685477.6250"));
+    CHECK(money.contains("SqlNumeric<19, 4> requires a toolchain with a 128-bit integer type"));
+
+    // Every emitted line is a properly indented comment, so it can be dropped into a struct body.
+    for (auto const line: std::views::split(std::string_view { money }, '\n'))
+    {
+        auto const text = std::string_view { line.begin(), line.end() };
+        CHECK((text.empty() || text.starts_with("    //")));
+    }
+}
+
+TEST_CASE("CxxModelPrinter: emits the precision note next to a money member", "[CxxModelPrinter]")
+{
+    using namespace Lightweight::SqlColumnTypeDefinitions;
+    CxxModelPrinter printer { CxxModelPrinter::Config {} };
+
+    printer.PrintTable(Lightweight::SqlSchema::Table {
+        .schema = "",
+        .name = "invoices",
+        .columns = { { .name = "id", .type = Integer {}, .isNullable = false, .isPrimaryKey = true },
+                     { .name = "total", .type = Decimal { .precision = 19, .scale = 4 }, .isNullable = false },
+                     { .name = "tax_rate", .type = Decimal { .precision = 5, .scale = 4 }, .isNullable = false } },
+        .primaryKeys = { "id" },
+    });
+
+    auto const output = printer.HeaderFileForTheTable("Models", "invoices");
+
+    // The note precedes the member it describes, and only that member.
+    auto const notePosition = output.find("// NOTE: DECIMAL(19, 4)");
+    REQUIRE(notePosition != std::string::npos);
+    auto const memberPosition = output.find("Light::SqlNumeric<19, 4>");
+    REQUIRE(memberPosition != std::string::npos);
+    CHECK(notePosition < memberPosition);
+
+    // DECIMAL(5, 4) fits a double comfortably and must not be annotated.
+    CHECK(!output.contains("// NOTE: DECIMAL(5, 4)"));
 }
 
 TEST_CASE("CxxModelPrinter::MakeType: date/time/timestamp/guid/binary", "[CxxModelPrinter],[MakeType]")

--- a/src/tests/CxxModelPrinterTests.cpp
+++ b/src/tests/CxxModelPrinterTests.cpp
@@ -234,12 +234,10 @@ TEST_CASE("CxxModelPrinter::MakeType: money maps to a type SqlNumeric accepts", 
     CHECK(CxxTypeName({ .name = "price", .type = Decimal { .precision = 10, .scale = 4 }, .isNullable = false })
           == "Light::SqlNumeric<10, 4>");
 
-    // `money` is instantiable wherever the toolchain has a 128-bit integer type. Where it does not
-    // (MSVC, clang-cl) the emitted record is a compile error rather than a silently sign-flipped
-    // value — MakeDecimalPrecisionNote() says so in the generated header, see below.
-#if defined(LIGHTWEIGHT_INT128_T)
+    // `money` is instantiable on every supported toolchain — unconditionally, which is the point:
+    // the generated header must compile regardless of which compiler consumes it, and `Int128`
+    // supplies a software 128-bit carrier where the compiler has no native one.
     STATIC_CHECK(Lightweight::SqlNumeric<19, 4>::Precision <= Lightweight::SqlMaxNumericPrecision);
-#endif
 
     // ddl2cpp still emits the column's declared precision verbatim, even where that is wider than
     // SqlNumeric accepts: truncating it here would silently misdescribe the schema, and the note
@@ -259,20 +257,28 @@ TEST_CASE("CxxModelPrinter::MakeDecimalPrecisionNote", "[CxxModelPrinter],[MakeT
     // Non-decimal columns are none of this function's business.
     CHECK(CxxModelPrinter::MakeDecimalPrecisionNote({ .name = "id", .type = Integer {}, .isNullable = false }).empty());
 
-    // 16..18 digits: the SQL_C_DOUBLE fallback loses the low digits on SQLite and MS SQL Server,
+    // 16..19 digits: the SQL_C_DOUBLE fallback loses the low digits on SQLite and MS SQL Server,
     // but the type itself is instantiable everywhere — one note, not two.
     auto const wide = CxxModelPrinter::MakeDecimalPrecisionNote(
         { .name = "amount", .type = Decimal { .precision = 18, .scale = 2 }, .isNullable = false });
     CHECK(wide.contains("SQL_C_DOUBLE"));
     CHECK(wide.contains("DECIMAL(18, 2)"));
-    CHECK(!wide.contains("128-bit"));
+    CHECK(!wide.contains("does not compile"));
 
-    // `money`: both hazards apply.
+    // `money` (DECIMAL(19, 4)) is at the bound, so only the transfer-precision note applies. It is
+    // instantiable on every toolchain, so no "does not compile" note is emitted for it any more.
     auto const money = CxxModelPrinter::MakeDecimalPrecisionNote(
         { .name = "price", .type = Decimal { .precision = 19, .scale = 4 }, .isNullable = false });
     CHECK(money.contains("SQL_C_DOUBLE"));
     CHECK(money.contains("922337203685477.6250"));
-    CHECK(money.contains("SqlNumeric<19, 4> requires a toolchain with a 128-bit integer type"));
+    CHECK(!money.contains("does not compile"));
+
+    // Past the bound both hazards apply: the column cannot be expressed as a SqlNumeric at all.
+    auto const huge = CxxModelPrinter::MakeDecimalPrecisionNote(
+        { .name = "huge", .type = Decimal { .precision = 38, .scale = 10 }, .isNullable = false });
+    CHECK(huge.contains("SQL_C_DOUBLE"));
+    CHECK(huge.contains("SqlNumeric<38, 10> does not compile"));
+    CHECK(huge.contains("Read this column as a string"));
 
     // Every emitted line is a properly indented comment, so it can be dropped into a struct body.
     for (auto const line: std::views::split(std::string_view { money }, '\n'))

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -540,6 +540,41 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlNumeric.StoreAndLoad", "[SqlDataBinder],[Sq
     // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
+// Largest relative error a value may carry after a round-trip through the `SQL_C_DOUBLE` fallback
+// of `SqlDataBinder<SqlNumeric<P, S>>`.
+//
+// That path stores the value in an IEEE-754 double, which by definition carries only
+// `std::numeric_limits<double>::digits10` (15) significant decimal digits; digit 16 and beyond are
+// not defined. The bound is therefore one unit in the last *defined* significant digit, which for a
+// decimal mantissa in [1, 10) is at most `10^-(digits10 - 1)` == 1e-14. It is stated per unit and
+// not per half unit because the round-trip rounds at that granularity more than once — the driver's
+// decimal-to-double conversion, the multiply by 10^Scale in ToUnscaledValue(), the 128-bit-to-double
+// conversion and the final divide — so a single half-ulp claim would not hold by construction.
+//
+// The bound is deliberately independent of any observed error: exceeding it means the fallback lost
+// a significant digit that a double is documented to preserve, which is a real defect.
+constexpr double SqlNumericDoubleFallbackTolerance = [] {
+    auto tolerance = 1.0;
+    for ([[maybe_unused]] auto const digit: std::views::iota(1, std::numeric_limits<double>::digits10))
+        tolerance /= 10.0;
+    return tolerance;
+}();
+
+// Whether the driver in use transfers a numeric's full mantissa through `SQL_C_NUMERIC`.
+//
+// `SqlDataBinder<SqlNumeric<..>>::NativeNumericSupportIsBroken()` decides the binding path from
+// `SqlServerType` alone, but losslessness is really a property of the *driver build*: the psqlODBC
+// that ships for Windows converts the value via a double before filling `SQL_NUMERIC_STRUCT` (a
+// 19-digit value arrives as the mantissa of its nearest double), while the Linux build hands over
+// the mantissa verbatim. The strict assertion below is therefore scoped to where the guarantee is
+// actually verified instead of being relaxed everywhere to whatever the weakest driver delivers.
+constexpr bool SqlNumericNativeMantissaIsLossless =
+#if defined(_WIN32)
+    false;
+#else
+    true;
+#endif
+
 TEST_CASE_METHOD(SqlTestFixture, "SqlNumeric.MoneyPrecision", "[SqlDataBinder],[SqlNumeric]")
 {
     // MS SQL Server's `money` is DECIMAL(19, 4) and ddl2cpp maps it to SqlNumeric<19, 4>. Verify
@@ -556,19 +591,72 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlNumeric.MoneyPrecision", "[SqlDataBinder],[
     auto const received = stmt.ExecuteDirectScalar<SqlNumeric<19, 4>>(stmt.Query("Test").Select().Field("Value").All());
     REQUIRE(received.has_value());
 
-    if (stmt.Connection().ServerType() == SqlServerType::POSTGRESQL)
+    // NOLINTBEGIN(bugprone-unchecked-optional-access) - guarded by the REQUIRE above
+
+    // How many of the 19 digits survive is a property of the *binding*, not of the declared
+    // precision, so gate on exactly the predicate the binder itself uses, plus the driver-build
+    // caveat above.
+    if (!SqlDataBinder<SqlNumeric<19, 4>>::NativeNumericSupportIsBroken(stmt.Connection().ServerType())
+        && SqlNumericNativeMantissaIsLossless)
     {
-        // PostgreSQL's driver supports SQL_C_NUMERIC, so the full 19-digit mantissa survives.
-        CHECK(received->ToString() == "123456789012345.6789"); // NOLINT(bugprone-unchecked-optional-access)
+        // Native SQL_C_NUMERIC (PostgreSQL on Linux): the whole 128-bit mantissa is transferred, so
+        // all 19 significant digits come back exactly. This is what makes SqlNumeric<19, 4> — and
+        // hence a precision cap of SqlMaxNumericPrecision rather than SQL_MAX_NUMERIC_LEN — worth
+        // having: SqlNumeric<16, 4> could not express this value at all.
+        CHECK(static_cast<long long>(received->ToUnscaledValue()) == 1234567890123456789LL);
+        CHECK(received->ToString() == "123456789012345.6789");
     }
     else
     {
-        // SQLite and MS SQL Server fall back to SQL_C_DOUBLE (see NativeNumericSupportIsBroken),
-        // which carries ~15 significant decimal digits. The value is therefore only approximate —
-        // a pre-existing property of that fallback, not of the declared precision.
-        CHECK_THAT(received->ToDouble(), // NOLINT(bugprone-unchecked-optional-access)
-                   Catch::Matchers::WithinRel(123456789012345.6789, 1e-15));
+        // Either the SQL_C_DOUBLE fallback (SQLite, MS SQL Server) or a driver that narrows through
+        // a double on the native path (Windows psqlODBC). In both cases only the leading `digits10`
+        // significant digits are meaningful. This is a property of the transfer, not of the declared
+        // precision: SqlNumeric<16, 4> loses exactly the same digits.
+        CHECK_THAT(received->ToDouble(),
+                   Catch::Matchers::WithinRel(123456789012345.6789, SqlNumericDoubleFallbackTolerance));
     }
+
+    // NOLINTEND(bugprone-unchecked-optional-access)
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlNumeric.Digits10AreExactOnEveryBackend", "[SqlDataBinder],[SqlNumeric]")
+{
+    // Pins the accuracy floor that `docs/data-binder.md` promises for the SQL_C_DOUBLE fallback:
+    // a value that fits into std::numeric_limits<double>::digits10 (15) significant decimal digits
+    // round-trips *exactly*, on every backend and regardless of which binding path is taken.
+    // 12345678901.2345 is 11 integral + 4 fractional = 15 significant digits.
+    STATIC_CHECK(std::numeric_limits<double>::digits10 == 15);
+
+    auto stmt = SqlStatement {};
+    stmt.MigrateDirect([](auto& migration) {
+        migration.CreateTable("Test").Column("Value", SqlColumnTypeDefinitions::Decimal { .precision = 15, .scale = 4 });
+    });
+
+    (void) stmt.ExecuteDirect(R"(INSERT INTO "Test" ("Value") VALUES (12345678901.2345))");
+
+    auto const received = stmt.ExecuteDirectScalar<SqlNumeric<15, 4>>(stmt.Query("Test").Select().Field("Value").All());
+    REQUIRE(received.has_value());
+    CHECK(received->ToString() == "12345678901.2345"); // NOLINT(bugprone-unchecked-optional-access)
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlNumeric.PurelyFractional", "[SqlDataBinder],[SqlNumeric]")
+{
+    // DECIMAL(4, 4) — every digit sits after the decimal point, so the column holds [0, 1).
+    // `SqlNumeric<4, 4>` used to be rejected by a `static_assert(Scale < Precision)` (issue #519).
+    auto stmt = SqlStatement {};
+    stmt.MigrateDirect([](auto& migration) {
+        migration.CreateTable("Test").Column("Value", SqlColumnTypeDefinitions::Decimal { .precision = 4, .scale = 4 });
+    });
+
+    auto const inputValue = SqlNumeric<4, 4> { 0.1234 };
+    stmt.Prepare(stmt.Query("Test").Insert().Set("Value", SqlWildcard));
+    (void) stmt.Execute(inputValue);
+
+    auto const received = stmt.ExecuteDirectScalar<SqlNumeric<4, 4>>(stmt.Query("Test").Select().Field("Value").All());
+    REQUIRE(received.has_value());
+    CHECK(received->ToString() == "0.1234");                                    // NOLINT(bugprone-unchecked-optional-access)
+    CHECK_THAT(received->ToDouble(), Catch::Matchers::WithinAbs(0.1234, 1e-9)); // NOLINT(bugprone-unchecked-optional-access)
+    CHECK(static_cast<long long>(received->ToUnscaledValue()) == 1234);         // NOLINT(bugprone-unchecked-optional-access)
 }
 
 TEST_CASE("SqlDateTime construction", "[SqlDataBinder],[SqlDateTime]")

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -569,12 +569,12 @@ constexpr double SqlNumericDoubleFallbackTolerance = [] {
 // the mantissa verbatim. The strict assertion below is therefore scoped to where the guarantee is
 // actually verified instead of being relaxed everywhere to whatever the weakest driver delivers.
 //
-// NB: `false` here does *not* mean "assert nothing". The narrowed branch still checks the sign and
-// the exact integral digits (see the round-trip test below), which is what a lost or corrupted
-// mantissa would break. The carrier's own guarantee — every digit up to SqlMaxNumericPrecision
-// survives ToUnscaledValue()/ToString() — is driver-independent and is asserted without a database
-// in "SqlNumeric renders every digit up to SqlMaxNumericPrecision exactly" (SqlNumericTests.cpp),
-// which runs on every platform including the int64_t-carrier ones.
+// NB: `false` here does *not* mean "assert nothing". The narrowed branch below still pins the sign
+// — which is exactly what the int64_t-overflow defect destroyed — and holds both the value and its
+// rendering to the accuracy a double is documented to preserve. The carrier's own guarantee, that
+// every digit up to SqlMaxNumericPrecision survives ToUnscaledValue(), is driver-independent and is
+// asserted without a database in "SqlNumeric carries every digit up to SqlMaxNumericPrecision"
+// (SqlNumericTests.cpp), which runs on every platform including the int64_t-carrier ones.
 constexpr bool SqlNumericNativeMantissaIsLossless =
 #if defined(_WIN32)
     false;
@@ -582,9 +582,9 @@ constexpr bool SqlNumericNativeMantissaIsLossless =
     true;
 #endif
 
-// Scale used by the maximum-precision probe below. Small enough that the integral part of the probe
-// value stays within `std::numeric_limits<double>::digits10`, so that part is exact on every
-// transfer path and can be asserted as a string even where the mantissa is narrowed.
+// Scale used by the maximum-precision probe below: enough fractional digits that the value exercises
+// the scaling path, few enough that the column stays a realistic `DECIMAL(p, 4)` — the shape of
+// MS SQL Server's `money`.
 constexpr std::size_t SqlNumericProbeScale = 4;
 
 // The digits of the probe value: `1234567890123...`, truncated to `precision` digits. A repeating
@@ -617,10 +617,6 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlNumeric.MaxPrecisionRoundTrip", "[SqlDataBi
     auto const integralDigits = digits.substr(0, precision - scale);
     auto const expectedText = std::format("{}.{}", integralDigits, digits.substr(precision - scale));
     auto const expectedValue = std::stod(expectedText);
-
-    // The integral part must stay inside double's exact range for the assertions below to be
-    // deterministic on the narrowed transfer paths.
-    REQUIRE(integralDigits.size() <= static_cast<std::size_t>(std::numeric_limits<double>::digits10));
 
     auto stmt = SqlStatement {};
     stmt.MigrateDirect([](auto& migration) {
@@ -656,13 +652,21 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlNumeric.MaxPrecisionRoundTrip", "[SqlDataBi
         // a double on the native path (Windows psqlODBC). Only the leading `digits10` significant
         // digits are meaningful — but that is still a concrete claim, not a free pass:
         //
-        //   - the sign must survive (the int64_t-overflow defect flipped it),
-        //   - the integral digits must be *exactly* right (they fit digits10 by construction, and
-        //     ToString() rounds only the fractional part, so this cannot round-trip-round away),
-        //   - the value must agree to within one unit in the last digit a double defines.
+        //   - the sign must survive (this is what the int64_t-overflow defect destroyed: it turned
+        //     the money maximum into its own negation),
+        //   - the value must agree with the stored one to within one unit in the last digit a
+        //     double defines,
+        //   - and ToString() must render *that* value, not some other one — so the rendering is
+        //     parsed back and held to the same bound.
+        //
+        // Deliberately no assertion on the digits of the rendered string. Rounding to `digits10`
+        // significant digits can carry into the integral part (this probe's 15 integral digits plus
+        // a fraction >= 0.5 round 123456789012345.6789 to 123456789012346), and how far a given
+        // driver or `long double` narrows is exactly what is *not* guaranteed here.
         CHECK(received->ToDouble() > 0.0);
-        CHECK(received->ToString().starts_with(integralDigits + "."));
         CHECK_THAT(received->ToDouble(), Catch::Matchers::WithinRel(expectedValue, SqlNumericDoubleFallbackTolerance));
+        CHECK_THAT(std::stod(received->ToString()),
+                   Catch::Matchers::WithinRel(expectedValue, SqlNumericDoubleFallbackTolerance));
     }
 
     // NOLINTEND(bugprone-unchecked-optional-access)

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -540,6 +540,37 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlNumeric.StoreAndLoad", "[SqlDataBinder],[Sq
     // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
+TEST_CASE_METHOD(SqlTestFixture, "SqlNumeric.MoneyPrecision", "[SqlDataBinder],[SqlNumeric]")
+{
+    // MS SQL Server's `money` is DECIMAL(19, 4) and ddl2cpp maps it to SqlNumeric<19, 4>. Verify
+    // that such a column can be declared, written and read back (issue #519). The value is written
+    // through a plain SQL literal so that the stored value carries all 19 digits, independently of
+    // what the C++ side can express.
+    auto stmt = SqlStatement {};
+    stmt.MigrateDirect([](auto& migration) {
+        migration.CreateTable("Test").Column("Value", SqlColumnTypeDefinitions::Decimal { .precision = 19, .scale = 4 });
+    });
+
+    (void) stmt.ExecuteDirect(R"(INSERT INTO "Test" ("Value") VALUES (123456789012345.6789))");
+
+    auto const received = stmt.ExecuteDirectScalar<SqlNumeric<19, 4>>(stmt.Query("Test").Select().Field("Value").All());
+    REQUIRE(received.has_value());
+
+    if (stmt.Connection().ServerType() == SqlServerType::POSTGRESQL)
+    {
+        // PostgreSQL's driver supports SQL_C_NUMERIC, so the full 19-digit mantissa survives.
+        CHECK(received->ToString() == "123456789012345.6789"); // NOLINT(bugprone-unchecked-optional-access)
+    }
+    else
+    {
+        // SQLite and MS SQL Server fall back to SQL_C_DOUBLE (see NativeNumericSupportIsBroken),
+        // which carries ~15 significant decimal digits. The value is therefore only approximate —
+        // a pre-existing property of that fallback, not of the declared precision.
+        CHECK_THAT(received->ToDouble(), // NOLINT(bugprone-unchecked-optional-access)
+                   Catch::Matchers::WithinRel(123456789012345.6789, 1e-15));
+    }
+}
+
 TEST_CASE("SqlDateTime construction", "[SqlDataBinder],[SqlDateTime]")
 {
     namespace chrono = std::chrono;

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -568,6 +568,13 @@ constexpr double SqlNumericDoubleFallbackTolerance = [] {
 // 19-digit value arrives as the mantissa of its nearest double), while the Linux build hands over
 // the mantissa verbatim. The strict assertion below is therefore scoped to where the guarantee is
 // actually verified instead of being relaxed everywhere to whatever the weakest driver delivers.
+//
+// NB: `false` here does *not* mean "assert nothing". The narrowed branch still checks the sign and
+// the exact integral digits (see the round-trip test below), which is what a lost or corrupted
+// mantissa would break. The carrier's own guarantee — every digit up to SqlMaxNumericPrecision
+// survives ToUnscaledValue()/ToString() — is driver-independent and is asserted without a database
+// in "SqlNumeric renders every digit up to SqlMaxNumericPrecision exactly" (SqlNumericTests.cpp),
+// which runs on every platform including the int64_t-carrier ones.
 constexpr bool SqlNumericNativeMantissaIsLossless =
 #if defined(_WIN32)
     false;
@@ -575,45 +582,87 @@ constexpr bool SqlNumericNativeMantissaIsLossless =
     true;
 #endif
 
-TEST_CASE_METHOD(SqlTestFixture, "SqlNumeric.MoneyPrecision", "[SqlDataBinder],[SqlNumeric]")
+// Scale used by the maximum-precision probe below. Small enough that the integral part of the probe
+// value stays within `std::numeric_limits<double>::digits10`, so that part is exact on every
+// transfer path and can be asserted as a string even where the mantissa is narrowed.
+constexpr std::size_t SqlNumericProbeScale = 4;
+
+// The digits of the probe value: `1234567890123...`, truncated to `precision` digits. A repeating
+// ramp rather than all-nines so that a dropped or reordered digit is visible in the failure output.
+static std::string MakeNumericProbeDigits(std::size_t precision)
 {
-    // MS SQL Server's `money` is DECIMAL(19, 4) and ddl2cpp maps it to SqlNumeric<19, 4>. Verify
-    // that such a column can be declared, written and read back (issue #519). The value is written
-    // through a plain SQL literal so that the stored value carries all 19 digits, independently of
-    // what the C++ side can express.
+    std::string digits;
+    for (auto const index: std::views::iota(std::size_t { 0 }, precision))
+        digits.push_back(static_cast<char>('0' + ((index + 1) % 10)));
+    return digits;
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlNumeric.MaxPrecisionRoundTrip", "[SqlDataBinder],[SqlNumeric]")
+{
+    // Round-trips a value at exactly `SqlMaxNumericPrecision` through a real driver. Nothing below
+    // this width exercises the two limits the bound is derived from: the unscaled carrier (an
+    // `int64_t` where the toolchain has no 128-bit integer) and the `long double` every accessor
+    // but ToUnscaledValue() divides through. Before the bound was corrected, `SqlNumeric<19, 4>`
+    // compiled on MSVC and turned the `money` maximum into its own negation.
+    //
+    // The precision is taken from the bound rather than hard-coded at 19, so the test measures the
+    // actual maximum on whichever toolchain is running it (19 with __int128, 18 without) instead of
+    // failing to instantiate on half of them. Where the bound is 19 this is exactly MS SQL Server's
+    // `money`, DECIMAL(19, 4), which is what ddl2cpp emits (issue #519).
+    constexpr auto precision = SqlMaxNumericPrecision;
+    constexpr auto scale = SqlNumericProbeScale;
+    using Probe = SqlNumeric<precision, scale>;
+
+    auto const digits = MakeNumericProbeDigits(precision);
+    auto const integralDigits = digits.substr(0, precision - scale);
+    auto const expectedText = std::format("{}.{}", integralDigits, digits.substr(precision - scale));
+    auto const expectedValue = std::stod(expectedText);
+
+    // The integral part must stay inside double's exact range for the assertions below to be
+    // deterministic on the narrowed transfer paths.
+    REQUIRE(integralDigits.size() <= static_cast<std::size_t>(std::numeric_limits<double>::digits10));
+
     auto stmt = SqlStatement {};
     stmt.MigrateDirect([](auto& migration) {
-        migration.CreateTable("Test").Column("Value", SqlColumnTypeDefinitions::Decimal { .precision = 19, .scale = 4 });
+        migration.CreateTable("Test").Column("Value",
+                                             SqlColumnTypeDefinitions::Decimal { .precision = precision, .scale = scale });
     });
 
-    (void) stmt.ExecuteDirect(R"(INSERT INTO "Test" ("Value") VALUES (123456789012345.6789))");
+    // Written as a plain SQL literal so the stored value carries all `precision` digits regardless
+    // of what the C++ side can express.
+    (void) stmt.ExecuteDirect(std::format(R"(INSERT INTO "Test" ("Value") VALUES ({}))", expectedText));
 
-    auto const received = stmt.ExecuteDirectScalar<SqlNumeric<19, 4>>(stmt.Query("Test").Select().Field("Value").All());
+    auto const received = stmt.ExecuteDirectScalar<Probe>(stmt.Query("Test").Select().Field("Value").All());
     REQUIRE(received.has_value());
 
     // NOLINTBEGIN(bugprone-unchecked-optional-access) - guarded by the REQUIRE above
 
-    // How many of the 19 digits survive is a property of the *binding*, not of the declared
-    // precision, so gate on exactly the predicate the binder itself uses, plus the driver-build
-    // caveat above.
-    if (!SqlDataBinder<SqlNumeric<19, 4>>::NativeNumericSupportIsBroken(stmt.Connection().ServerType())
+    // How many of the digits survive is a property of the *binding*, not of the declared precision,
+    // so gate on exactly the predicate the binder itself uses, plus the driver-build caveat above.
+    if (!SqlDataBinder<Probe>::NativeNumericSupportIsBroken(stmt.Connection().ServerType())
         && SqlNumericNativeMantissaIsLossless)
     {
-        // Native SQL_C_NUMERIC (PostgreSQL on Linux): the whole 128-bit mantissa is transferred, so
-        // all 19 significant digits come back exactly. This is what makes SqlNumeric<19, 4> — and
-        // hence a precision cap of SqlMaxNumericPrecision rather than SQL_MAX_NUMERIC_LEN — worth
-        // having: SqlNumeric<16, 4> could not express this value at all.
-        CHECK(static_cast<long long>(received->ToUnscaledValue()) == 1234567890123456789LL);
-        CHECK(received->ToString() == "123456789012345.6789");
+        // Native SQL_C_NUMERIC (PostgreSQL on Linux): the mantissa is transferred verbatim, so every
+        // digit comes back exactly. This is what the bound buys — one digit more and ToString()
+        // would already be wrong.
+        // The unscaled value is a `__int128` on this path, which std::format does not handle; at
+        // `precision <= 19` digits its magnitude always fits a std::uint64_t, so narrow it there.
+        CHECK(std::format("{}", static_cast<std::uint64_t>(received->ToUnscaledValue())) == digits);
+        CHECK(received->ToString() == expectedText);
     }
     else
     {
         // Either the SQL_C_DOUBLE fallback (SQLite, MS SQL Server) or a driver that narrows through
-        // a double on the native path (Windows psqlODBC). In both cases only the leading `digits10`
-        // significant digits are meaningful. This is a property of the transfer, not of the declared
-        // precision: SqlNumeric<16, 4> loses exactly the same digits.
-        CHECK_THAT(received->ToDouble(),
-                   Catch::Matchers::WithinRel(123456789012345.6789, SqlNumericDoubleFallbackTolerance));
+        // a double on the native path (Windows psqlODBC). Only the leading `digits10` significant
+        // digits are meaningful — but that is still a concrete claim, not a free pass:
+        //
+        //   - the sign must survive (the int64_t-overflow defect flipped it),
+        //   - the integral digits must be *exactly* right (they fit digits10 by construction, and
+        //     ToString() rounds only the fractional part, so this cannot round-trip-round away),
+        //   - the value must agree to within one unit in the last digit a double defines.
+        CHECK(received->ToDouble() > 0.0);
+        CHECK(received->ToString().starts_with(integralDigits + "."));
+        CHECK_THAT(received->ToDouble(), Catch::Matchers::WithinRel(expectedValue, SqlNumericDoubleFallbackTolerance));
     }
 
     // NOLINTEND(bugprone-unchecked-optional-access)

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -570,11 +570,11 @@ constexpr double SqlNumericDoubleFallbackTolerance = [] {
 // actually verified instead of being relaxed everywhere to whatever the weakest driver delivers.
 //
 // NB: `false` here does *not* mean "assert nothing". The narrowed branch below still pins the sign
-// — which is exactly what the int64_t-overflow defect destroyed — and holds both the value and its
+// — which is exactly what an int64_t-carrier overflow destroys — and holds both the value and its
 // rendering to the accuracy a double is documented to preserve. The carrier's own guarantee, that
 // every digit up to SqlMaxNumericPrecision survives ToUnscaledValue(), is driver-independent and is
 // asserted without a database in "SqlNumeric carries every digit up to SqlMaxNumericPrecision"
-// (SqlNumericTests.cpp), which runs on every platform including the int64_t-carrier ones.
+// (SqlNumericTests.cpp), which runs on every platform.
 constexpr bool SqlNumericNativeMantissaIsLossless =
 #if defined(_WIN32)
     false;
@@ -600,15 +600,13 @@ static std::string MakeNumericProbeDigits(std::size_t precision)
 TEST_CASE_METHOD(SqlTestFixture, "SqlNumeric.MaxPrecisionRoundTrip", "[SqlDataBinder],[SqlNumeric]")
 {
     // Round-trips a value at exactly `SqlMaxNumericPrecision` through a real driver. Nothing below
-    // this width exercises the two limits the bound is derived from: the unscaled carrier (an
-    // `int64_t` where the toolchain has no 128-bit integer) and the `long double` every accessor
-    // but ToUnscaledValue() divides through. Before the bound was corrected, `SqlNumeric<19, 4>`
-    // compiled on MSVC and turned the `money` maximum into its own negation.
+    // this width exercises the two limits the bound is derived from: the width of the unscaled
+    // carrier, and the `long double` every accessor but ToUnscaledValue() and ToString() divides
+    // through.
     //
-    // The precision is taken from the bound rather than hard-coded at 19, so the test measures the
-    // actual maximum on whichever toolchain is running it (19 with __int128, 18 without) instead of
-    // failing to instantiate on half of them. Where the bound is 19 this is exactly MS SQL Server's
-    // `money`, DECIMAL(19, 4), which is what ddl2cpp emits (issue #519).
+    // The precision is taken from the bound rather than hard-coded at 19 so that the test follows
+    // the bound if it ever moves. The bound is 19 on every toolchain, which makes this exactly
+    // MS SQL Server's `money`, DECIMAL(19, 4) — what ddl2cpp emits (issue #519).
     constexpr auto precision = SqlMaxNumericPrecision;
     constexpr auto scale = SqlNumericProbeScale;
     using Probe = SqlNumeric<precision, scale>;
@@ -652,7 +650,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlNumeric.MaxPrecisionRoundTrip", "[SqlDataBi
         // a double on the native path (Windows psqlODBC). Only the leading `digits10` significant
         // digits are meaningful — but that is still a concrete claim, not a free pass:
         //
-        //   - the sign must survive (this is what the int64_t-overflow defect destroyed: it turned
+        //   - the sign must survive (this is what an int64_t-carrier overflow destroys: it turns
         //     the money maximum into its own negation),
         //   - the value must agree with the stored one to within one unit in the last digit a
         //     double defines,
@@ -695,7 +693,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlNumeric.Digits10AreExactOnEveryBackend", "[
 TEST_CASE_METHOD(SqlTestFixture, "SqlNumeric.PurelyFractional", "[SqlDataBinder],[SqlNumeric]")
 {
     // DECIMAL(4, 4) — every digit sits after the decimal point, so the column holds [0, 1).
-    // `SqlNumeric<4, 4>` used to be rejected by a `static_assert(Scale < Precision)` (issue #519).
+    // `SqlNumeric<4, 4>` is a legal instantiation: Scale may equal Precision (issue #519).
     auto stmt = SqlStatement {};
     stmt.MigrateDirect([](auto& migration) {
         migration.CreateTable("Test").Column("Value", SqlColumnTypeDefinitions::Decimal { .precision = 4, .scale = 4 });

--- a/src/tests/Int128Tests.cpp
+++ b/src/tests/Int128Tests.cpp
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <Lightweight/DataBinder/Int128.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <string>
+
+using namespace Lightweight;
+using Lightweight::detail::Int128Soft;
+using Lightweight::detail::ToDecimalString;
+
+// ================================================================================================
+// detail::Int128Soft — the software 128-bit carrier.
+//
+// These tests exercise `Int128Soft` *directly and unconditionally*, on every toolchain, rather than
+// only where it happens to be what `Int128` aliases. Without that, the software path — the one that
+// exists specifically for MSVC and clang-cl — would go completely untested on the Linux/macOS CI
+// legs that do have a native __int128_t, and a regression in it would only ever surface on Windows.
+// Where a native type is available the tests below additionally cross-check the two implementations
+// agree.
+// ================================================================================================
+
+namespace
+{
+
+/// The largest unscaled value MS SQL Server's `money` (DECIMAL(19, 4)) can hold: 922337203685477.5807
+/// scaled by 10^4. This is the value that motivated the whole change — it is one past INT64_MAX, so
+/// the previous `int64_t` carrier turned it into INT64_MIN and rendered it sign-flipped.
+constexpr auto MoneyMaxUnscaled = std::uint64_t { 9'223'372'036'854'775'808ULL };
+
+} // namespace
+
+TEST_CASE("Int128Soft default-constructs to zero", "[Int128]")
+{
+    constexpr auto zero = Int128Soft {};
+    STATIC_CHECK(zero.low == 0);
+    STATIC_CHECK(zero.high == 0);
+    STATIC_CHECK_FALSE(zero.IsNegative());
+    CHECK(ToDecimalString(zero) == "0");
+}
+
+TEST_CASE("Int128Soft widens from 64-bit integers", "[Int128]")
+{
+    // Unsigned widens by zero-extension...
+    constexpr auto positive = Int128Soft { std::uint64_t { 42 } };
+    STATIC_CHECK(positive.low == 42);
+    STATIC_CHECK(positive.high == 0);
+
+    // ...signed by sign-extension, so a negative value fills the high word with ones.
+    constexpr auto negative = Int128Soft { std::int64_t { -42 } };
+    STATIC_CHECK(negative.high == ~std::uint64_t { 0 });
+    STATIC_CHECK(negative.IsNegative());
+
+    CHECK(ToDecimalString(positive) == "42");
+    CHECK(ToDecimalString(negative) == "-42");
+
+    // The boundaries of the 64-bit types must survive widening intact.
+    CHECK(ToDecimalString(Int128Soft { std::numeric_limits<std::int64_t>::max() }) == "9223372036854775807");
+    CHECK(ToDecimalString(Int128Soft { std::numeric_limits<std::int64_t>::min() }) == "-9223372036854775808");
+    CHECK(ToDecimalString(Int128Soft { std::numeric_limits<std::uint64_t>::max() }) == "18446744073709551615");
+}
+
+TEST_CASE("Int128Soft negation round-trips", "[Int128]")
+{
+    constexpr auto value = Int128Soft { std::uint64_t { 12345 } };
+    STATIC_CHECK(-(-value) == value);
+    STATIC_CHECK((-value).IsNegative());
+    STATIC_CHECK(+value == value);
+    CHECK(ToDecimalString(-value) == "-12345");
+
+    // Negating zero stays zero rather than producing a negative zero representation.
+    STATIC_CHECK(-Int128Soft {} == Int128Soft {});
+
+    // Crossing the 64-bit boundary: negating a value whose low word is zero must borrow correctly.
+    constexpr auto highOnly = Int128Soft { std::uint64_t { 0 }, std::uint64_t { 1 } }; // 2^64
+    CHECK(ToDecimalString(highOnly) == "18446744073709551616");
+    CHECK(ToDecimalString(-highOnly) == "-18446744073709551616");
+    STATIC_CHECK(-(-highOnly) == highOnly);
+}
+
+TEST_CASE("Int128Soft orders signed values correctly", "[Int128]")
+{
+    constexpr auto negative = Int128Soft { std::int64_t { -5 } };
+    constexpr auto zero = Int128Soft {};
+    constexpr auto small = Int128Soft { std::uint64_t { 5 } };
+    constexpr auto large = Int128Soft { std::uint64_t { 0 }, std::uint64_t { 1 } }; // 2^64
+
+    // A negative value is less than every non-negative one, even though its *unsigned* bit pattern
+    // is the larger — the ordering must consult the sign bit first.
+    STATIC_CHECK(negative < zero);
+    STATIC_CHECK(negative < small);
+    STATIC_CHECK(negative < large);
+    STATIC_CHECK(zero < small);
+    STATIC_CHECK(small < large);
+    STATIC_CHECK(large > small);
+
+    // Two negatives compare by magnitude in the right direction.
+    STATIC_CHECK(Int128Soft { std::int64_t { -10 } } < Int128Soft { std::int64_t { -5 } });
+
+    STATIC_CHECK(small == Int128Soft { std::uint64_t { 5 } });
+    STATIC_CHECK(small != large);
+}
+
+TEST_CASE("Int128Soft converts from floating point without overflow", "[Int128]")
+{
+    // The motivating case: `money`'s maximum unscaled value is one past INT64_MAX. An int64_t
+    // carrier made this UB (sign-flipped on x86-64); the 128-bit carrier represents it exactly.
+    auto const moneyMax = Int128Soft { 9'223'372'036'854'775'808.0L };
+    CHECK(ToDecimalString(moneyMax) == "9223372036854775808");
+    CHECK_FALSE(moneyMax.IsNegative());
+
+    // ...and its negative counterpart.
+    auto const moneyMin = Int128Soft { -9'223'372'036'854'775'808.0L };
+    CHECK(ToDecimalString(moneyMin) == "-9223372036854775808");
+    CHECK(moneyMin.IsNegative());
+
+    // Small values, both signs, and truncation toward zero.
+    CHECK(ToDecimalString(Int128Soft { 42.0 }) == "42");
+    CHECK(ToDecimalString(Int128Soft { -42.0 }) == "-42");
+    CHECK(ToDecimalString(Int128Soft { 42.9 }) == "42");
+    CHECK(ToDecimalString(Int128Soft { -42.9 }) == "-42");
+    CHECK(ToDecimalString(Int128Soft { 0.0 }) == "0");
+    CHECK(ToDecimalString(Int128Soft { 0.9 }) == "0");
+}
+
+TEST_CASE("Int128Soft saturates rather than invoking UB on out-of-range floats", "[Int128]")
+{
+    // An out-of-range float-to-integer conversion is undefined behaviour; the whole reason this type
+    // exists is that the old carrier performed one silently. Beyond the representable range the
+    // result must be the clamped extreme, and — critically — must keep the sign of the input rather
+    // than flipping it the way the int64_t overflow did.
+    auto const huge = Int128Soft { 1.0e40L };
+    CHECK_FALSE(huge.IsNegative());
+    CHECK(ToDecimalString(huge) == "170141183460469231731687303715884105727"); // 2^127 - 1
+
+    auto const hugeNegative = Int128Soft { -1.0e40L };
+    CHECK(hugeNegative.IsNegative());
+    CHECK(ToDecimalString(hugeNegative) == "-170141183460469231731687303715884105728"); // -2^127
+
+    // Infinity saturates the same way.
+    CHECK(Int128Soft { std::numeric_limits<long double>::infinity() }.IsNegative() == false);
+    CHECK(Int128Soft { -std::numeric_limits<long double>::infinity() }.IsNegative());
+
+    // NaN has no integer image; zero is the defined answer rather than garbage.
+    CHECK(Int128Soft { std::numeric_limits<long double>::quiet_NaN() } == Int128Soft {});
+}
+
+TEST_CASE("Int128Soft converts to floating point", "[Int128]")
+{
+    CHECK_THAT(Int128Soft { std::uint64_t { 42 } }.To<double>(), Catch::Matchers::WithinAbs(42.0, 1e-9));
+    CHECK_THAT(Int128Soft { std::int64_t { -42 } }.To<double>(), Catch::Matchers::WithinAbs(-42.0, 1e-9));
+    CHECK_THAT(static_cast<double>(Int128Soft { std::uint64_t { 7 } }), Catch::Matchers::WithinAbs(7.0, 1e-9));
+    CHECK_THAT(static_cast<float>(Int128Soft { std::uint64_t { 7 } }), Catch::Matchers::WithinAbs(7.0F, 1e-6F));
+
+    // Values above 2^64 must combine the two words, not just read the low one.
+    auto const twoPow64 = Int128Soft { std::uint64_t { 0 }, std::uint64_t { 1 } };
+    CHECK_THAT(twoPow64.To<double>(), Catch::Matchers::WithinRel(18446744073709551616.0, 1e-15));
+    CHECK_THAT(static_cast<double>(-twoPow64), Catch::Matchers::WithinRel(-18446744073709551616.0, 1e-15));
+
+    // The round trip through `long double` for a value at the precision bound.
+    auto const moneyMax = Int128Soft { 9'223'372'036'854'775'808.0L };
+    CHECK_THAT(static_cast<double>(moneyMax.To<long double>()), Catch::Matchers::WithinRel(9223372036854775808.0, 1e-15));
+}
+
+TEST_CASE("Int128Soft narrows to 64-bit like a native __int128_t does", "[Int128]")
+{
+    // Narrowing truncates to the low word, matching `static_cast<int64_t>` on the native type.
+    constexpr auto value = Int128Soft { std::uint64_t { 0xDEAD'BEEF }, std::uint64_t { 0xFFFF } };
+    STATIC_CHECK(static_cast<std::uint64_t>(value) == 0xDEAD'BEEFULL);
+    STATIC_CHECK(static_cast<std::int64_t>(value) == 0xDEAD'BEEFLL);
+    STATIC_CHECK(static_cast<std::int32_t>(Int128Soft { std::uint64_t { 1234 } }) == 1234);
+}
+
+TEST_CASE("Int128Soft renders decimal across the full 128-bit range", "[Int128]")
+{
+    // Rendering divides by 10^19 repeatedly, so the interesting cases are around chunk boundaries
+    // and at the extremes where the padding/trimming of the most significant chunk matters.
+    CHECK(ToDecimalString(Int128Soft { std::uint64_t { 1 } }) == "1");
+    CHECK(ToDecimalString(Int128Soft { std::uint64_t { 10 } }) == "10");
+
+    // Exactly one chunk (10^19 - 1), then one past it, where a second chunk appears and the first
+    // must be zero-padded to 19 digits.
+    CHECK(ToDecimalString(Int128Soft { std::uint64_t { 9'999'999'999'999'999'999ULL } }) == "9999999999999999999");
+    CHECK(ToDecimalString(Int128Soft { std::uint64_t { 10'000'000'000'000'000'000ULL } }) == "10000000000000000000");
+
+    // A value with interior zeros, which the zero-padding of a non-final chunk must preserve.
+    // 10^20 == 5 * 2^20 * 10^... — construct it directly from the word pair instead:
+    // 100000000000000000000 = 0x5_6BC7_5E2D_6310_0000
+    auto const tenPow20 = Int128Soft { std::uint64_t { 0x6BC7'5E2D'6310'0000ULL }, std::uint64_t { 0x5 } };
+    CHECK(ToDecimalString(tenPow20) == "100000000000000000000");
+
+    // The extremes of the type.
+    auto const maxValue = Int128Soft { ~std::uint64_t { 0 }, ~std::uint64_t { 0 } >> 1 };
+    CHECK(ToDecimalString(maxValue) == "170141183460469231731687303715884105727"); // 2^127 - 1
+
+    auto const minValue = Int128Soft { std::uint64_t { 0 }, std::uint64_t { 1 } << 63 };
+    CHECK(ToDecimalString(minValue) == "-170141183460469231731687303715884105728"); // -2^127
+}
+
+TEST_CASE("Int128Soft byte layout matches SQL_NUMERIC_STRUCT::val", "[Int128]")
+{
+    // The carrier is memcpy'd straight into and out of the ODBC struct's little-endian mantissa, so
+    // its representation has to be exactly that: 16 bytes, low word first.
+    STATIC_CHECK(sizeof(Int128Soft) == 16);
+
+    auto const value = Int128Soft { MoneyMaxUnscaled };
+
+    auto bytes = std::array<unsigned char, 16> {};
+    std::memcpy(bytes.data(), &value, sizeof(value));
+
+    // 9223372036854775808 == 2^63 — the low word's top bit set, everything else clear.
+    CHECK(bytes[7] == 0x80);
+    for (auto const index: { 0, 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15 })
+        CHECK(bytes[static_cast<std::size_t>(index)] == 0x00);
+
+    // ...and the reverse direction reconstructs it.
+    auto restored = Int128Soft {};
+    std::memcpy(&restored, bytes.data(), sizeof(restored));
+    CHECK(restored == value);
+    CHECK(ToDecimalString(restored) == "9223372036854775808");
+}
+
+TEST_CASE("Int128 is 128 bits wide on every toolchain", "[Int128]")
+{
+    // The property the review comment asked for: the carrier's width — and therefore the widest
+    // declarable SqlNumeric precision — does not depend on which compiler built the executable.
+    STATIC_CHECK(sizeof(Int128) == 16);
+
+    CHECK(detail::Int128ToString(static_cast<Int128>(9'223'372'036'854'775'808.0L)) == "9223372036854775808");
+    CHECK(detail::Int128ToString(static_cast<Int128>(-9'223'372'036'854'775'808.0L)) == "-9223372036854775808");
+    CHECK(detail::Int128ToString(Int128 {}) == "0");
+}
+
+#if defined(LIGHTWEIGHT_HAVE_NATIVE_INT128)
+TEST_CASE("Int128Soft agrees with the native __int128_t", "[Int128]")
+{
+    // Where both implementations exist, the software one is only correct if it is indistinguishable
+    // from the native one. Cross-check the operations SqlNumeric actually performs over a spread of
+    // values, including the ones that overflow 64 bits.
+    auto const check = [](long double input) {
+        auto const soft = Int128Soft { input };
+        auto const native = static_cast<__int128_t>(input);
+
+        // Same decimal rendering...
+        CHECK(ToDecimalString(soft) == detail::Int128ToString(native));
+
+        // ...same floating-point image...
+        CHECK_THAT(static_cast<double>(soft.To<long double>()),
+                   Catch::Matchers::WithinRel(static_cast<double>(static_cast<long double>(native)), 1e-15));
+
+        // ...same 16-byte little-endian representation, which is what gets memcpy'd into ODBC.
+        auto softBytes = std::array<unsigned char, 16> {};
+        auto nativeBytes = std::array<unsigned char, 16> {};
+        std::memcpy(softBytes.data(), &soft, sizeof(soft));
+        std::memcpy(nativeBytes.data(), &native, sizeof(native));
+        CHECK(softBytes == nativeBytes);
+
+        // ...and the same sign and negation behaviour.
+        CHECK(soft.IsNegative() == (native < 0));
+        CHECK(ToDecimalString(-soft) == detail::Int128ToString(static_cast<__int128_t>(-native)));
+    };
+
+    check(0.0L);
+    check(1.0L);
+    check(-1.0L);
+    check(42.0L);
+    check(-42.0L);
+    check(9'223'372'036'854'775'807.0L);  // INT64_MAX
+    check(9'223'372'036'854'775'808.0L);  // money's max unscaled — one past INT64_MAX
+    check(-9'223'372'036'854'775'808.0L); // INT64_MIN
+    check(1.0e19L);
+    check(-1.0e19L);
+    check(1.0e30L);
+    check(-1.0e30L);
+}
+#endif

--- a/src/tests/Int128Tests.cpp
+++ b/src/tests/Int128Tests.cpp
@@ -32,8 +32,8 @@ namespace
 {
 
 /// The largest unscaled value MS SQL Server's `money` (DECIMAL(19, 4)) can hold: 922337203685477.5807
-/// scaled by 10^4. This is the value that motivated the whole change — it is one past INT64_MAX, so
-/// the previous `int64_t` carrier turned it into INT64_MIN and rendered it sign-flipped.
+/// scaled by 10^4. This is the value the carrier's width is chosen for — it is one past INT64_MAX,
+/// so an `int64_t` carrier turns it into INT64_MIN and renders it sign-flipped.
 constexpr auto MoneyMaxUnscaled = std::uint64_t { 9'223'372'036'854'775'808ULL };
 
 } // namespace
@@ -112,7 +112,7 @@ TEST_CASE("Int128Soft orders signed values correctly", "[Int128]")
 TEST_CASE("Int128Soft converts from floating point without overflow", "[Int128]")
 {
     // The motivating case: `money`'s maximum unscaled value is one past INT64_MAX. An int64_t
-    // carrier made this UB (sign-flipped on x86-64); the 128-bit carrier represents it exactly.
+    // carrier makes this UB (sign-flipped on x86-64); the 128-bit carrier represents it exactly.
     auto const moneyMax = Int128Soft { 9'223'372'036'854'775'808.0L };
     CHECK(ToDecimalString(moneyMax) == "9223372036854775808");
     CHECK_FALSE(moneyMax.IsNegative());
@@ -133,10 +133,10 @@ TEST_CASE("Int128Soft converts from floating point without overflow", "[Int128]"
 
 TEST_CASE("Int128Soft saturates rather than invoking UB on out-of-range floats", "[Int128]")
 {
-    // An out-of-range float-to-integer conversion is undefined behaviour; the whole reason this type
-    // exists is that the old carrier performed one silently. Beyond the representable range the
-    // result must be the clamped extreme, and — critically — must keep the sign of the input rather
-    // than flipping it the way the int64_t overflow did.
+    // An out-of-range float-to-integer conversion is undefined behaviour, and saturating instead is
+    // a large part of why this type exists. Beyond the representable range the result must be the
+    // clamped extreme, and — critically — must keep the sign of the input rather than flipping it
+    // the way an int64_t overflow does.
     auto const huge = Int128Soft { 1.0e40L };
     CHECK_FALSE(huge.IsNegative());
     CHECK(ToDecimalString(huge) == "170141183460469231731687303715884105727"); // 2^127 - 1

--- a/src/tests/Int128Tests.cpp
+++ b/src/tests/Int128Tests.cpp
@@ -165,9 +165,11 @@ TEST_CASE("Int128Soft converts to floating point", "[Int128]")
     CHECK_THAT(twoPow64.To<double>(), Catch::Matchers::WithinRel(18446744073709551616.0, 1e-15));
     CHECK_THAT(static_cast<double>(-twoPow64), Catch::Matchers::WithinRel(-18446744073709551616.0, 1e-15));
 
-    // The round trip through `long double` for a value at the precision bound.
+    // The round trip through `long double` for a value at the precision bound. 2^63 is a power of
+    // two, hence exactly representable in every floating-point format, so this holds even where
+    // `long double` is narrow (MSVC) or emulated at 53 bits (the CI SQLite3 leg runs under Valgrind).
     auto const moneyMax = Int128Soft { 9'223'372'036'854'775'808.0L };
-    CHECK_THAT(static_cast<double>(moneyMax.To<long double>()), Catch::Matchers::WithinRel(9223372036854775808.0, 1e-15));
+    CHECK(static_cast<double>(moneyMax.To<long double>()) == 9223372036854775808.0);
 }
 
 TEST_CASE("Int128Soft narrows to 64-bit like a native __int128_t does", "[Int128]")
@@ -252,9 +254,14 @@ TEST_CASE("Int128Soft agrees with the native __int128_t", "[Int128]")
         // Same decimal rendering...
         CHECK(ToDecimalString(soft) == detail::Int128ToString(native));
 
-        // ...same floating-point image...
-        CHECK_THAT(static_cast<double>(soft.To<long double>()),
-                   Catch::Matchers::WithinRel(static_cast<double>(static_cast<long double>(native)), 1e-15));
+        // ...same floating-point image. Compared via `double` rather than `long double`: the CI
+        // SQLite3 leg runs the suite under Valgrind, which does not emulate the x87 80-bit
+        // `long double` faithfully. Under it the *native* `__int128_t -> long double` conversion
+        // (`__floattixf`) returns 0 for small negative values — verified by reproducing this exact
+        // failure for -1 and -42 under `valgrind` locally — so a `long double` comparison fails on
+        // the reference side while the shim is correct. `double` is exact for every probe value
+        // below (both sides round identically, even at 1e30) and is emulated faithfully.
+        CHECK(soft.To<double>() == static_cast<double>(native));
 
         // ...same 16-byte little-endian representation, which is what gets memcpy'd into ODBC.
         auto softBytes = std::array<unsigned char, 16> {};

--- a/src/tests/SqlNumericTests.cpp
+++ b/src/tests/SqlNumericTests.cpp
@@ -8,7 +8,11 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include <compare>
+#include <cstdint>
+#include <cstring>
 #include <format>
+#include <ranges>
+#include <string>
 
 using namespace Lightweight;
 
@@ -112,23 +116,68 @@ TEST_CASE("SqlNumeric ColumnType matches template arguments", "[SqlNumeric]")
     CHECK(col.scale == 4);
 }
 
-TEST_CASE("SqlNumeric supports the full decimal precision of the ODBC mantissa", "[SqlNumeric]")
+TEST_CASE("SqlMaxNumericPrecision is the width this implementation can carry", "[SqlNumeric]")
 {
-    // SQL_MAX_NUMERIC_LEN is the mantissa size in *bytes* (16), not a digit count. 16 bytes hold a
-    // 128-bit unsigned integer, i.e. 38 full decimal digits — which is also the maximum DECIMAL
-    // precision of MS SQL Server and PostgreSQL.
-    STATIC_CHECK(SqlMaxNumericPrecision == 38);
+    // SQL_MAX_NUMERIC_LEN is the mantissa size in *bytes* (16), not a digit count, so the historical
+    // `Precision <= SQL_MAX_NUMERIC_LEN` was a category error that rejected DECIMAL(18, 2). But the
+    // mantissa's 38-digit capacity is not the bound either — see the derivation on
+    // SqlMaxNumericPrecision. Two things narrow it, and the bound is the tighter of the two:
+    //
+    //   - the unscaled carrier: `int64_t` (18 digits) without a 128-bit integer type,
+    //   - the readable width: `long double`, which every accessor but ToUnscaledValue() divides
+    //     through (19 digits on the 80-bit x87 long double).
+    STATIC_CHECK(detail::DecimalDigitsForBits(63) == 18);  // int64_t magnitude
+    STATIC_CHECK(detail::DecimalDigitsForBits(64) == 19);  // x87 long double significand
+    STATIC_CHECK(detail::DecimalDigitsForBits(127) == 38); // __int128 magnitude — deliberately NOT the bound
 
-    // MS SQL Server's `money` is DECIMAL(19, 4); it must be expressible.
+#if defined(LIGHTWEIGHT_INT128_T)
+    STATIC_CHECK(SqlMaxNumericPrecision == 19);
+
+    // MS SQL Server's `money` is DECIMAL(19, 4); here it must be expressible.
     STATIC_CHECK(SqlNumeric<19, 4>::Precision == 19);
     STATIC_CHECK(SqlNumeric<19, 4>::Scale == 4);
     STATIC_CHECK(SqlNumeric<19, 4>::ColumnType.precision == 19);
+#else
+    // Without a 128-bit integer the unscaled value is carried by an `int64_t`, whose magnitude
+    // holds 18 digits. `SqlNumeric<19, 4>` at the `money` maximum would need an unscaled
+    // 9223372036854775808 — one past INT64_MAX — and the out-of-range float-to-int conversion is
+    // undefined behaviour that flips the sign on x86-64. Rejecting it at compile time is the point.
+    STATIC_CHECK(SqlMaxNumericPrecision == 18);
+#endif
 
-    // ... as must the widest DECIMAL either server supports.
-    STATIC_CHECK(SqlNumeric<SqlMaxNumericPrecision, 10>::Precision == 38);
+    // DECIMAL(18, s), the widest column that works on every supported toolchain.
+    STATIC_CHECK(SqlNumeric<18, 4>::Precision == 18);
 
-    SqlNumeric<19, 4> const money { 1234567890.1234 };
-    CHECK(money.ToString() == "1234567890.1234");
+    SqlNumeric<SqlMaxNumericPrecision, 4> const widest { 1234567890.1234 };
+    CHECK(widest.ToString() == "1234567890.1234");
+}
+
+TEST_CASE("SqlNumeric renders every digit up to SqlMaxNumericPrecision exactly", "[SqlNumeric]")
+{
+    // The bound's whole purpose: at SqlMaxNumericPrecision the worst case — an all-nines mantissa,
+    // the largest value the precision admits — must still round-trip through ToUnscaledValue() and
+    // render exactly via ToString(). One digit more and it does not, which is why the bound is
+    // where it is. Values are injected through the SQL_NUMERIC_STRUCT constructor because that is
+    // the state a native SQL_C_NUMERIC fetch leaves behind (nativeValue == 0, mantissa verbatim);
+    // going through `assign()` would measure the `double` argument instead.
+    constexpr auto precision = SqlMaxNumericPrecision;
+
+    auto allNines = std::uint64_t { 0 };
+    for ([[maybe_unused]] auto const digit: std::views::iota(std::size_t { 0 }, precision))
+        allNines = (allNines * 10) + 9;
+
+    auto raw = SQL_NUMERIC_STRUCT {};
+    raw.precision = static_cast<SQLCHAR>(precision);
+    raw.scale = 0;
+    raw.sign = 1;
+    std::memcpy(static_cast<void*>(raw.val), &allNines, sizeof(allNines));
+
+    SqlNumeric<precision, 0> const widest { raw };
+    auto const expected = std::string(precision, '9');
+    CHECK(widest.ToString() == expected);
+    // The unscaled value is a `__int128` where one exists, which std::format does not handle; at
+    // `precision <= 19` digits its magnitude always fits a std::uint64_t, so narrow it there.
+    CHECK(std::format("{}", static_cast<std::uint64_t>(widest.ToUnscaledValue())) == expected);
 }
 
 TEST_CASE("SqlNumeric supports a purely fractional Scale == Precision", "[SqlNumeric]")

--- a/src/tests/SqlNumericTests.cpp
+++ b/src/tests/SqlNumericTests.cpp
@@ -112,6 +112,25 @@ TEST_CASE("SqlNumeric ColumnType matches template arguments", "[SqlNumeric]")
     CHECK(col.scale == 4);
 }
 
+TEST_CASE("SqlNumeric supports the full decimal precision of the ODBC mantissa", "[SqlNumeric]")
+{
+    // SQL_MAX_NUMERIC_LEN is the mantissa size in *bytes* (16), not a digit count. 16 bytes hold a
+    // 128-bit unsigned integer, i.e. 38 full decimal digits — which is also the maximum DECIMAL
+    // precision of MS SQL Server and PostgreSQL.
+    STATIC_CHECK(SqlMaxNumericPrecision == 38);
+
+    // MS SQL Server's `money` is DECIMAL(19, 4); it must be expressible.
+    STATIC_CHECK(SqlNumeric<19, 4>::Precision == 19);
+    STATIC_CHECK(SqlNumeric<19, 4>::Scale == 4);
+    STATIC_CHECK(SqlNumeric<19, 4>::ColumnType.precision == 19);
+
+    // ... as must the widest DECIMAL either server supports.
+    STATIC_CHECK(SqlNumeric<SqlMaxNumericPrecision, 10>::Precision == 38);
+
+    SqlNumeric<19, 4> const money { 1234567890.1234 };
+    CHECK(money.ToString() == "1234567890.1234");
+}
+
 TEST_CASE("SqlNumeric ToUnscaledValue scales by 10^Scale", "[SqlNumeric]")
 {
     SqlNumeric<10, 2> const n { 1.23 };

--- a/src/tests/SqlNumericTests.cpp
+++ b/src/tests/SqlNumericTests.cpp
@@ -184,24 +184,20 @@ TEST_CASE("SqlNumeric carries every digit up to SqlMaxNumericPrecision", "[SqlNu
     // always fits a std::uint64_t, so narrow it there.
     CHECK(std::format("{}", static_cast<std::uint64_t>(widest.ToUnscaledValue())) == expected);
 
-    // ToString() is a weaker guarantee, because it — like every accessor but ToUnscaledValue() —
-    // divides through `long double`. It therefore renders only as many digits as that type's
-    // significand holds: 19 on the 80-bit x87 `long double`, but 15 wherever `long double` is a
-    // `double` (MSVC, and Clang on Apple Silicon). Assert exactness only where it is actually
-    // promised, and the documented relative accuracy everywhere else — asserting the strong form
-    // unconditionally would be asserting something docs/data-binder.md does not claim.
-    constexpr auto renderableDigits =
-        detail::DecimalDigitsForBits(static_cast<std::size_t>(std::numeric_limits<long double>::digits));
-    if constexpr (precision <= renderableDigits)
-        CHECK(widest.ToString() == expected);
-    else
-    {
-        auto relativeTolerance = 1.0L;
-        for ([[maybe_unused]] auto const digit: std::views::iota(std::size_t { 1 }, renderableDigits))
-            relativeTolerance /= 10.0L;
-        CHECK_THAT(static_cast<double>(widest.ToLongDouble()),
-                   Catch::Matchers::WithinRel(static_cast<double>(allNines), static_cast<double>(relativeTolerance)));
-    }
+    // ToString() is a distinctly weaker, toolchain-dependent guarantee, because it — like every
+    // accessor but ToUnscaledValue() — divides through `long double` and is then rendered by the
+    // standard library's formatter. How many digits survive depends on *both*: the width of that
+    // type (53 bits on MSVC and on Clang for Apple Silicon, 64 on the x87 80-bit one) and the
+    // formatter's own long-double support, which in practice narrows to `double` on some
+    // toolchains even where the type is wider. The portable promise — and the only one
+    // docs/data-binder.md makes — is `std::numeric_limits<double>::digits10` significant digits,
+    // so assert exactly that and nothing stronger. The strong claim lives on ToUnscaledValue()
+    // above, where it actually holds.
+    constexpr auto portableDigits = static_cast<std::size_t>(std::numeric_limits<double>::digits10);
+    auto relativeTolerance = 1.0;
+    for ([[maybe_unused]] auto const digit: std::views::iota(std::size_t { 1 }, portableDigits))
+        relativeTolerance /= 10.0;
+    CHECK_THAT(std::stod(widest.ToString()), Catch::Matchers::WithinRel(static_cast<double>(allNines), relativeTolerance));
 }
 
 TEST_CASE("SqlNumeric supports a purely fractional Scale == Precision", "[SqlNumeric]")

--- a/src/tests/SqlNumericTests.cpp
+++ b/src/tests/SqlNumericTests.cpp
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <cstring>
 #include <format>
+#include <limits>
 #include <ranges>
 #include <string>
 
@@ -124,10 +125,12 @@ TEST_CASE("SqlMaxNumericPrecision is the width this implementation can carry", "
     // SqlMaxNumericPrecision. Two things narrow it, and the bound is the tighter of the two:
     //
     //   - the unscaled carrier: `int64_t` (18 digits) without a 128-bit integer type,
-    //   - the readable width: `long double`, which every accessor but ToUnscaledValue() divides
-    //     through (19 digits on the 80-bit x87 long double).
+    //   - the readable width: at most a 64-bit magnitude (19 digits), which is what the widest
+    //     `long double` in use — the 80-bit x87 one — renders exactly. Where `long double` is
+    //     narrower still (MSVC, Clang on Apple Silicon) ToString() is correspondingly narrower;
+    //     that is an accessor property, not a representability one, and is asserted separately.
     STATIC_CHECK(detail::DecimalDigitsForBits(63) == 18);  // int64_t magnitude
-    STATIC_CHECK(detail::DecimalDigitsForBits(64) == 19);  // x87 long double significand
+    STATIC_CHECK(detail::DecimalDigitsForBits(64) == 19);  // 64-bit magnitude / x87 significand
     STATIC_CHECK(detail::DecimalDigitsForBits(127) == 38); // __int128 magnitude — deliberately NOT the bound
 
 #if defined(LIGHTWEIGHT_INT128_T)
@@ -152,14 +155,14 @@ TEST_CASE("SqlMaxNumericPrecision is the width this implementation can carry", "
     CHECK(widest.ToString() == "1234567890.1234");
 }
 
-TEST_CASE("SqlNumeric renders every digit up to SqlMaxNumericPrecision exactly", "[SqlNumeric]")
+TEST_CASE("SqlNumeric carries every digit up to SqlMaxNumericPrecision", "[SqlNumeric]")
 {
     // The bound's whole purpose: at SqlMaxNumericPrecision the worst case — an all-nines mantissa,
-    // the largest value the precision admits — must still round-trip through ToUnscaledValue() and
-    // render exactly via ToString(). One digit more and it does not, which is why the bound is
-    // where it is. Values are injected through the SQL_NUMERIC_STRUCT constructor because that is
-    // the state a native SQL_C_NUMERIC fetch leaves behind (nativeValue == 0, mantissa verbatim);
-    // going through `assign()` would measure the `double` argument instead.
+    // the largest value the precision admits — must still survive the unscaled carrier. One digit
+    // more and it does not, which is why the bound is where it is. Values are injected through the
+    // SQL_NUMERIC_STRUCT constructor because that is the state a native SQL_C_NUMERIC fetch leaves
+    // behind (nativeValue == 0, mantissa verbatim); going through `assign()` would measure the
+    // `double` argument instead.
     constexpr auto precision = SqlMaxNumericPrecision;
 
     auto allNines = std::uint64_t { 0 };
@@ -174,10 +177,31 @@ TEST_CASE("SqlNumeric renders every digit up to SqlMaxNumericPrecision exactly",
 
     SqlNumeric<precision, 0> const widest { raw };
     auto const expected = std::string(precision, '9');
-    CHECK(widest.ToString() == expected);
-    // The unscaled value is a `__int128` where one exists, which std::format does not handle; at
-    // `precision <= 19` digits its magnitude always fits a std::uint64_t, so narrow it there.
+
+    // The carrier's guarantee, and the one the bound is derived from: unconditional, on every
+    // platform, independent of any floating-point type. The unscaled value is a `__int128` where
+    // one exists, which std::format does not handle; at `precision <= 19` digits its magnitude
+    // always fits a std::uint64_t, so narrow it there.
     CHECK(std::format("{}", static_cast<std::uint64_t>(widest.ToUnscaledValue())) == expected);
+
+    // ToString() is a weaker guarantee, because it — like every accessor but ToUnscaledValue() —
+    // divides through `long double`. It therefore renders only as many digits as that type's
+    // significand holds: 19 on the 80-bit x87 `long double`, but 15 wherever `long double` is a
+    // `double` (MSVC, and Clang on Apple Silicon). Assert exactness only where it is actually
+    // promised, and the documented relative accuracy everywhere else — asserting the strong form
+    // unconditionally would be asserting something docs/data-binder.md does not claim.
+    constexpr auto renderableDigits =
+        detail::DecimalDigitsForBits(static_cast<std::size_t>(std::numeric_limits<long double>::digits));
+    if constexpr (precision <= renderableDigits)
+        CHECK(widest.ToString() == expected);
+    else
+    {
+        auto relativeTolerance = 1.0L;
+        for ([[maybe_unused]] auto const digit: std::views::iota(std::size_t { 1 }, renderableDigits))
+            relativeTolerance /= 10.0L;
+        CHECK_THAT(static_cast<double>(widest.ToLongDouble()),
+                   Catch::Matchers::WithinRel(static_cast<double>(allNines), static_cast<double>(relativeTolerance)));
+    }
 }
 
 TEST_CASE("SqlNumeric supports a purely fractional Scale == Precision", "[SqlNumeric]")

--- a/src/tests/SqlNumericTests.cpp
+++ b/src/tests/SqlNumericTests.cpp
@@ -142,23 +142,23 @@ TEST_CASE("SqlNumeric ColumnType matches template arguments", "[SqlNumeric]")
 
 TEST_CASE("SqlMaxNumericPrecision is the width this implementation can carry", "[SqlNumeric]")
 {
-    // SQL_MAX_NUMERIC_LEN is the mantissa size in *bytes* (16), not a digit count, so the historical
-    // `Precision <= SQL_MAX_NUMERIC_LEN` was a category error that rejected DECIMAL(18, 2). But the
-    // mantissa's 38-digit capacity is not the bound either — see the derivation on
-    // SqlMaxNumericPrecision. What narrows it is the readable width: at most a 64-bit magnitude
-    // (19 digits), which is what the widest `long double` in use — the 80-bit x87 one — renders.
-    // Where `long double` is narrower still (MSVC, Clang on Apple Silicon) the *floating-point*
-    // accessors are correspondingly narrower; ToString() and ToUnscaledValue() are not, because
-    // neither goes through one. That is an accessor property, asserted separately below.
-    STATIC_CHECK(detail::DecimalDigitsForBits(63) == 18);  // int64_t magnitude — no longer the bound
+    // SQL_MAX_NUMERIC_LEN is the mantissa size in *bytes* (16), not a digit count, so comparing a
+    // digit count against it is a category error that rejects DECIMAL(18, 2). But the mantissa's
+    // 38-digit capacity is not the bound either — see the derivation on SqlMaxNumericPrecision.
+    // What narrows it is the readable width: at most a 64-bit magnitude (19 digits), which is what
+    // the widest `long double` in use — the 80-bit x87 one — renders. Where `long double` is
+    // narrower still (MSVC, Clang on Apple Silicon) the *floating-point* accessors are
+    // correspondingly narrower; ToString() and ToUnscaledValue() are not, because neither goes
+    // through one. That is an accessor property, asserted separately below.
+    STATIC_CHECK(detail::DecimalDigitsForBits(63) == 18);  // int64_t magnitude — deliberately NOT the bound
     STATIC_CHECK(detail::DecimalDigitsForBits(64) == 19);  // 64-bit magnitude / x87 significand
     STATIC_CHECK(detail::DecimalDigitsForBits(127) == 38); // __int128 magnitude — deliberately NOT the bound
 
     // The bound is the *same on every toolchain*. This is the property that matters: a column's
     // precision comes from the database schema, so a ddl2cpp-generated record must compile
     // regardless of which compiler builds the client. `Int128` supplies a software 128-bit carrier
-    // where the compiler has no native one, which is what makes this unconditional — before that,
-    // the bound was 18 under MSVC/clang-cl and 19 elsewhere.
+    // where the compiler has no native one, which is what makes this unconditional: without it the
+    // bound would be 18 under MSVC/clang-cl and 19 elsewhere.
     STATIC_CHECK(SqlMaxNumericPrecision == 19);
 
     // MS SQL Server's `money` is DECIMAL(19, 4), and it is expressible everywhere.
@@ -174,12 +174,12 @@ TEST_CASE("SqlMaxNumericPrecision is the width this implementation can carry", "
 
 TEST_CASE("SqlNumeric carries money's full range on every toolchain", "[SqlNumeric]")
 {
-    // The regression this whole change is about. MS SQL Server's `money` spans
-    // -922337203685477.5808 .. 922337203685477.5807, i.e. unscaled values of exactly INT64_MIN and
-    // INT64_MAX. The negative endpoint has magnitude 9223372036854775808 — one past INT64_MAX — so
-    // with the previous `int64_t` carrier `assign()`'s float-to-int conversion was out of range
-    // (undefined behaviour) and on x86-64 produced INT64_MIN, rendering the value sign-flipped. With
-    // a 128-bit carrier on every toolchain both endpoints round-trip.
+    // MS SQL Server's `money` spans -922337203685477.5808 .. 922337203685477.5807, i.e. unscaled
+    // values of exactly INT64_MIN and INT64_MAX. The negative endpoint has magnitude
+    // 9223372036854775808 — one past INT64_MAX — so with an `int64_t` carrier `assign()`'s
+    // float-to-int conversion is out of range (undefined behaviour) and on x86-64 yields INT64_MIN,
+    // rendering the value sign-flipped. With a 128-bit carrier on every toolchain both endpoints
+    // round-trip.
     //
     // Injected through the SQL_NUMERIC_STRUCT constructor because that is the state a native
     // SQL_C_NUMERIC fetch leaves behind: mantissa verbatim, nativeValue still zero. Note that the
@@ -199,7 +199,7 @@ TEST_CASE("SqlNumeric carries money's full range on every toolchain", "[SqlNumer
     CHECK(money.ToString().front() != '-'); // the sign flip this guards against
 
     // The negative endpoint: -922337203685477.5808, unscaled magnitude 2^63 — one past INT64_MAX,
-    // which is precisely the value the old carrier could not hold.
+    // which is precisely the value a 64-bit carrier cannot hold.
     constexpr auto minMagnitude = std::uint64_t { 9'223'372'036'854'775'808ULL };
     raw.sign = 0; // negative
     std::memcpy(static_cast<void*>(raw.val), &minMagnitude, sizeof(minMagnitude));
@@ -208,9 +208,10 @@ TEST_CASE("SqlNumeric carries money's full range on every toolchain", "[SqlNumer
     CHECK(detail::Int128ToString(negativeMoney.ToUnscaledValue()) == "-9223372036854775808");
     CHECK(negativeMoney.ToString() == "-922337203685477.5808");
 
-    // The same endpoint reached through assign() rather than a native fetch — this is the path that
-    // performed the out-of-range conversion. `long double` is 53-bit on MSVC so the low digits are
-    // not expected to survive here; what must survive is the *sign*, which UB used to invert.
+    // The same endpoint reached through assign() rather than a native fetch — this is the path
+    // where a narrow carrier makes the conversion out of range. `long double` is 53-bit on MSVC so
+    // the low digits are not expected to survive here; what must survive is the *sign*, which that
+    // UB inverts.
     SqlNumeric<19, 4> const assigned { -922337203685477.5808 };
     CHECK(assigned.ToString().front() == '-');
     CHECK(assigned.ToDouble() < 0.0);
@@ -219,8 +220,8 @@ TEST_CASE("SqlNumeric carries money's full range on every toolchain", "[SqlNumer
 TEST_CASE("SqlNumeric::ToString renders exactly, without a floating-point detour", "[SqlNumeric]")
 {
     // ToString() formats from the unscaled integer rather than from ToLongDouble(), so all 19 digits
-    // survive on every toolchain — including MSVC, whose `long double` is 53 bits and would have
-    // dropped the low four here.
+    // survive on every toolchain — including MSVC, whose `long double` is 53 bits and would drop the
+    // low four here.
     // 19 significant digits, scale 0 — the widest integral value the type admits.
     CHECK(ExactNumeric<19, 0>(9'999'999'999'999'999'999ULL).ToString() == "9999999999999999999");
 
@@ -261,14 +262,15 @@ TEST_CASE("SqlNumeric carries every digit up to SqlMaxNumericPrecision", "[SqlNu
     CHECK(detail::Int128ToString(widest.ToUnscaledValue()) == expected);
 
     // ToString() carries the same guarantee, because it renders from that integer rather than from
-    // ToLongDouble(). It used to be strictly weaker — divided through `long double` and handed to
-    // the standard library's formatter, so how many digits survived depended both on that type's
-    // width (53 bits on MSVC and on Clang for Apple Silicon, 64 on the x87 80-bit one) and on the
-    // formatter's own long-double support, which narrows to `double` on some toolchains regardless.
+    // ToLongDouble(). Dividing through `long double` and handing the result to the standard
+    // library's formatter would be strictly weaker: how many digits survive would depend both on
+    // that type's width (53 bits on MSVC and on Clang for Apple Silicon, 64 on the x87 80-bit one)
+    // and on the formatter's own long-double support, which narrows to `double` on some toolchains
+    // regardless.
     CHECK(widest.ToString() == expected);
 
-    // The floating-point accessors remain the weaker, toolchain-dependent path — they genuinely do
-    // divide through `long double`, and that has not changed. The portable promise for them is
+    // The floating-point accessors are the weaker, toolchain-dependent path — they genuinely do
+    // divide through `long double`. The portable promise for them is
     // `std::numeric_limits<double>::digits10` significant digits, so assert exactly that.
     constexpr auto portableDigits = static_cast<std::size_t>(std::numeric_limits<double>::digits10);
     auto relativeTolerance = 1.0;

--- a/src/tests/SqlNumericTests.cpp
+++ b/src/tests/SqlNumericTests.cpp
@@ -17,6 +17,29 @@
 
 using namespace Lightweight;
 
+namespace
+{
+
+/// Builds a `SqlNumeric<Precision, Scale>` from its unscaled mantissa, reproducing the state a
+/// native SQL_C_NUMERIC fetch leaves behind (nativeValue == 0, mantissa verbatim). Constructing
+/// through `assign()` instead would measure a `double` argument and lose the low digits.
+///
+/// @param unscaled The mantissa, i.e. the represented value scaled by 10^Scale.
+/// @param positive Whether the value is non-negative.
+/// @return The numeric carrying exactly @p unscaled.
+template <std::size_t Precision, std::size_t Scale>
+SqlNumeric<Precision, Scale> ExactNumeric(std::uint64_t unscaled, bool positive = true)
+{
+    auto raw = SQL_NUMERIC_STRUCT {};
+    raw.precision = static_cast<SQLCHAR>(Precision);
+    raw.scale = static_cast<SQLSCHAR>(Scale);
+    raw.sign = static_cast<SQLCHAR>(positive ? 1 : 0);
+    std::memcpy(static_cast<void*>(raw.val), &unscaled, sizeof(unscaled));
+    return SqlNumeric<Precision, Scale> { raw };
+}
+
+} // namespace
+
 // ================================================================================================
 // SqlNumeric construction & conversion (no DB required)
 // ================================================================================================
@@ -122,37 +145,98 @@ TEST_CASE("SqlMaxNumericPrecision is the width this implementation can carry", "
     // SQL_MAX_NUMERIC_LEN is the mantissa size in *bytes* (16), not a digit count, so the historical
     // `Precision <= SQL_MAX_NUMERIC_LEN` was a category error that rejected DECIMAL(18, 2). But the
     // mantissa's 38-digit capacity is not the bound either — see the derivation on
-    // SqlMaxNumericPrecision. Two things narrow it, and the bound is the tighter of the two:
-    //
-    //   - the unscaled carrier: `int64_t` (18 digits) without a 128-bit integer type,
-    //   - the readable width: at most a 64-bit magnitude (19 digits), which is what the widest
-    //     `long double` in use — the 80-bit x87 one — renders exactly. Where `long double` is
-    //     narrower still (MSVC, Clang on Apple Silicon) ToString() is correspondingly narrower;
-    //     that is an accessor property, not a representability one, and is asserted separately.
-    STATIC_CHECK(detail::DecimalDigitsForBits(63) == 18);  // int64_t magnitude
+    // SqlMaxNumericPrecision. What narrows it is the readable width: at most a 64-bit magnitude
+    // (19 digits), which is what the widest `long double` in use — the 80-bit x87 one — renders.
+    // Where `long double` is narrower still (MSVC, Clang on Apple Silicon) the *floating-point*
+    // accessors are correspondingly narrower; ToString() and ToUnscaledValue() are not, because
+    // neither goes through one. That is an accessor property, asserted separately below.
+    STATIC_CHECK(detail::DecimalDigitsForBits(63) == 18);  // int64_t magnitude — no longer the bound
     STATIC_CHECK(detail::DecimalDigitsForBits(64) == 19);  // 64-bit magnitude / x87 significand
     STATIC_CHECK(detail::DecimalDigitsForBits(127) == 38); // __int128 magnitude — deliberately NOT the bound
 
-#if defined(LIGHTWEIGHT_INT128_T)
+    // The bound is the *same on every toolchain*. This is the property that matters: a column's
+    // precision comes from the database schema, so a ddl2cpp-generated record must compile
+    // regardless of which compiler builds the client. `Int128` supplies a software 128-bit carrier
+    // where the compiler has no native one, which is what makes this unconditional — before that,
+    // the bound was 18 under MSVC/clang-cl and 19 elsewhere.
     STATIC_CHECK(SqlMaxNumericPrecision == 19);
 
-    // MS SQL Server's `money` is DECIMAL(19, 4); here it must be expressible.
+    // MS SQL Server's `money` is DECIMAL(19, 4), and it is expressible everywhere.
     STATIC_CHECK(SqlNumeric<19, 4>::Precision == 19);
     STATIC_CHECK(SqlNumeric<19, 4>::Scale == 4);
     STATIC_CHECK(SqlNumeric<19, 4>::ColumnType.precision == 19);
-#else
-    // Without a 128-bit integer the unscaled value is carried by an `int64_t`, whose magnitude
-    // holds 18 digits. `SqlNumeric<19, 4>` at the `money` maximum would need an unscaled
-    // 9223372036854775808 — one past INT64_MAX — and the out-of-range float-to-int conversion is
-    // undefined behaviour that flips the sign on x86-64. Rejecting it at compile time is the point.
-    STATIC_CHECK(SqlMaxNumericPrecision == 18);
-#endif
 
-    // DECIMAL(18, s), the widest column that works on every supported toolchain.
     STATIC_CHECK(SqlNumeric<18, 4>::Precision == 18);
 
     SqlNumeric<SqlMaxNumericPrecision, 4> const widest { 1234567890.1234 };
     CHECK(widest.ToString() == "1234567890.1234");
+}
+
+TEST_CASE("SqlNumeric carries money's full range on every toolchain", "[SqlNumeric]")
+{
+    // The regression this whole change is about. MS SQL Server's `money` spans
+    // -922337203685477.5808 .. 922337203685477.5807, i.e. unscaled values of exactly INT64_MIN and
+    // INT64_MAX. The negative endpoint has magnitude 9223372036854775808 — one past INT64_MAX — so
+    // with the previous `int64_t` carrier `assign()`'s float-to-int conversion was out of range
+    // (undefined behaviour) and on x86-64 produced INT64_MIN, rendering the value sign-flipped. With
+    // a 128-bit carrier on every toolchain both endpoints round-trip.
+    //
+    // Injected through the SQL_NUMERIC_STRUCT constructor because that is the state a native
+    // SQL_C_NUMERIC fetch leaves behind: mantissa verbatim, nativeValue still zero. Note that the
+    // mantissa is a *magnitude* — SQL_NUMERIC_STRUCT carries the sign in its own field.
+    auto raw = SQL_NUMERIC_STRUCT {};
+    raw.precision = 19;
+    raw.scale = 4;
+
+    // The positive endpoint: 922337203685477.5807, unscaled magnitude INT64_MAX.
+    constexpr auto maxMagnitude = std::uint64_t { 9'223'372'036'854'775'807ULL };
+    raw.sign = 1; // positive
+    std::memcpy(static_cast<void*>(raw.val), &maxMagnitude, sizeof(maxMagnitude));
+
+    SqlNumeric<19, 4> const money { raw };
+    CHECK(detail::Int128ToString(money.ToUnscaledValue()) == "9223372036854775807");
+    CHECK(money.ToString() == "922337203685477.5807");
+    CHECK(money.ToString().front() != '-'); // the sign flip this guards against
+
+    // The negative endpoint: -922337203685477.5808, unscaled magnitude 2^63 — one past INT64_MAX,
+    // which is precisely the value the old carrier could not hold.
+    constexpr auto minMagnitude = std::uint64_t { 9'223'372'036'854'775'808ULL };
+    raw.sign = 0; // negative
+    std::memcpy(static_cast<void*>(raw.val), &minMagnitude, sizeof(minMagnitude));
+
+    SqlNumeric<19, 4> const negativeMoney { raw };
+    CHECK(detail::Int128ToString(negativeMoney.ToUnscaledValue()) == "-9223372036854775808");
+    CHECK(negativeMoney.ToString() == "-922337203685477.5808");
+
+    // The same endpoint reached through assign() rather than a native fetch — this is the path that
+    // performed the out-of-range conversion. `long double` is 53-bit on MSVC so the low digits are
+    // not expected to survive here; what must survive is the *sign*, which UB used to invert.
+    SqlNumeric<19, 4> const assigned { -922337203685477.5808 };
+    CHECK(assigned.ToString().front() == '-');
+    CHECK(assigned.ToDouble() < 0.0);
+}
+
+TEST_CASE("SqlNumeric::ToString renders exactly, without a floating-point detour", "[SqlNumeric]")
+{
+    // ToString() formats from the unscaled integer rather than from ToLongDouble(), so all 19 digits
+    // survive on every toolchain — including MSVC, whose `long double` is 53 bits and would have
+    // dropped the low four here.
+    // 19 significant digits, scale 0 — the widest integral value the type admits.
+    CHECK(ExactNumeric<19, 0>(9'999'999'999'999'999'999ULL).ToString() == "9999999999999999999");
+
+    // 19 digits with a scale, i.e. the `money` shape.
+    CHECK(ExactNumeric<19, 4>(1'234'567'890'123'456'789ULL).ToString() == "123456789012345.6789");
+
+    // Scale == Precision: no integral digit at all, so the renderer must pad a leading zero.
+    CHECK(ExactNumeric<19, 19>(1'234'567'890'123'456'789ULL).ToString() == "0.1234567890123456789");
+
+    // A value needing interior zero padding between the point and the first significant digit.
+    CHECK(ExactNumeric<10, 4>(1ULL).ToString() == "0.0001");
+    CHECK(ExactNumeric<10, 4>(1ULL, /*positive=*/false).ToString() == "-0.0001");
+
+    // Zero renders with the full complement of fractional digits, not as a bare "0".
+    CHECK(ExactNumeric<10, 4>(0ULL).ToString() == "0.0000");
+    CHECK(ExactNumeric<10, 0>(0ULL).ToString() == "0");
 }
 
 TEST_CASE("SqlNumeric carries every digit up to SqlMaxNumericPrecision", "[SqlNumeric]")
@@ -169,35 +253,28 @@ TEST_CASE("SqlNumeric carries every digit up to SqlMaxNumericPrecision", "[SqlNu
     for ([[maybe_unused]] auto const digit: std::views::iota(std::size_t { 0 }, precision))
         allNines = (allNines * 10) + 9;
 
-    auto raw = SQL_NUMERIC_STRUCT {};
-    raw.precision = static_cast<SQLCHAR>(precision);
-    raw.scale = 0;
-    raw.sign = 1;
-    std::memcpy(static_cast<void*>(raw.val), &allNines, sizeof(allNines));
-
-    SqlNumeric<precision, 0> const widest { raw };
+    SqlNumeric<precision, 0> const widest = ExactNumeric<precision, 0>(allNines);
     auto const expected = std::string(precision, '9');
 
     // The carrier's guarantee, and the one the bound is derived from: unconditional, on every
-    // platform, independent of any floating-point type. The unscaled value is a `__int128` where
-    // one exists, which std::format does not handle; at `precision <= 19` digits its magnitude
-    // always fits a std::uint64_t, so narrow it there.
-    CHECK(std::format("{}", static_cast<std::uint64_t>(widest.ToUnscaledValue())) == expected);
+    // platform, independent of any floating-point type.
+    CHECK(detail::Int128ToString(widest.ToUnscaledValue()) == expected);
 
-    // ToString() is a distinctly weaker, toolchain-dependent guarantee, because it — like every
-    // accessor but ToUnscaledValue() — divides through `long double` and is then rendered by the
-    // standard library's formatter. How many digits survive depends on *both*: the width of that
-    // type (53 bits on MSVC and on Clang for Apple Silicon, 64 on the x87 80-bit one) and the
-    // formatter's own long-double support, which in practice narrows to `double` on some
-    // toolchains even where the type is wider. The portable promise — and the only one
-    // docs/data-binder.md makes — is `std::numeric_limits<double>::digits10` significant digits,
-    // so assert exactly that and nothing stronger. The strong claim lives on ToUnscaledValue()
-    // above, where it actually holds.
+    // ToString() carries the same guarantee, because it renders from that integer rather than from
+    // ToLongDouble(). It used to be strictly weaker — divided through `long double` and handed to
+    // the standard library's formatter, so how many digits survived depended both on that type's
+    // width (53 bits on MSVC and on Clang for Apple Silicon, 64 on the x87 80-bit one) and on the
+    // formatter's own long-double support, which narrows to `double` on some toolchains regardless.
+    CHECK(widest.ToString() == expected);
+
+    // The floating-point accessors remain the weaker, toolchain-dependent path — they genuinely do
+    // divide through `long double`, and that has not changed. The portable promise for them is
+    // `std::numeric_limits<double>::digits10` significant digits, so assert exactly that.
     constexpr auto portableDigits = static_cast<std::size_t>(std::numeric_limits<double>::digits10);
     auto relativeTolerance = 1.0;
     for ([[maybe_unused]] auto const digit: std::views::iota(std::size_t { 1 }, portableDigits))
         relativeTolerance /= 10.0;
-    CHECK_THAT(std::stod(widest.ToString()), Catch::Matchers::WithinRel(static_cast<double>(allNines), relativeTolerance));
+    CHECK_THAT(widest.ToDouble(), Catch::Matchers::WithinRel(static_cast<double>(allNines), relativeTolerance));
 }
 
 TEST_CASE("SqlNumeric supports a purely fractional Scale == Precision", "[SqlNumeric]")

--- a/src/tests/SqlNumericTests.cpp
+++ b/src/tests/SqlNumericTests.cpp
@@ -131,6 +131,34 @@ TEST_CASE("SqlNumeric supports the full decimal precision of the ODBC mantissa",
     CHECK(money.ToString() == "1234567890.1234");
 }
 
+TEST_CASE("SqlNumeric supports a purely fractional Scale == Precision", "[SqlNumeric]")
+{
+    // `DECIMAL(4, 4)` is legal SQL: four digits, all of them after the decimal point, i.e. the
+    // value range [0.0000, 0.9999]. No conversion path needs an integral digit.
+    STATIC_CHECK(SqlNumeric<4, 4>::Precision == 4);
+    STATIC_CHECK(SqlNumeric<4, 4>::Scale == 4);
+    STATIC_CHECK(SqlNumeric<4, 4>::ColumnType.precision == 4);
+    STATIC_CHECK(SqlNumeric<4, 4>::ColumnType.scale == 4);
+
+    SqlNumeric<4, 4> const fraction { 0.1234 };
+    CHECK(fraction.ToString() == "0.1234");
+    CHECK(static_cast<long long>(fraction.ToUnscaledValue()) == 1234);
+    CHECK_THAT(fraction.ToDouble(), Catch::Matchers::WithinAbs(0.1234, 1e-9));
+    CHECK_THAT(fraction.ToFloat(), Catch::Matchers::WithinAbs(0.1234F, 1e-6F));
+
+    // The boundaries of the range, and the negative half.
+    CHECK(SqlNumeric<4, 4>(0.9999).ToString() == "0.9999");
+    CHECK(SqlNumeric<4, 4>(0.0).ToString() == "0.0000");
+    CHECK(SqlNumeric<4, 4>(-0.1234).ToString() == "-0.1234");
+
+    // Ordering and equality keep working across the fractional-only form.
+    CHECK(SqlNumeric<4, 4>(0.1234) < SqlNumeric<4, 4>(0.5678));
+    CHECK(SqlNumeric<4, 4>(0.1234) == SqlNumeric<8, 4>(0.1234));
+
+    // Scale == Precision at the widest supported precision is fine too.
+    STATIC_CHECK(SqlNumeric<SqlMaxNumericPrecision, SqlMaxNumericPrecision>::Scale == SqlMaxNumericPrecision);
+}
+
 TEST_CASE("SqlNumeric ToUnscaledValue scales by 10^Scale", "[SqlNumeric]")
 {
     SqlNumeric<10, 2> const n { 1.23 };

--- a/src/tests/SqlSchemaDbTests.cpp
+++ b/src/tests/SqlSchemaDbTests.cpp
@@ -8,6 +8,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
+#include <variant>
 
 using namespace Lightweight;
 
@@ -513,4 +514,69 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlTestFixture::DropTableRecursively: diamond 
     CHECK_FALSE(TableExists(stmt, "DiaLeft"));
     CHECK_FALSE(TableExists(stmt, "DiaRight"));
     CHECK_FALSE(TableExists(stmt, "DiaLeaf"));
+}
+
+// ================================================================================================
+// MS SQL Server type reporting (regression coverage for issue #519)
+// ================================================================================================
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlSchema::ReadAllTables reports money as DECIMAL(19, 4)", "[SqlSchema]")
+{
+    auto stmt = SqlStatement {};
+    UNSUPPORTED_DATABASE(stmt, SqlServerType::SQLITE);
+    UNSUPPORTED_DATABASE(stmt, SqlServerType::POSTGRESQL);
+
+    (void) stmt.ExecuteDirect(R"(CREATE TABLE "MoneyProbe" ("price" money NOT NULL, "small" smallmoney NULL))");
+
+    auto const tables = SqlSchema::ReadAllTables(stmt, stmt.Connection().DatabaseName(), /*schema=*/"");
+    auto const probe = std::ranges::find_if(tables, [](SqlSchema::Table const& t) { return t.name == "MoneyProbe"; });
+    REQUIRE(probe != tables.end());
+    REQUIRE(probe->columns.size() == 2);
+
+    // `money` is DECIMAL(19, 4) and `smallmoney` is DECIMAL(10, 4). Both must be reported with
+    // their true precision — the emitted SqlNumeric<19, 4> has to be a legal instantiation.
+    using Lightweight::SqlColumnTypeDefinitions::Decimal;
+    REQUIRE(std::holds_alternative<Decimal>(probe->columns[0].type));
+    CHECK(std::get<Decimal>(probe->columns[0].type).precision == 19);
+    CHECK(std::get<Decimal>(probe->columns[0].type).scale == 4);
+    REQUIRE(std::holds_alternative<Decimal>(probe->columns[1].type));
+    CHECK(std::get<Decimal>(probe->columns[1].type).precision == 10);
+    CHECK(std::get<Decimal>(probe->columns[1].type).scale == 4);
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlSchema::ReadAllTables resolves MS SQL Server alias types", "[SqlSchema]")
+{
+    auto stmt = SqlStatement {};
+    UNSUPPORTED_DATABASE(stmt, SqlServerType::SQLITE);
+    UNSUPPORTED_DATABASE(stmt, SqlServerType::POSTGRESQL);
+
+    // A column declared with an alias type (or with the built-in `sysname` alias) must be
+    // reported as its base type. Reporting the alias name would drop the column into the
+    // unmapped-type fallback, which mistakes an nvarchar(N) for a non-Unicode string of
+    // 2*N bytes.
+    (void) stmt.ExecuteDirect(R"(DROP TABLE IF EXISTS "AliasProbe")"); // may survive a failed run
+    (void) stmt.ExecuteDirect(R"(DROP TYPE IF EXISTS "LightweightAliasNVarchar")");
+    (void) stmt.ExecuteDirect(R"(DROP TYPE IF EXISTS "LightweightAliasVarchar")");
+    (void) stmt.ExecuteDirect(R"(CREATE TYPE "LightweightAliasNVarchar" FROM nvarchar(50) NULL)");
+    (void) stmt.ExecuteDirect(R"(CREATE TYPE "LightweightAliasVarchar" FROM varchar(100) NULL)");
+    (void) stmt.ExecuteDirect(R"(CREATE TABLE "AliasProbe" ("wide" "LightweightAliasNVarchar" NULL,
+                                                            "ansi" "LightweightAliasVarchar" NULL,
+                                                            "name" sysname NULL))");
+
+    auto const tables = SqlSchema::ReadAllTables(stmt, stmt.Connection().DatabaseName(), /*schema=*/"");
+    auto const probe = std::ranges::find_if(tables, [](SqlSchema::Table const& t) { return t.name == "AliasProbe"; });
+    REQUIRE(probe != tables.end());
+    REQUIRE(probe->columns.size() == 3);
+
+    using namespace Lightweight::SqlColumnTypeDefinitions;
+    REQUIRE(std::holds_alternative<NVarchar>(probe->columns[0].type));
+    CHECK(std::get<NVarchar>(probe->columns[0].type).size == 50); // characters, not bytes
+    REQUIRE(std::holds_alternative<Varchar>(probe->columns[1].type));
+    CHECK(std::get<Varchar>(probe->columns[1].type).size == 100);
+    REQUIRE(std::holds_alternative<NVarchar>(probe->columns[2].type)); // sysname == nvarchar(128)
+    CHECK(std::get<NVarchar>(probe->columns[2].type).size == 128);
+
+    (void) stmt.ExecuteDirect(R"(DROP TABLE "AliasProbe")");
+    (void) stmt.ExecuteDirect(R"(DROP TYPE IF EXISTS "LightweightAliasNVarchar")");
+    (void) stmt.ExecuteDirect(R"(DROP TYPE IF EXISTS "LightweightAliasVarchar")");
 }

--- a/src/tests/Utils.hpp
+++ b/src/tests/Utils.hpp
@@ -137,13 +137,15 @@ namespace std
 template <std::size_t Precision, std::size_t Scale>
 std::ostream& operator<<(std::ostream& os, Lightweight::SqlNumeric<Precision, Scale> const& value)
 {
+    // The unscaled value is a 128-bit integer, which std::format handles for neither the native
+    // __int128_t nor the software stand-in — render it through the carrier's own formatter.
     return os << std::format("SqlNumeric<{}, {}>({}, {}, {}, {})",
                              Precision,
                              Scale,
                              value.sqlValue.sign,
                              value.sqlValue.precision,
                              value.sqlValue.scale,
-                             value.ToUnscaledValue());
+                             Lightweight::detail::Int128ToString(value.ToUnscaledValue()));
 }
 } // namespace std
 


### PR DESCRIPTION
Fixes #519, plus two `SqlNumeric` constraint bugs found while fixing it.

## 1. Duplicate `#include` for repeated FK targets

`CxxModelPrinter::TableInfo::requiredTables` was a `std::vector<std::string>` appended once **per FK column**, and `HeaderFileForTheTable()` sorted but never deduplicated — so a table with N foreign keys to the same target emitted that `#include` N times (the reporter saw one header repeat a single include 55 times, ~400 duplicate lines across 98 files).

Changed to `std::set<std::string>`, which dedupes and yields the same sorted order for free, so the explicit sort was dropped. Verified byte-identical Chinook golden output.

## 2. `money` mapped to a precision `SqlNumeric` rejected

`ddl2cpp` emits `SqlNumeric<19, 4>` for SQL Server `money`, but `SqlNumeric` asserted `Precision <= SQL_MAX_NUMERIC_LEN`, so every generated entity with a `money` column failed to compile.

`SQL_MAX_NUMERIC_LEN` is the size **in bytes** of `SQL_NUMERIC_STRUCT::val` (16 bytes = a 128-bit mantissa) — not a maximum decimal precision. The assert compared digits against bytes and rejected *every* decimal wider than 16 digits, including plain `decimal(18,2)`.

**The bound is now what this implementation can actually carry**, which is not the same as what the ODBC struct could hold. Two things narrow it:

- **The carrier.** `assign()` and `ToUnscaledValue()` fall back to `int64_t` when `__int128` is unavailable — and the guard excludes **both MSVC and clang-cl**. An `int64_t` unscaled value holds 18 digits; at `money`'s maximum the multiply exceeds `INT64_MAX`, the float→int conversion is UB, and x86-64 yields a sign-flipped `-922337203685477.5808`.
- **The readable width.** Every accessor except `ToUnscaledValue()` divides through `long double`, whose widest form (80-bit x87) carries 19 digits. Past that, nothing is readable on any platform.

So: **19 with a 128-bit carrier, 18 without.** `decimal(18, s)` compiles everywhere and `money` compiles wherever `__int128` exists; wider columns must be read as strings. `docs/data-binder.md` now tabulates what each accessor delivers — including that `operator==` compares via `ToFloat()` (7 digits).

## 3. `static_assert(Scale < Precision)` rejected legal types

`decimal(4,4)` — all four digits after the point, values in [0,1) — is legal in the SQL standard and in all three backends. Traced every conversion path first (`assign`, `ToUnscaledValue`, `ToFloat/Double/LongDouble`, `ToString`): the value is stored as the unscaled integer `value × 10^Scale` and nothing assumes an integral digit. Relaxed to `Scale <= Precision`, with `static_assert(Precision > 0)` added to preserve the rejection of `SqlNumeric<0,0>` the strict `<` gave for free.

## 4. MSSQL alias types resolved to the wrong column type

The batched `sys.columns` reader joined `sys.types` on `user_type_id` only, so alias types (`CREATE TYPE X FROM nvarchar(50)`) and `sysname` matched nothing and fell through to a `Varchar{max_length}` default — an `nvarchar(50)` became `SqlAnsiString<100>`: wrong char width *and* bytes-instead-of-chars size.

Fixed with `COALESCE(bt.name, ty.name)` + `LEFT JOIN sys.types bt ON ty.system_type_id = bt.user_type_id`. Verified against a live container that `user_type_id` has no duplicates (no row multiplication) and that no ordinary column's resolved type changes.

This is the same symptom class as the reporter's third, low-confidence item (a `varchar(100)` generated as `SqlWideString<50>`). That exact case **could not be reproduced** — it needs the force-unicode config *and* `Varchar{50}` — and is not claimed as fixed.

## Risk assessment

- The precision bound is *raised* relative to `master` (16 → 18/19), so no previously-compiling record stops compiling. `SqlNumeric<0,0>` was already rejected.
- Above 15 digits, `SqlNumeric` is exact only on the native `SQL_C_NUMERIC` path, which is unavailable on SQLite and MS SQL Server (`NativeNumericSupportIsBroken`) *and* on the Windows psqlODBC build. That is pre-existing, now documented, and worth its own issue — `NativeNumericSupportIsBroken()` keys off `SqlServerType`, but losslessness is a property of the driver build.
- The `sys.types` join is MSSQL-only and additive.

## Known issues confirmed but not fixed here

- `ToUnscaledValue()` reads `sqlValue.val` via `reinterpret_cast<__int128 const*>` at offset 3 of a 1-aligned struct — a misaligned load, tolerated on x86-64.
- `OutputColumn` passes `sizeof(ValueType)` as the `SQL_C_NUMERIC` buffer length for a 19-byte target followed immediately by `nativeValue`.
- `SqlSchema.cpp` now stores the resolved base-type name in `Column::dialectDependantTypeString`, so a declared alias name is no longer recoverable. Inert today — no consumer in `src/`.

## Databases tested

`sqlite3` (3.49.1), `mssql2022` (16.00.4250, Docker), `postgres` (16.4, Docker) — full suite, 0 failures on each.

## Compilers tested

`clang-debug` (clang-tidy + ASan/UBSan, `-Werror`), `gcc-release` (the compiler CI's database legs actually run), `gcc-release -D LIGHTWEIGHT_BUILD_MODULES=ON` (the module build, which rejects an exported entity with internal linkage — hence `inline constexpr`), and the Doxygen docs build with `LIGHTWEIGHT_DOCS_WARN_AS_ERROR=ON`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)