### PR TITLE
Skip relation members in the DataMapper column-enumerating code paths

### DIFF
--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -972,6 +972,16 @@ namespace detail
             record, [reader = &reader, &indexFromQuery]<size_t I, typename Field>(Field& field) mutable {
                 // Only members that map onto a column consume a result set index — relations
                 // (HasMany, HasManyThrough, HasOneThrough, ...) are not part of the projection.
+                //
+                // The projection side (RecordColumnMember, see SqlSelectQueryBuilder::Fields and
+                // DataMapper::BuildFullyQualifiedFieldList) and this read side must classify every
+                // member identically; a member that only one of them counts silently shifts the index
+                // of every column following it. Both predicates ultimately ask whether SqlDataBinder<T>
+                // is usable as a column, so pin them together here rather than letting them drift.
+                static_assert(RecordColumnMember<Field> == (IsField<Field> || SqlGetColumnNativeType<Field>),
+                              "Record member is projected but not readable (or readable but not projected). "
+                              "A SqlDataBinder<T> used as a record member must provide both OutputColumn() "
+                              "and GetColumn().");
                 if constexpr (IsField<Field>)
                 {
                     ++indexFromQuery;
@@ -1005,41 +1015,11 @@ namespace detail
     {
         auto& [firstRecord, secondRecord] = record;
 
-        EnumerateRecordMembers(firstRecord, [reader = &reader]<size_t I, typename Field>(Field& field) mutable {
-            if constexpr (IsField<Field>)
-            {
-                if constexpr (Field::IsOptional)
-                    field.MutableValue() = reader->GetNullableColumn<typename Field::ValueType::value_type>(I + 1);
-                else
-                    field.MutableValue() = reader->GetColumn<typename Field::ValueType>(I + 1);
-            }
-            else if constexpr (SqlGetColumnNativeType<Field>)
-            {
-                if constexpr (Field::IsOptional)
-                    field = reader->GetNullableColumn<typename Field::BaseType>(I + 1);
-                else
-                    field = reader->GetColumn<Field>(I + 1);
-            }
-        });
-
-        EnumerateRecordMembers(secondRecord, [reader = &reader]<size_t I, typename Field>(Field& field) mutable {
-            if constexpr (IsField<Field>)
-            {
-                if constexpr (Field::IsOptional)
-                    field.MutableValue() = reader->GetNullableColumn<typename Field::ValueType::value_type>(
-                        RecordMemberCount<FirstRecord> + I + 1);
-                else
-                    field.MutableValue() =
-                        reader->GetColumn<typename Field::ValueType>(RecordMemberCount<FirstRecord> + I + 1);
-            }
-            else if constexpr (SqlGetColumnNativeType<Field>)
-            {
-                if constexpr (Field::IsOptional)
-                    field = reader->GetNullableColumn<typename Field::BaseType>(RecordMemberCount<FirstRecord> + I + 1);
-                else
-                    field = reader->GetColumn<Field>(RecordMemberCount<FirstRecord> + I + 1);
-            }
-        });
+        // Both sub-records are read through the single-record overload, so relation members are skipped
+        // (rather than indexed by member position) on both sides. The second sub-record starts after the
+        // *columns* the first one projects, which is RecordColumnCount, not RecordMemberCount.
+        GetAllColumns(reader, firstRecord, 0);
+        GetAllColumns(reader, secondRecord, static_cast<SQLUSMALLINT>(RecordColumnCount<FirstRecord>));
     }
 
     template <typename Record>
@@ -1553,7 +1533,10 @@ void SqlAllFieldsQueryBuilder<std::tuple<FirstRecord, SecondRecord>, QueryOption
         if (canSafelyBindAll)
         {
             detail::BindAllOutputColumnsWithOffset(reader, firstRecord, 1);
-            detail::BindAllOutputColumnsWithOffset(reader, secondRecord, 1 + RecordMemberCount<FirstRecord>);
+            // The second sub-record starts after the *columns* projected for the first one; relation
+            // members are not projected, so RecordMemberCount would over-count here.
+            detail::BindAllOutputColumnsWithOffset(
+                reader, secondRecord, static_cast<SQLUSMALLINT>(1 + RecordColumnCount<FirstRecord>));
         }
 
         if (!reader.FetchRow())
@@ -2120,16 +2103,21 @@ std::optional<Record> DataMapper::QuerySingle(PrimaryKeyTypes&&... primaryKeys)
     // first storage field via the returned Builder&, then reuse that pointer.
     auto selectStarter = _connection.Query(RecordTableName<Record>).Select();
     SqlSelectQueryBuilder* queryBuilder = nullptr;
+    // Project exactly the members the read side (detail::ReadSingleResult) consumes as columns —
+    // FieldWithStorage alone would drop plain bindable members such as `std::string note;`.
     EnumerateRecordMembers<Record>([&]<size_t I, typename FieldType>() {
-        if constexpr (FieldWithStorage<FieldType>)
+        if constexpr (RecordColumnMember<FieldType>)
         {
             if (queryBuilder == nullptr)
                 queryBuilder = &selectStarter.Field(FieldNameAt<I, Record>);
             else
                 queryBuilder->Field(FieldNameAt<I, Record>);
 
-            if constexpr (FieldType::IsPrimaryKey)
-                std::ignore = queryBuilder->Where(FieldNameAt<I, Record>, SqlWildcard);
+            if constexpr (FieldWithStorage<FieldType>)
+            {
+                if constexpr (FieldType::IsPrimaryKey)
+                    std::ignore = queryBuilder->Where(FieldNameAt<I, Record>, SqlWildcard);
+            }
         }
     });
 
@@ -2160,8 +2148,9 @@ std::optional<Record> DataMapper::QuerySingle(SqlSelectQueryBuilder selectQuery,
     ZoneScopedN("DataMapper::QuerySingle(Builder)");
     ZoneTextObject(RecordTableName<Record>);
 
+    // Same projection predicate as the read side; see the note in QuerySingle(PrimaryKeyTypes...).
     EnumerateRecordMembers<Record>([&]<size_t I, typename FieldType>() {
-        if constexpr (FieldWithStorage<FieldType>)
+        if constexpr (RecordColumnMember<FieldType>)
             selectQuery.Field(SqlQualifiedTableColumnName { RecordTableName<Record>, FieldNameAt<I, Record> });
     });
     auto const composedSql = selectQuery.First().ToSql();
@@ -2262,13 +2251,16 @@ std::vector<std::tuple<First, Second, Rest...>> DataMapper::Query(SqlSelectQuery
     _stmt.Prepare(tupleSql);
     auto reader = _stmt.Execute();
 
+    // The 1-based result set index of the first column belonging to the I-th sub-record. The projection
+    // (SqlSelectQueryBuilder::Fields<Records...>) emits one entry per RecordColumnMember, so relation
+    // members contribute no column and RecordMemberCount would over-count the preceding sub-records.
     constexpr auto calculateOffset = []<size_t I, typename Tuple>() {
         size_t offset = 1;
 
         if constexpr (I > 0)
         {
             [&]<size_t... Indices>(std::index_sequence<Indices...>) {
-                ((Indices < I ? (offset += RecordMemberCount<std::tuple_element_t<Indices, Tuple>>) : 0), ...);
+                ((Indices < I ? (offset += RecordColumnCount<std::tuple_element_t<Indices, Tuple>>) : 0), ...);
             }(std::make_index_sequence<I> {});
         }
         return offset;

--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -584,14 +584,18 @@ class DataMapper
     [[nodiscard]] static std::string BuildFullyQualifiedFieldList()
     {
         std::string fields;
-        EnumerateRecordMembers<Record>([&fields]<size_t I, typename Field>() {
-            if (!fields.empty())
-                fields += ", ";
-            fields += '"';
-            fields += RecordTableName<Record>;
-            fields += "\".\"";
-            fields += FieldNameAt<I, Record>;
-            fields += '"';
+        EnumerateRecordMembers<Record>([&fields]<size_t I, typename FieldType>() {
+            // Relations (HasMany, HasManyThrough, HasOneThrough, ...) have no column of their own.
+            if constexpr (RecordColumnMember<FieldType>)
+            {
+                if (!fields.empty())
+                    fields += ", ";
+                fields += '"';
+                fields += RecordTableName<Record>;
+                fields += "\".\"";
+                fields += FieldNameAt<I, Record>;
+                fields += '"';
+            }
         });
         return fields;
     }
@@ -966,9 +970,11 @@ namespace detail
     {
         EnumerateRecordMembers<ElementMask>(
             record, [reader = &reader, &indexFromQuery]<size_t I, typename Field>(Field& field) mutable {
-                ++indexFromQuery;
+                // Only members that map onto a column consume a result set index — relations
+                // (HasMany, HasManyThrough, HasOneThrough, ...) are not part of the projection.
                 if constexpr (IsField<Field>)
                 {
+                    ++indexFromQuery;
                     if constexpr (Field::IsOptional)
                         field.MutableValue() =
                             reader->GetNullableColumn<typename Field::ValueType::value_type>(indexFromQuery);
@@ -977,6 +983,7 @@ namespace detail
                 }
                 else if constexpr (SqlGetColumnNativeType<Field>)
                 {
+                    ++indexFromQuery;
                     if constexpr (IsOptionalBelongsTo<Field>)
                         field = reader->GetNullableColumn<typename Field::BaseType>(indexFromQuery);
                     else
@@ -1942,12 +1949,17 @@ void DataMapper::Update(Record& record)
     }
 #else
     EnumerateRecordMembers(record, [&query]<size_t I, typename FieldType>(FieldType const& field) {
-        if (field.IsModified())
-            query.Set(FieldNameAt<I, Record>, SqlWildcard);
         // for some reason compiler do not want to properly deduce FieldType, so here we
         // directly infer the type from the Record type and index
-        if constexpr (IsPrimaryKey<RecordMemberTypeOf<I, Record>>)
-            std::ignore = query.Where(FieldNameAt<I, Record>, SqlWildcard);
+        using MemberType = RecordMemberTypeOf<I, Record>;
+        // Relations (HasMany, HasManyThrough, HasOneThrough, ...) have no column of their own.
+        if constexpr (FieldWithStorage<MemberType>)
+        {
+            if (field.IsModified())
+                query.Set(FieldNameAt<I, Record>, SqlWildcard);
+            if constexpr (IsPrimaryKey<MemberType>)
+                std::ignore = query.Where(FieldNameAt<I, Record>, SqlWildcard);
+        }
     });
 #endif
     _stmt.Prepare(query);
@@ -1957,25 +1969,37 @@ void DataMapper::Update(Record& record)
 #if defined(LIGHTWEIGHT_CXX26_REFLECTION)
     template for (constexpr auto el: define_static_array(nonstatic_data_members_of(^^Record, ctx)))
     {
-        if (record.[:el:].IsModified())
+        using FieldType = typename[:std::meta::type_of(el):];
+        // Relations (HasMany, HasManyThrough, HasOneThrough, ...) have no column of their own.
+        if constexpr (FieldWithStorage<FieldType>)
         {
-            _stmt.BindInputParameter(i++, record.[:el:].Value(), FieldNameOf<el>);
+            if (record.[:el:].IsModified())
+            {
+                _stmt.BindInputParameter(i++, record.[:el:].Value(), FieldNameOf<el>);
+            }
         }
     }
 
     template for (constexpr auto el: define_static_array(nonstatic_data_members_of(^^Record, ctx)))
     {
         using FieldType = typename[:std::meta::type_of(el):];
-        if constexpr (FieldType::IsPrimaryKey)
+        if constexpr (FieldWithStorage<FieldType>)
         {
-            _stmt.BindInputParameter(i++, record.[:el:].Value(), FieldNameOf<el>);
+            if constexpr (FieldType::IsPrimaryKey)
+            {
+                _stmt.BindInputParameter(i++, record.[:el:].Value(), FieldNameOf<el>);
+            }
         }
     }
 #else
     // Bind the SET clause
     EnumerateRecordMembers(record, [this, &i]<size_t I, typename FieldType>(FieldType const& field) {
-        if (field.IsModified())
-            _stmt.BindInputParameter(i++, field.Value(), FieldNameAt<I, Record>);
+        // Relations (HasMany, HasManyThrough, HasOneThrough, ...) have no column of their own.
+        if constexpr (FieldWithStorage<RecordMemberTypeOf<I, Record>>)
+        {
+            if (field.IsModified())
+                _stmt.BindInputParameter(i++, field.Value(), FieldNameAt<I, Record>);
+        }
     });
 
     // Bind the WHERE clause
@@ -2041,8 +2065,10 @@ std::size_t DataMapper::Delete(Record const& record)
     template for (constexpr auto el: define_static_array(nonstatic_data_members_of(^^Record, ctx)))
     {
         using FieldType = typename[:std::meta::type_of(el):];
-        if constexpr (FieldType::IsPrimaryKey)
-            std::ignore = query.Where(FieldNameOf<el>, SqlWildcard);
+        // Relations (HasMany, HasManyThrough, HasOneThrough, ...) have no column of their own.
+        if constexpr (FieldWithStorage<FieldType>)
+            if constexpr (FieldType::IsPrimaryKey)
+                std::ignore = query.Where(FieldNameOf<el>, SqlWildcard);
     }
 #else
     EnumerateRecordMembers(record, [&query]<size_t I, typename FieldType>(FieldType const& /*field*/) {
@@ -2058,9 +2084,12 @@ std::size_t DataMapper::Delete(Record const& record)
     template for (constexpr auto el: define_static_array(nonstatic_data_members_of(^^Record, ctx)))
     {
         using FieldType = typename[:std::meta::type_of(el):];
-        if constexpr (FieldType::IsPrimaryKey)
+        if constexpr (FieldWithStorage<FieldType>)
         {
-            _stmt.BindInputParameter(i++, record.[:el:].Value(), FieldNameOf<el>);
+            if constexpr (FieldType::IsPrimaryKey)
+            {
+                _stmt.BindInputParameter(i++, record.[:el:].Value(), FieldNameOf<el>);
+            }
         }
     }
 #else

--- a/src/Lightweight/DataMapper/Record.hpp
+++ b/src/Lightweight/DataMapper/Record.hpp
@@ -130,6 +130,18 @@ concept FieldWithStorage = requires(T const& field, T& mutableField) {
     // clang-format on
 };
 
+/// @brief Requires that T maps onto a column of its record's table.
+///
+/// This is satisfied by fields with storage (Field, BelongsTo) as well as by plain record members
+/// that are directly bindable as an output column (a record may be a plain struct of bindable
+/// members). Relation members (HasMany, HasManyThrough, HasOneThrough, ...) have no column of their
+/// own and therefore must be skipped by every column-enumerating code path, such as the projection
+/// of a SELECT statement.
+///
+/// @ingroup DataMapper
+template <typename T>
+concept RecordColumnMember = FieldWithStorage<T> || SqlOutputColumnBinder<T>;
+
 /// Represents the number of fields with storage in a record.
 ///
 /// @ingroup DataMapper

--- a/src/Lightweight/DataMapper/Record.hpp
+++ b/src/Lightweight/DataMapper/Record.hpp
@@ -142,6 +142,24 @@ concept FieldWithStorage = requires(T const& field, T& mutableField) {
 template <typename T>
 concept RecordColumnMember = FieldWithStorage<T> || SqlOutputColumnBinder<T>;
 
+/// @brief Represents the number of members of a record that map onto a column of a result set.
+///
+/// This is the width the record occupies in a projection built from the @c RecordColumnMember
+/// concept (e.g. @c SqlSelectQueryBuilder::Fields), and therefore the amount by which the index must be
+/// advanced to reach the first column of the record that follows it in a multi-record projection.
+/// It differs from @c RecordMemberCount exactly by the number of relation members (HasMany,
+/// HasManyThrough, HasOneThrough, ...), which have no column of their own.
+///
+/// @ingroup DataMapper
+template <typename Record>
+constexpr size_t RecordColumnCount =
+    FoldRecordMembers<Record>(size_t { 0 }, []<size_t I, typename Field>(size_t const accum) constexpr {
+        if constexpr (RecordColumnMember<Field>)
+            return accum + 1;
+        else
+            return accum;
+    });
+
 /// Represents the number of fields with storage in a record.
 ///
 /// @ingroup DataMapper

--- a/src/Lightweight/Lightweight.cppm
+++ b/src/Lightweight/Lightweight.cppm
@@ -88,6 +88,7 @@ using Lightweight::ParseConnectionString;
 using Lightweight::PostgreSqlFormatter;
 using Lightweight::PrimaryKey;
 using Lightweight::QualifiedColumnName;
+using Lightweight::RecordColumnMember;
 using Lightweight::RecordPrimaryKeyIndex;
 using Lightweight::RecordPrimaryKeyOf;
 using Lightweight::RecordPrimaryKeyType;

--- a/src/Lightweight/Lightweight.cppm
+++ b/src/Lightweight/Lightweight.cppm
@@ -88,6 +88,7 @@ using Lightweight::ParseConnectionString;
 using Lightweight::PostgreSqlFormatter;
 using Lightweight::PrimaryKey;
 using Lightweight::QualifiedColumnName;
+using Lightweight::RecordColumnCount;
 using Lightweight::RecordColumnMember;
 using Lightweight::RecordPrimaryKeyIndex;
 using Lightweight::RecordPrimaryKeyOf;

--- a/src/Lightweight/SqlOdbcWide.hpp
+++ b/src/Lightweight/SqlOdbcWide.hpp
@@ -2,6 +2,11 @@
 
 #pragma once
 
+// <sql.h> below needs the Windows prelude established first — see the note in Utils.hpp.
+#if defined(_WIN32) || defined(_WIN64)
+    #include <Windows.h>
+#endif
+
 #include "DataBinder/UnicodeConverter.hpp"
 
 #include <string>

--- a/src/Lightweight/SqlQuery/Select.hpp
+++ b/src/Lightweight/SqlQuery/Select.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "../DataMapper/Record.hpp"
 #include "../SqlQueryFormatter.hpp"
 #include "../Utils.hpp"
 #include "Core.hpp"
@@ -281,25 +282,31 @@ inline LIGHTWEIGHT_FORCE_INLINE SqlSelectQueryBuilder& SqlSelectQueryBuilder::Bu
 template <typename FirstRecord, typename... MoreRecords>
 inline LIGHTWEIGHT_FORCE_INLINE SqlSelectQueryBuilder& SqlSelectQueryBuilder::Fields()
 {
+    // Relations (HasMany, HasManyThrough, HasOneThrough, ...) have no column of their own and
+    // must not be projected into the SELECT clause.
     if constexpr (sizeof...(MoreRecords) == 0)
     {
-        EnumerateRecordMembers<FirstRecord>(
-            [&]<size_t FieldIndex, typename FieldType>() { Field(FieldNameAt<FieldIndex, FirstRecord>); });
+        EnumerateRecordMembers<FirstRecord>([&]<size_t FieldIndex, typename FieldType>() {
+            if constexpr (RecordColumnMember<FieldType>)
+                Field(FieldNameAt<FieldIndex, FirstRecord>);
+        });
     }
     else
     {
         EnumerateRecordMembers<FirstRecord>([&]<size_t FieldIndex, typename FieldType>() {
-            Field(SqlQualifiedTableColumnName {
-                .tableName = RecordTableName<FirstRecord>,
-                .columnName = FieldNameAt<FieldIndex, FirstRecord>,
-            });
+            if constexpr (RecordColumnMember<FieldType>)
+                Field(SqlQualifiedTableColumnName {
+                    .tableName = RecordTableName<FirstRecord>,
+                    .columnName = FieldNameAt<FieldIndex, FirstRecord>,
+                });
         });
 
         (EnumerateRecordMembers<MoreRecords>([&]<size_t FieldIndex, typename FieldType>() {
-             Field(SqlQualifiedTableColumnName {
-                 .tableName = RecordTableName<MoreRecords>,
-                 .columnName = FieldNameAt<FieldIndex, MoreRecords>,
-             });
+             if constexpr (RecordColumnMember<FieldType>)
+                 Field(SqlQualifiedTableColumnName {
+                     .tableName = RecordTableName<MoreRecords>,
+                     .columnName = FieldNameAt<FieldIndex, MoreRecords>,
+                 });
          }),
          ...);
     }

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -15,6 +15,7 @@
 #include "DataBinder/SqlNumeric.hpp"
 #include "DataBinder/StringInterface.hpp"
 #include "DataBinder/UnicodeConverter.hpp"
+#include "DataMapper/Record.hpp"
 #include "SqlConnection.hpp"
 #include "SqlQuery.hpp"
 #include "SqlQueryFormatter.hpp"
@@ -928,9 +929,20 @@ class SqlRowIterator
         {
             auto res = T {};
 
-            EnumerateRecordMembers(res, [this]<size_t I>(auto&& value) {
-                auto tmp = _cursor->GetColumn<typename RecordMemberTypeOf<I, value_type>::ValueType>(I + 1);
-                value = tmp;
+            // begin() projects the record via Select().Fields<T>(), which emits one column per
+            // RecordColumnMember. Enumerate by column position rather than by member position, so that
+            // relation members (HasMany, HasManyThrough, HasOneThrough, ...) neither need a column nor
+            // shift the ones that follow them.
+            SQLUSMALLINT columnIndex = 0;
+            EnumerateRecordMembers(res, [this, &columnIndex]<size_t I, typename FieldType>(FieldType& value) {
+                if constexpr (RecordColumnMember<FieldType>)
+                {
+                    ++columnIndex;
+                    if constexpr (FieldWithStorage<FieldType>)
+                        value = _cursor->GetColumn<typename FieldType::ValueType>(columnIndex);
+                    else
+                        value = _cursor->GetColumn<FieldType>(columnIndex);
+                }
             });
 
             return res;
@@ -1067,8 +1079,12 @@ void SqlStatement::BindOutputColumnsToRecord(Records*... records)
         SQLUSMALLINT i = 0;
         ((EnumerateRecordMembers(*records,
                                  [this, &i]<size_t I, typename FieldType>(FieldType& value) {
-                                     ++i;
-                                     this->RecordPrefetchOutputColumn<FieldType>(i, &value);
+                                     // Only members mapping onto a column occupy a result set index.
+                                     if constexpr (RecordColumnMember<FieldType>)
+                                     {
+                                         ++i;
+                                         this->RecordPrefetchOutputColumn<FieldType>(i, &value);
+                                     }
                                  })),
          ...);
         return;
@@ -1079,9 +1095,13 @@ void SqlStatement::BindOutputColumnsToRecord(Records*... records)
     SQLUSMALLINT i = 0;
     ((EnumerateRecordMembers(*records,
                              [this, &i]<size_t I, typename FieldType>(FieldType& value) {
-                                 ++i;
-                                 RequireSuccess(SqlDataBinder<FieldType>::OutputColumn(
-                                     m_hStmt, i, &value, GetIndicatorForColumn(i), *this));
+                                 // Only members mapping onto a column occupy a result set index.
+                                 if constexpr (RecordColumnMember<FieldType>)
+                                 {
+                                     ++i;
+                                     RequireSuccess(SqlDataBinder<FieldType>::OutputColumn(
+                                         m_hStmt, i, &value, GetIndicatorForColumn(i), *this));
+                                 }
                              })),
      ...);
 }

--- a/src/Lightweight/Utils.hpp
+++ b/src/Lightweight/Utils.hpp
@@ -2,6 +2,14 @@
 
 #pragma once
 
+// <sql.h> below is not self-contained on Windows: the SDK's <sqltypes.h> resolves SQLLEN/SQLULEN/
+// SQLHWND/GUID against the Windows prelude, so <Windows.h> has to come first. Every other header
+// here that reaches an ODBC header opens with the same block; without it this header would only
+// compile when some other header happened to establish the prelude earlier in the translation unit.
+#if defined(_WIN32) || defined(_WIN64)
+    #include <Windows.h>
+#endif
+
 #include "Api.hpp"
 #include "Description.hpp"
 

--- a/src/tests/DataMapper/RelationTests.cpp
+++ b/src/tests/DataMapper/RelationTests.cpp
@@ -823,4 +823,198 @@ TEST_CASE("HasOneThrough: operator* returns the loaded record by reference", "[H
     CHECK(deref.credit_rating.Value() == 42);
 }
 
+// ================================================================================================
+// Regression tests for issue #517: members without storage (HasMany and friends) must be skipped
+// by *every* column-enumerating code path. DataMapper::Update() used to fail to compile on such a
+// record, and the fluent DataMapper::Query<T>() projected the relation member into the SELECT
+// list, which the database rejected with "no such column".
+// ================================================================================================
+
+/// Records the SQL statements a test triggers, so a query can be asserted on its emitted text.
+class ScopedQueryRecordingLogger final: public SqlLogger::Null
+{
+  public:
+    ScopedQueryRecordingLogger()
+    {
+        SqlLogger::SetLogger(*this);
+    }
+
+    ScopedQueryRecordingLogger(ScopedQueryRecordingLogger const&) = delete;
+    ScopedQueryRecordingLogger(ScopedQueryRecordingLogger&&) = delete;
+    ScopedQueryRecordingLogger& operator=(ScopedQueryRecordingLogger const&) = delete;
+    ScopedQueryRecordingLogger& operator=(ScopedQueryRecordingLogger&&) = delete;
+
+    ~ScopedQueryRecordingLogger() override
+    {
+        SqlLogger::SetLogger(_previousLogger);
+    }
+
+    void OnPrepare(std::string_view const& query) override
+    {
+        _queries.emplace_back(query);
+    }
+
+    void OnExecuteDirect(std::string_view const& query) override
+    {
+        _queries.emplace_back(query);
+    }
+
+    /// The SQL statements recorded so far.
+    [[nodiscard]] std::vector<std::string> const& Queries() const noexcept
+    {
+        return _queries;
+    }
+
+    /// Tests whether any recorded query contains @p needle.
+    [[nodiscard]] bool AnyQueryContains(std::string_view needle) const
+    {
+        return std::ranges::any_of(_queries, [needle](std::string const& query) { return query.contains(needle); });
+    }
+
+  private:
+    std::vector<std::string> _queries;
+    SqlLogger& _previousLogger = SqlLogger::GetLogger();
+};
+
+struct Issue517Child;
+
+struct Issue517Parent
+{
+    static constexpr std::string_view TableName = "Issue517Parent";
+
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement, SqlRealName { "id" }> id {};
+    Field<SqlAnsiString<32>, SqlRealName { "name" }> name {};
+    HasMany<Issue517Child> children {};
+};
+
+struct Issue517Child
+{
+    static constexpr std::string_view TableName = "Issue517Child";
+
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement, SqlRealName { "id" }> id {};
+    Field<int, SqlRealName { "n" }> n {};
+    BelongsTo<Member(Issue517Parent::id), SqlRealName { "parent_id" }> parent {};
+};
+
+static_assert(RecordStorageFieldCount<Issue517Parent> == 2);
+static_assert(RecordMemberCount<Issue517Parent> == 3);
+
+TEST_CASE_METHOD(SqlTestFixture, "Record with HasMany: Update", "[DataMapper][relations][HasMany][regression]")
+{
+    auto dm = DataMapper();
+    dm.CreateTables<Issue517Parent, Issue517Child>();
+
+    auto parent = Issue517Parent { .name = SqlAnsiString<32> { "acme" } };
+    dm.Create(parent);
+
+    dm.CreateExplicit(Issue517Child { .n = 1, .parent = parent.id.Value() });
+
+    auto loaded = dm.QuerySingle<Issue517Parent>(parent.id.Value()).value();
+    REQUIRE(loaded.name.Value() == "acme");
+
+    loaded.name = SqlAnsiString<32> { "beta" };
+
+    auto const recordedQueries = [&] {
+        auto logger = ScopedQueryRecordingLogger {};
+        dm.Update(loaded); // Used to not even compile (issue #517).
+        return logger.Queries();
+    }();
+
+    // The relation member must not appear in the UPDATE statement.
+    CHECK(std::ranges::none_of(
+        recordedQueries, [](std::string const& query) { return query.contains("UPDATE") && query.contains("children"); }));
+
+    auto const reloaded = dm.QuerySingle<Issue517Parent>(parent.id.Value()).value();
+    CHECK(reloaded.id.Value() == parent.id.Value());
+    CHECK(reloaded.name.Value() == "beta");
+    CHECK(reloaded.children.Count() == 1);
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "Record with HasMany: fluent Query", "[DataMapper][relations][HasMany][regression]")
+{
+    auto dm = DataMapper();
+    dm.CreateTables<Issue517Parent, Issue517Child>();
+
+    auto parent = Issue517Parent { .name = SqlAnsiString<32> { "acme" } };
+    dm.Create(parent);
+    dm.CreateExplicit(Issue517Parent { .name = SqlAnsiString<32> { "globex" } });
+
+    SECTION("All")
+    {
+        auto logger = ScopedQueryRecordingLogger {};
+
+        auto const records = dm.Query<Issue517Parent>().All(); // Used to throw "no such column".
+
+        CHECK_FALSE(logger.AnyQueryContains("children"));
+        REQUIRE(records.size() == 2);
+        CHECK(records[0].name.Value() == "acme");
+        CHECK(records[1].name.Value() == "globex");
+    }
+
+    SECTION("First and Count")
+    {
+        auto const first = dm.Query<Issue517Parent>().Where(FieldNameOf<Member(Issue517Parent::name)>, "=", "acme").First();
+        REQUIRE(first.has_value());
+        CHECK(first->id.Value() == parent.id.Value());
+        CHECK(dm.Query<Issue517Parent>().Count() == 2);
+    }
+
+    SECTION("Query builder Fields<>() skips the relation member")
+    {
+        auto const sql =
+            dm.Connection().Query(RecordTableName<Issue517Parent>).Select().Fields<Issue517Parent>().All().ToSql();
+        CHECK_FALSE(sql.contains("children"));
+        CHECK(sql.contains("\"name\""));
+    }
+}
+
+// Same as above, but with the relation member in the *middle* of the record, so that skipping it
+// must not shift the column indices of the members following it. The dynamic string field forces
+// the GetAllColumns() code path on MS SQL Server (bound columns may need to grow there).
+struct Issue517MidChild;
+
+struct Issue517MidParent
+{
+    static constexpr std::string_view TableName = "Issue517MidParent";
+
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id {};
+    HasMany<Issue517MidChild> children {};
+    Field<std::string> name {};
+    Field<int> counter {};
+};
+
+struct Issue517MidChild
+{
+    static constexpr std::string_view TableName = "Issue517MidChild";
+
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id {};
+    BelongsTo<Member(Issue517MidParent::id)> parent {};
+};
+
+TEST_CASE_METHOD(SqlTestFixture,
+                 "Record with HasMany in the middle: Update and fluent Query",
+                 "[DataMapper][relations][HasMany][regression]")
+{
+    auto dm = DataMapper();
+    dm.CreateTables<Issue517MidParent, Issue517MidChild>();
+
+    auto parent = Issue517MidParent { .name = "acme", .counter = 1 };
+    dm.Create(parent);
+    dm.CreateExplicit(Issue517MidChild { .parent = parent.id.Value() });
+
+    auto loaded = dm.QuerySingle<Issue517MidParent>(parent.id.Value()).value();
+    CHECK(loaded.name.Value() == "acme");
+    CHECK(loaded.counter.Value() == 1);
+
+    loaded.counter = 2;
+    dm.Update(loaded);
+
+    auto const records = dm.Query<Issue517MidParent>().All();
+    REQUIRE(records.size() == 1);
+    CHECK(records[0].id.Value() == parent.id.Value());
+    CHECK(records[0].name.Value() == "acme");
+    CHECK(records[0].counter.Value() == 2);
+    CHECK(records[0].children.Count() == 1);
+}
+
 // NOLINTEND(bugprone-unchecked-optional-access)

--- a/src/tests/DataMapper/RelationTests.cpp
+++ b/src/tests/DataMapper/RelationTests.cpp
@@ -943,7 +943,9 @@ TEST_CASE_METHOD(SqlTestFixture, "Record with HasMany: fluent Query", "[DataMapp
     {
         auto logger = ScopedQueryRecordingLogger {};
 
-        auto const records = dm.Query<Issue517Parent>().All(); // Used to throw "no such column".
+        // Used to throw "no such column". ORDER BY, because a bare All() leaves the row order
+        // unspecified and the ordering is incidental to what this checks.
+        auto const records = dm.Query<Issue517Parent>().OrderBy(FieldNameOf<Member(Issue517Parent::id)>).All();
 
         CHECK_FALSE(logger.AnyQueryContains("children"));
         REQUIRE(records.size() == 2);
@@ -1015,6 +1017,91 @@ TEST_CASE_METHOD(SqlTestFixture,
     CHECK(records[0].name.Value() == "acme");
     CHECK(records[0].counter.Value() == 2);
     CHECK(records[0].children.Count() == 1);
+}
+
+TEST_CASE_METHOD(SqlTestFixture,
+                 "Record with HasMany in the middle: SqlRowIterator",
+                 "[DataMapper][relations][HasMany][SqlRowIterator][regression]")
+{
+    auto dm = DataMapper();
+    dm.CreateTables<Issue517MidParent, Issue517MidChild>();
+
+    dm.CreateExplicit(Issue517MidParent { .name = "acme", .counter = 7 });
+
+    // SqlRowIterator::begin() projects via Select().Fields<T>(), so operator*() must read by column
+    // position too. Reading by member position used to not even compile here (HasMany has no
+    // ValueType) and would otherwise have read `counter` out of the `name` column.
+    auto rows = std::vector<Issue517MidParent> {};
+    for (auto&& row: SqlRowIterator<Issue517MidParent>(dm.Connection()))
+        rows.emplace_back(row);
+
+    REQUIRE(rows.size() == 1);
+    CHECK(rows[0].name.Value() == "acme");
+    CHECK(rows[0].counter.Value() == 7);
+}
+
+// A two-record JOIN projection where the *first* record carries a relation member. Fields<A, B>()
+// emits one column per column-mapping member, so the second record starts after A's *columns*; an
+// offset computed from RecordMemberCount would place B one column too far to the right and make every
+// one of its fields read the neighbouring column (or run off the end of the result set — observed as
+// `07009 Invalid Descriptor Index` on MS SQL Server).
+struct Issue517JoinChild;
+
+struct Issue517JoinParent
+{
+    static constexpr std::string_view TableName = "Issue517JoinParent";
+
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id {};
+    HasMany<Issue517JoinChild> children {};
+    Field<SqlAnsiString<32>> name {};
+};
+
+struct Issue517JoinChild
+{
+    static constexpr std::string_view TableName = "Issue517JoinChild";
+
+    Field<uint64_t, PrimaryKey::ServerSideAutoIncrement> id {};
+    BelongsTo<Member(Issue517JoinParent::id)> parent {};
+    Field<SqlAnsiString<32>> title {};
+};
+
+// The projection is 2 (parent) + 3 (child) = 5 columns wide, not 3 + 3.
+static_assert(RecordMemberCount<Issue517JoinParent> == 3);
+static_assert(RecordColumnCount<Issue517JoinParent> == 2);
+static_assert(RecordColumnCount<Issue517JoinChild> == 3);
+
+TEST_CASE_METHOD(SqlTestFixture,
+                 "Record with HasMany: two-record JOIN projection offset",
+                 "[DataMapper][relations][HasMany][regression]")
+{
+    auto dm = DataMapper();
+    dm.CreateTables<Issue517JoinParent, Issue517JoinChild>();
+
+    auto parent = Issue517JoinParent { .name = SqlAnsiString<32> { "acme" } };
+    dm.Create(parent);
+    dm.CreateExplicit(Issue517JoinChild { .parent = parent.id.Value(), .title = SqlAnsiString<32> { "widget" } });
+
+    auto const query = dm.FromTable(RecordTableName<Issue517JoinParent>)
+                           .Select()
+                           .Fields<Issue517JoinParent, Issue517JoinChild>()
+                           .InnerJoin<Member(Issue517JoinChild::parent), Member(Issue517JoinParent::id)>()
+                           .OrderBy(SqlQualifiedTableColumnName {
+                               .tableName = RecordTableName<Issue517JoinChild>,
+                               .columnName = FieldNameOf<Member(Issue517JoinChild::id)>,
+                           })
+                           .All();
+
+    CHECK_FALSE(query.ToSql().contains("children"));
+
+    // Used to read the second record starting one column too far right (relation member counted).
+    auto const records = dm.Query<Issue517JoinParent, Issue517JoinChild>(query);
+
+    REQUIRE(records.size() == 1);
+    auto const& [loadedParent, loadedChild] = records[0];
+    CHECK(loadedParent.id.Value() == parent.id.Value());
+    CHECK(loadedParent.name.Value() == "acme");
+    CHECK(loadedChild.parent.Value() == parent.id.Value());
+    CHECK(loadedChild.title.Value() == "widget");
 }
 
 // NOLINTEND(bugprone-unchecked-optional-access)


### PR DESCRIPTION
## Root cause

`HasMany` (and every other member without a column of its own) breaks the code paths that
enumerate record members and treat *each* member as a storage column. The C++26-reflection
branches guard each member with `if constexpr (FieldWithStorage<FieldType>)`; several
non-reflection branches (and, as it turns out, two reflection branches) did not:

* **`DataMapper::Update(record)`** — failed to **compile**:
  `'const class Lightweight::HasMany<Child>' has no member named 'IsModified'`.
* **fluent `DataMapper::Query<T>()`** — failed at **runtime** with
  `no such column: parents.children`, because `BuildFullyQualifiedFieldList` put every member
  into the SELECT list.

Auditing the remaining enumeration sites found more instances of the same defect. This PR fixes
the sites listed below; see **Scope** at the end for what is deliberately *not* covered.

## Commit 1 — guard the projection / update sites

| # | Location | Symptom before |
|---|----------|----------------|
| 1 | `DataMapper::Update` — non-reflection SET-clause build loop (`DataMapper.hpp`) | compile error on `field.IsModified()` |
| 2 | `DataMapper::Update` — non-reflection SET-clause input-binding loop | compile error on `field.IsModified()` / `field.Value()` |
| 3 | `DataMapper::BuildFullyQualifiedFieldList` (shared by `Query<T>()` and `QueryAsync<T>()`) | `no such column: <table>.<relation>` |
| 4 | `SqlSelectQueryBuilder::Fields<Records...>()` (`SqlQuery/Select.hpp`) | same `no such column`, via the query DSL and via `SqlStatement`'s record iterator (`Select().Fields<T>()`) |
| 5 | `detail::GetAllColumns()` (`DataMapper.hpp`) | the result-set index was advanced for members that were then skipped, so a relation member placed *before* other fields shifted every following column by one — observed on MS SQL Server as `07009 (0) Invalid Descriptor Index` |
| 6 | reflection branches of `Update` (SET/WHERE binding) and of `Delete` | `record.[:el:].IsModified()` / `FieldType::IsPrimaryKey` do not compile for a relation member either; the reflection CI job builds & runs `LightweightTest`, so the new tests would have broken it |

### `RecordColumnMember`

Projections may legitimately contain plain, non-`Field<>` members — `dm.Query<SimpleStruct2>()`
over `struct SimpleStruct2 { std::u8string name; int age; }` and
`Select().Fields<Simple1, Simple2>()` are covered by the existing suite. Gating the projection
sites on `FieldWithStorage` alone therefore emitted `SELECT  FROM "T"` for such records (caught
by the test suite while developing this PR). The projection sites now gate on a new concept in
`DataMapper/Record.hpp`:

```cpp
template <typename T>
concept RecordColumnMember = FieldWithStorage<T> || SqlOutputColumnBinder<T>;
```

which is exactly the set of members the output-column binder consumes. `Update`, which needs
`IsModified()`/`Value()`, keeps `FieldWithStorage` — matching its reflection branch. The concept
is exported from `Lightweight.cppm` alongside `FieldWithStorage`.

## Commit 2 — Windows build fix

The first push turned both Windows jobs red while compiling `SqlQuery/Select.cpp`:

```
sqltypes.h(64,25):  error C2146: syntax error: missing ';' before identifier 'SQLLEN'
sqltypes.h(151,33): error C2146: syntax error: missing ';' before identifier 'SQLHWND'
sqltypes.h(289,11): error C3646: 'Data1': unknown override specifier
```

Root cause is *not* that the query DSL newly sees ODBC — it always did: on `master`,
`SqlQuery/Select.cpp` already reaches `sql.h`, `sqltypes.h`, `sqlext.h` and `sqlucode.h` through
`SqlQueryFormatter.hpp` → `SqlConnection.hpp` (verified with `clang++ -E -H`). What changed is
*which header gets there first*. `Utils.hpp` includes `<sql.h>` without first including
`<Windows.h>`, and on MSVC the SDK's `<sqltypes.h>` resolves `SQLLEN`/`SQLULEN`/`SQLHWND`/`GUID`
against the Windows prelude. Six other headers here (`SqlError.hpp`, `SqlConnection.hpp`,
`DataBinder/Core.hpp`, `SqlColumnTypeDefinitions.hpp`, `SqlStatement.hpp`, `SqlTransaction.hpp`)
open with exactly that guarded `#include <Windows.h>` block, so `Utils.hpp` only ever compiled
because one of them happened to be reached earlier in the TU. The new include re-sorted the graph
to `Select.cpp -> Select.hpp -> Record.hpp -> Utils.hpp -> <sql.h>`, and `Select.cpp` became the
first TU to arrive without a prelude.

Fixed at the source: `Utils.hpp` and `SqlOdbcWide.hpp` now open with the same guarded prelude, so
they are self-contained (as `AGENT.md` requires) and no include ordering can resurrect this. No
shared prelude header is introduced — this is the convention already used in-tree.

Mechanical verification (walk the include graph of every source in `src/` in include order and
report any that reaches an ODBC header with no `<Windows.h>` before it):

| | files checked | reach ODBC headers | reach them with no prelude |
|---|---|---|---|
| before this commit | 299 | 199 | **6** — `Utils.hpp`, `SqlOdbcWide.hpp`, `DataMapper/Record.hpp`, `DataMapper/HasManyThrough.hpp`, `SqlQuery/Select.hpp`, `SqlQuery/Select.cpp` |
| after | 299 | 199 | **0** |

(Four of those six were already broken as standalone headers on `master`; they simply never had a
TU that reached them first.) The added block is inert off Windows, and it introduces no new macro
pollution: any Windows TU that reaches `<sql.h>` already had to have `<Windows.h>` in it to compile
at all. There is no `winsock` usage in the tree, so pulling `<Windows.h>` earlier is order-safe.

## Commit 3 — count columns, not members, when offsetting into a result set

Code review of the first commit found the same defect class on the *read* side: the projection now
emits one entry per `RecordColumnMember`, but every multi-record read still computed its starting
index from `RecordMemberCount`. `BindOutputColumns` and `GetAllColumns` skip non-columns
*internally*, so only the starting offset was wrong — by exactly the number of relation members in
the preceding sub-records.

New `RecordColumnCount<Record>` (a fold over `RecordColumnMember`, next to the existing
`RecordStorageFieldCount`) replaces `RecordMemberCount` at the three offset computations:

| # | Location | Symptom before |
|---|----------|----------------|
| 7 | `DataMapper::Query<First, Second, Rest...>(ComposedQuery)` — `calculateOffset` | with `Fields<A, B>()` and a relation member in `A`, `B` was read one column too far right: silent column shift on SQLite/PostgreSQL, `07009 Invalid Descriptor Index` on MS SQL Server |
| 8 | `SqlAllFieldsQueryBuilder<std::tuple<A, B>>::ReadResults` — `BindAllOutputColumnsWithOffset(..., 1 + RecordMemberCount<A>)` | the fallback disagreed with the `ReadAllRowWiseTuple` fast path (which `tuple_cat`s empty tuples for non-columns and was already correct), so the same query gave different results depending on `SupportsNativeRowArrayFetch` |
| 9 | the two-record tuple `detail::GetAllColumns` overload | additionally indexed the *first* record by member position. It now delegates to the single-record overload twice, removing the duplicated (and by now divergent) per-member reader |

Brought into line with the same predicate:

| # | Location | Symptom before |
|---|----------|----------------|
| 10 | `SqlRowIterator<T>::iterator::operator*` | enumerated unguarded and indexed by member position, while its `begin()` projects through the now-fixed `Select().Fields<T>()`. Hard compile error for a relation-bearing record. `SqlStatement::BindOutputColumnsToRecord` had the same shape and is guarded too |
| 11 | both `DataMapper::QuerySingle` overloads | projected with `FieldWithStorage` while the read side accepts any bindable member, so `QuerySingle<Rec>` on `struct Rec { Field<uint64_t, PK> id; std::string note; }` selected one column and read two. Both now use `RecordColumnMember`, so the codebase gives one answer to "is this member a column" |

### `RecordColumnMember` vs. the reader's predicate

`detail::GetAllColumns` advances its index on `IsField || SqlGetColumnNativeType`, which was
*assumed* equal to `RecordColumnMember` (`FieldWithStorage || SqlOutputColumnBinder`) but is not:
`SqlDataBinder<SqlVariant>` declares `GetColumn` but no `OutputColumn`, so a plain `SqlVariant`
member is readable but not projectable — dropped from the SELECT while the reader still advances
for it, shifting every following column.

No in-tree record does this and the bound path was already broken for such records, so it is
unreachable today. Rather than leave the fix resting on an unenforced invariant, `GetAllColumns`
now carries a `static_assert` tying the two predicates together per member. Chosen over silently
gating the reader on `RecordColumnMember`, because a one-sided binder is a bug in the binder:
failing to compile with a message that names the missing function is more useful than quietly
leaving the member default-constructed. It costs nothing at runtime and holds for every record in
the tree (the whole suite builds clean).

## Tests

Regression tests in `src/tests/DataMapper/RelationTests.cpp`, built on the issue's reproducer and
the existing `SqlTestFixture` (connection comes from `--test-env`):

* **`Record with HasMany: Update`** — `Update()` on a `HasMany`-bearing record compiles, writes
  only the storage columns (asserted via a scoped SQL-recording logger: no `UPDATE` statement
  mentions the relation member), and the change round-trips through the database.
* **`Record with HasMany: fluent Query`** — `Query<Parent>().All()` returns the rows,
  `Where(...).First()` and `Count()` work, no emitted statement mentions the relation member, and
  `Select().Fields<Parent>().All().ToSql()` contains the columns but not the relation. Ordered by
  `id`, since a bare `All()` leaves the row order unspecified.
* **`Record with HasMany in the middle: Update and fluent Query`** — same record shape with the
  relation member *between* two field members plus a dynamic string field. This test reproduced
  finding #5 (it failed with `Invalid Descriptor Index` before that fix). Note that its coverage of
  the `GetAllColumns` index-advance path is **DBMS-conditional**: `CanSafelyBindOutputColumns`
  short-circuits to `true` for everything except MS SQL Server, so only the `mssql*` CI legs
  exercise that path; the other legs take the bound-column path.
* **`Record with HasMany in the middle: SqlRowIterator`** — compile-and-read guard for finding #10.
* **`Record with HasMany: two-record JOIN projection offset`** — the `Fields<A, B>()` +
  `Query<A, B>()` shape with a relation member in the first record. Verified to fail without the
  `calculateOffset` fix (`loadedChild.parent` and `loadedChild.title` read the neighbouring columns
  on SQLite).

Plus `static_assert`s pinning `RecordMemberCount` against `RecordColumnCount` for the fixture
records.

## Databases tested

Full suite, `clang-debug` preset (clang-tidy + ASan/UBSan, `-Werror`), all green:

```
./out/build/clang-debug/src/tests/LightweightTest --test-env=sqlite3
  test cases: 1246 | 1245 passed | 1 skipped   assertions: 12744 | all passed
./out/build/clang-debug/src/tests/LightweightTest --test-env=mssql2022
  test cases: 1246 | 1243 passed | 3 skipped   assertions: 12699 | all passed
./out/build/clang-debug/src/tests/LightweightTest --test-env=postgres
  test cases: 1246 | 1244 passed | 2 skipped   assertions: 12664 | all passed
```

Second compiler leg, `gcc-release` preset (GCC, `-O3`, no sanitizers), also green:

```
./out/build/gcc-release/src/tests/LightweightTest --test-env=sqlite3    1245 passed | 1 skipped
./out/build/gcc-release/src/tests/LightweightTest --test-env=postgres   1244 passed | 2 skipped
```

The skips are the pre-existing per-DBMS `SKIP()` / `UNSUPPORTED_DATABASE()` cases in
`DataBinderTests.cpp`, `QueryBuilderTests.cpp` and `MigrationTests.cpp`.
`python3 src/tests/test_dbtool.py` passes for `sqlite3`, `mssql2022` and `postgres`.

Versions: SQLite3 (unixODBC), MS SQL Server 2022 (Docker, ODBC Driver 18), PostgreSQL 16.4
(Docker, psqlODBC Unicode).

**Not run locally:** the C++26-reflection configuration (`LIGHTWEIGHT_CXX26_REFLECTION=ON`), which
needs the `clang-p2996` toolchain image; no such toolchain is available in this environment. The
reflection-branch changes (#6) only *add* `if constexpr (FieldWithStorage<...>)` guards around
existing bodies, mirroring the guard patterns already used in neighbouring reflection branches, and
the `cpp26-reflection` CI job compiles and runs `LightweightTest` for that configuration.

## Risk assessment

* **Behaviour change:** members that are neither a field with storage nor directly output-bindable
  are no longer projected/bound/updated. For record types without relation members nothing changes —
  `FieldWithStorage`/`SqlOutputColumnBinder` hold for all of them, which is why the whole existing
  suite is unaffected on all three DBMS.
* **Offset change:** `RecordColumnCount == RecordMemberCount` for every relation-free record, so the
  three offset computations are identical for existing code; they only change the broken case.
* **`QuerySingle` projection widening:** records made only of `Field<>`/`BelongsTo` members are
  unaffected (`RecordColumnMember` is a superset of `FieldWithStorage`). Records with plain bindable
  members now emit those columns where they previously did not — matching what the read side already
  consumed.
* **New `static_assert`:** turns a record with a one-sided binder member (e.g. a bare `SqlVariant`)
  from a silent column shift into a compile error. No such record exists in the tree.
* **Diagnostics:** `Update()` on a record made *only* of plain, non-`Field<>` members previously
  failed to compile and now builds an UPDATE without a SET clause. That combination was never
  supported (and the reflection branch has always behaved this way).
* **Includes:** `SqlQuery/Select.hpp` and `SqlStatement.hpp` now include `DataMapper/Record.hpp`,
  following the precedent of `SqlQuery/Migrate.hpp`; no include cycle (`Record.hpp` pulls in only
  `Utils`/`Field`).
* **Windows prelude:** moving `<Windows.h>` earlier in TUs that already contained it is behaviour-
  preserving; `-DNOMINMAX` is already set project-wide for MSVC and no `winsock` header is used
  anywhere in the tree.
* **ABI/ODBC:** header-only, template-level changes; no ABI or ODBC-version surface touched.
* **Performance:** none — the added guards are `if constexpr`, resolved at compile time, and they
  *shrink* the generated SQL for relation-bearing records.

## Scope

This covers the DataMapper projection and read paths, the query-builder `Fields<>()` projection and
the record iterator — the paths reachable from a record type that carries a relation member. It is
**not** an exhaustive audit of every member-enumerating template in the tree: sites outside those
paths (other `Reflection::CallOnMembers` consumers such as `Inspect`, and `SqlBackup` / `ddl2cpp`)
were not reviewed for this defect class and may still assume that every member is a column.

Fixes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)
