### PR TITLE
tests: make DropTableRecursively cycle- and diamond-safe

### DIFF
--- a/src/tests/SqlBackup/AllColumnTypesTests.cpp
+++ b/src/tests/SqlBackup/AllColumnTypesTests.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include "../Utils.hpp"
 #include "TestHelpers.hpp"
 
 #include <Lightweight/SqlBackup.hpp>
@@ -37,7 +38,7 @@ SqlConnectionString const& GetConnectionString()
 // The existing SqlBackup tests cover Integer + Varchar + Binary + NVarchar, but never a
 // Tinyint, Smallint, Bigint, Real, Bool, Char, NChar, Text in the same metadata pass, so
 // those serializer branches stay cold in coverage. This single test fixes that.
-TEST_CASE("SqlBackup: round-trip every supported column type", "[SqlBackup][AllTypes]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: round-trip every supported column type", "[SqlBackup][AllTypes]")
 {
     using namespace SqlColumnTypeDefinitions;
 

--- a/src/tests/SqlBackup/MultiPkTests.cpp
+++ b/src/tests/SqlBackup/MultiPkTests.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include "../Utils.hpp"
+
 #include <Lightweight/SqlBackup.hpp>
 #include <Lightweight/SqlConnectInfo.hpp>
 #include <Lightweight/SqlConnection.hpp>
@@ -58,7 +60,7 @@ struct SilentProgressManager: SqlBackup::ProgressManager
 
 } // namespace
 
-TEST_CASE("SqlBackup: Composite Primary Key Order", "[SqlBackup][MultiPk]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Composite Primary Key Order", "[SqlBackup][MultiPk]")
 {
     ScopedFileRemoved const backupFileCleaner { BackupFile };
 

--- a/src/tests/SqlBackup/ProductionReadinessTests.cpp
+++ b/src/tests/SqlBackup/ProductionReadinessTests.cpp
@@ -140,7 +140,7 @@ TEST_CASE("SqlBackup: Error counting in ProgressManager", "[SqlBackup][Productio
     REQUIRE(pm.ErrorCount() == 2);
 }
 
-TEST_CASE("SqlBackup: Format version in metadata", "[SqlBackup][ProductionReadiness]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Format version in metadata", "[SqlBackup][ProductionReadiness]")
 {
     ScopedFileRemoved const backupFileCleaner { BackupFile };
     SetupTestTable();
@@ -174,7 +174,7 @@ TEST_CASE("SqlBackup: Format version in metadata", "[SqlBackup][ProductionReadin
     REQUIRE(metadata["format_version"] == "1.0");
 }
 
-TEST_CASE("SqlBackup: Checksums in backup", "[SqlBackup][ProductionReadiness]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Checksums in backup", "[SqlBackup][ProductionReadiness]")
 {
     ScopedFileRemoved const backupFileCleaner { BackupFile };
     SetupTestTable();
@@ -213,7 +213,7 @@ TEST_CASE("SqlBackup: Checksums in backup", "[SqlBackup][ProductionReadiness]")
     REQUIRE(!checksums["files"].empty());
 }
 
-TEST_CASE("SqlBackup: Filter tables in restore", "[SqlBackup][ProductionReadiness]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Filter tables in restore", "[SqlBackup][ProductionReadiness]")
 {
     using namespace SqlColumnTypeDefinitions;
 

--- a/src/tests/SqlBackup/RobustnessTests.cpp
+++ b/src/tests/SqlBackup/RobustnessTests.cpp
@@ -72,7 +72,7 @@ struct ScopedFileRemoved
 
 } // namespace
 
-TEST_CASE("SqlBackup: Foreign Key Restoration", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Foreign Key Restoration", "[SqlBackup]")
 {
     using namespace SqlColumnTypeDefinitions;
 
@@ -165,7 +165,7 @@ TEST_CASE("SqlBackup: Foreign Key Restoration", "[SqlBackup]")
     }
 }
 
-TEST_CASE("SqlBackup: Robustness Types and Nulls", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Robustness Types and Nulls", "[SqlBackup]")
 {
     using namespace SqlColumnTypeDefinitions;
 
@@ -279,7 +279,7 @@ TEST_CASE("SqlBackup: Robustness Types and Nulls", "[SqlBackup]")
     }
 }
 
-TEST_CASE("SqlBackup: Constraints and Defaults", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Constraints and Defaults", "[SqlBackup]")
 {
     using namespace SqlColumnTypeDefinitions;
 

--- a/src/tests/SqlBackup/SqlBackupCompositeFKTests.cpp
+++ b/src/tests/SqlBackup/SqlBackupCompositeFKTests.cpp
@@ -75,7 +75,7 @@ struct LambdaProgressManager: SqlBackup::ProgressManager
 
 } // namespace
 
-TEST_CASE("SqlBackup: Composite Foreign Keys", "[SqlBackup][ForeignKeys]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Composite Foreign Keys", "[SqlBackup][ForeignKeys]")
 {
     auto const testDir = std::filesystem::current_path() / "test_output" / "CompositeFK";
     if (std::filesystem::exists(testDir))

--- a/src/tests/SqlBackup/SqlBackupIndexTests.cpp
+++ b/src/tests/SqlBackup/SqlBackupIndexTests.cpp
@@ -204,7 +204,7 @@ std::vector<IndexInfo> GetIndexes(SqlStatement& stmt,
 } // namespace
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-TEST_CASE("SqlBackup: Index Restoration", "[SqlBackup][Indexes]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Index Restoration", "[SqlBackup][Indexes]")
 {
     auto const testDir = std::filesystem::current_path() / "test_output" / "IndexRestore";
     if (std::filesystem::exists(testDir))

--- a/src/tests/SqlBackup/Tests.cpp
+++ b/src/tests/SqlBackup/Tests.cpp
@@ -91,7 +91,7 @@ void VerifyDatabase()
 
 } // namespace
 
-TEST_CASE("SqlBackup: Backup and Restore", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Backup and Restore", "[SqlBackup]")
 {
     ScopedFileRemoved const backupFileCleaner { BackupFile };
 
@@ -375,7 +375,7 @@ void VerifyComplexDatabase()
 
 } // namespace
 
-TEST_CASE("SqlBackup: Complex Types", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Complex Types", "[SqlBackup]")
 {
     auto const backupFileCleaner = ScopedFileRemoved { BackupFile };
     ScopedFileRemoved { BackupFile }.RemoveIfExists();
@@ -439,7 +439,7 @@ TEST_CASE("SqlBackup: Schema Parsing with Unknown Type", "[SqlBackup]")
     REQUIRE(std::holds_alternative<SqlColumnTypeDefinitions::Text>(schema.at("test_table").columns[1].type));
 }
 
-TEST_CASE("SqlBackup: Corner Cases", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Corner Cases", "[SqlBackup]")
 {
     using namespace SqlColumnTypeDefinitions;
 
@@ -509,7 +509,7 @@ TEST_CASE("SqlBackup: Corner Cases", "[SqlBackup]")
     REQUIRE(stmt.ExecuteDirectScalar<std::string>("SELECT txt FROM corner_cases WHERE id=4") == "");
 }
 
-TEST_CASE("SqlBackup: Concurrent Restore", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Concurrent Restore", "[SqlBackup]")
 {
     using namespace SqlColumnTypeDefinitions;
 
@@ -576,7 +576,7 @@ TEST_CASE("SqlBackup: Concurrent Restore", "[SqlBackup]")
     }
 }
 
-TEST_CASE("SqlBackup: MsgPack Backup and Restore", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: MsgPack Backup and Restore", "[SqlBackup]")
 {
     auto const backupFileCleaner = ScopedFileRemoved { BackupFile };
 
@@ -610,7 +610,7 @@ TEST_CASE("SqlBackup: MsgPack Backup and Restore", "[SqlBackup]")
     VerifyComplexDatabase();
 }
 
-TEST_CASE("SqlBackup: Table With Spaces", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Table With Spaces", "[SqlBackup]")
 {
     using namespace SqlColumnTypeDefinitions;
 
@@ -667,7 +667,7 @@ TEST_CASE("SqlBackup: Table With Spaces", "[SqlBackup]")
     }
 }
 
-TEST_CASE("SqlBackup: DateTime Columns", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: DateTime Columns", "[SqlBackup]")
 {
     // This test validates backup/restore of DateTime columns.
     // DateTime columns require special handling to avoid ODBC driver issues:
@@ -778,7 +778,7 @@ TEST_CASE("SqlBackup: DateTime Columns", "[SqlBackup]")
     }
 }
 
-TEST_CASE("SqlBackup: Date Columns", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Date Columns", "[SqlBackup]")
 {
     // This test validates backup/restore of Date columns.
     // Date columns require special handling to bind using SQL_TYPE_DATE.
@@ -875,7 +875,7 @@ TEST_CASE("SqlBackup: Date Columns", "[SqlBackup]")
     }
 }
 
-TEST_CASE("SqlBackup: Time Columns", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Time Columns", "[SqlBackup]")
 {
     // This test validates backup/restore of Time columns.
     // Time columns require special handling to bind using SQL_TYPE_TIME.
@@ -1049,7 +1049,7 @@ TEST_CASE("SqlBackup: Time Columns", "[SqlBackup]")
     }
 }
 
-TEST_CASE("SqlBackup: Decimal Precision", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Decimal Precision", "[SqlBackup]")
 {
     // This test validates that high-precision Decimal values are preserved during backup/restore.
     // Decimal columns are now read as strings (not doubles) during backup to preserve full precision.
@@ -1265,7 +1265,7 @@ TEST_CASE("SqlBackup: Compression Method Support", "[SqlBackup]")
     }
 }
 
-TEST_CASE("SqlBackup: Backup with Custom Compression", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Backup with Custom Compression", "[SqlBackup]")
 {
     using namespace SqlColumnTypeDefinitions;
 
@@ -1415,7 +1415,7 @@ TEST_CASE("SqlBackup: Backup with Table Filter", "[SqlBackup]")
 // Retry Settings Tests
 // =============================================================================
 
-TEST_CASE("SqlBackup: RetrySettings configuration", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: RetrySettings configuration", "[SqlBackup]")
 {
     // Test that RetrySettings can be configured and used
     SqlBackup::RetrySettings settings {
@@ -1662,7 +1662,7 @@ TEST_CASE("SqlBackup: ParseSchema with binary column markers", "[SqlBackup]")
 // Format Version Validation Tests
 // =============================================================================
 
-TEST_CASE("SqlBackup: Restore rejects unsupported format version", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Restore rejects unsupported format version", "[SqlBackup]")
 {
     // First create a valid backup
     ScopedFileRemoved const backupFileCleaner { BackupFile };
@@ -1770,7 +1770,7 @@ TEST_CASE("SqlBackup: Restore rejects unsupported format version", "[SqlBackup]"
 // Schema-only Backup / Restore Tests
 // =============================================================================
 
-TEST_CASE("SqlBackup: Schema-only Backup and Restore", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Schema-only Backup and Restore", "[SqlBackup]")
 {
     ScopedFileRemoved const backupFileCleaner { BackupFile };
 
@@ -1846,7 +1846,7 @@ TEST_CASE("SqlBackup: Schema-only Backup and Restore", "[SqlBackup]")
     REQUIRE(count == 0);
 }
 
-TEST_CASE("SqlBackup: Schema-only restore from full backup", "[SqlBackup]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlBackup: Schema-only restore from full backup", "[SqlBackup]")
 {
     ScopedFileRemoved const backupFileCleaner { BackupFile };
 

--- a/src/tests/SqlSchemaDbTests.cpp
+++ b/src/tests/SqlSchemaDbTests.cpp
@@ -306,3 +306,130 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlSchema::ReadAllTables reports composite key
     CHECK(index->columns[1] == "val_two");
     CHECK(index->isUnique);
 }
+
+// ================================================================================================
+// SqlTestFixture::DropTableRecursively — foreign-key graphs that are not trees
+// ================================================================================================
+
+namespace
+{
+
+SqlSchema::FullyQualifiedTableName TableNamed(std::string name)
+{
+    return SqlSchema::FullyQualifiedTableName { .catalog = {}, .schema = {}, .table = std::move(name) };
+}
+
+/// Builds `CREATE TABLE "<table>" ("id" INT NOT NULL PRIMARY KEY, "ref_<t>" INT REFERENCES "<t>"("id"), ...)`.
+/// Plain ANSI DDL, accepted verbatim by SQLite, SQL Server and PostgreSQL alike.
+///
+/// @param table            Name of the table to create.
+/// @param referencedTables Tables to declare an inline foreign key against, one column each.
+/// @return The CREATE TABLE statement.
+std::string CreateTableReferencingSql(std::string_view table, std::vector<std::string_view> const& referencedTables)
+{
+    auto sql = std::format(R"(CREATE TABLE "{}" ("id" INT NOT NULL PRIMARY KEY)", table);
+    for (auto const& referenced: referencedTables)
+        sql += std::format(R"(, "ref_{0}" INT REFERENCES "{0}"("id"))", referenced);
+    sql += ')';
+    return sql;
+}
+
+/// @return Whether @p table is currently present in the connection's default schema.
+bool TableExists(SqlStatement& stmt, std::string_view table)
+{
+    auto const tableNames = SqlTestFixture::GetAllTableNames(stmt);
+    return std::ranges::find(tableNames, table) != tableNames.end();
+}
+
+/// @return How often @p table appears in @p dropped.
+size_t CountDropped(std::vector<SqlSchema::FullyQualifiedTableName> const& dropped, std::string_view table)
+{
+    return static_cast<size_t>(std::ranges::count_if(dropped, [&](auto const& name) { return name.table == table; }));
+}
+
+/// @return The position of @p table within @p dropped; fails the test when it is absent.
+size_t DropIndexOf(std::vector<SqlSchema::FullyQualifiedTableName> const& dropped, std::string_view table)
+{
+    auto const it = std::ranges::find_if(dropped, [&](auto const& name) { return name.table == table; });
+    REQUIRE(it != dropped.end());
+    return static_cast<size_t>(std::ranges::distance(dropped.begin(), it));
+}
+
+} // namespace
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlTestFixture::DropTableRecursively: self-referencing foreign key", "[SqlSchema]")
+{
+    auto stmt = SqlStatement {};
+
+    // Chinook's Employee.ReportsTo in miniature: the table is its own dependant. Following that
+    // edge blindly recurses until the stack is exhausted.
+    (void) stmt.ExecuteDirect(CreateTableReferencingSql("SelfRef", { "SelfRef" }));
+
+    auto const dropped = SqlTestFixture::DropTableRecursively(stmt, TableNamed("SelfRef"));
+
+    CHECK(dropped.size() == 1);
+    CHECK(CountDropped(dropped, "SelfRef") == 1);
+    CHECK_FALSE(TableExists(stmt, "SelfRef"));
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlTestFixture::DropTableRecursively: two-table foreign-key cycle", "[SqlSchema]")
+{
+    auto stmt = SqlStatement {};
+
+    if (stmt.Connection().ServerType() == SqlServerType::SQLITE)
+    {
+        // SQLite resolves foreign-key targets lazily, so a forward reference is legal here — and
+        // it has to be, because SQLite has no ALTER TABLE ... ADD CONSTRAINT to fall back on.
+        (void) stmt.ExecuteDirect(CreateTableReferencingSql("CycleA", { "CycleB" }));
+        (void) stmt.ExecuteDirect(CreateTableReferencingSql("CycleB", { "CycleA" }));
+    }
+    else
+    {
+        (void) stmt.ExecuteDirect(R"(CREATE TABLE "CycleA" ("id" INT NOT NULL PRIMARY KEY, "ref_CycleB" INT))");
+        (void) stmt.ExecuteDirect(CreateTableReferencingSql("CycleB", { "CycleA" }));
+        (void) stmt.ExecuteDirect(R"(ALTER TABLE "CycleA" ADD CONSTRAINT "FK_CycleA_CycleB" )"
+                                  R"(FOREIGN KEY ("ref_CycleB") REFERENCES "CycleB"("id"))");
+    }
+
+    auto const dropped = SqlTestFixture::DropTableRecursively(stmt, TableNamed("CycleA"));
+
+    CHECK(dropped.size() == 2);
+    CHECK(CountDropped(dropped, "CycleA") == 1);
+    CHECK(CountDropped(dropped, "CycleB") == 1);
+    CHECK_FALSE(TableExists(stmt, "CycleA"));
+    CHECK_FALSE(TableExists(stmt, "CycleB"));
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlTestFixture::DropTableRecursively: diamond drops each table once", "[SqlSchema]")
+{
+    auto stmt = SqlStatement {};
+
+    // DiaRoot <- DiaLeft, DiaRight <- DiaLeaf: two independent paths reach DiaLeaf. On top of
+    // that DiaLeft references DiaRoot through *two* separate constraints, so DiaRoot's dependant
+    // list names DiaLeft twice — the shape that makes the redundant descent observable.
+    (void) stmt.ExecuteDirect(CreateTableReferencingSql("DiaRoot", {}));
+    (void) stmt.ExecuteDirect(R"(CREATE TABLE "DiaLeft" ("id" INT NOT NULL PRIMARY KEY, )"
+                              R"("ref_a" INT REFERENCES "DiaRoot"("id"), )"
+                              R"("ref_b" INT REFERENCES "DiaRoot"("id")))");
+    (void) stmt.ExecuteDirect(CreateTableReferencingSql("DiaRight", { "DiaRoot" }));
+    (void) stmt.ExecuteDirect(CreateTableReferencingSql("DiaLeaf", { "DiaLeft", "DiaRight" }));
+
+    auto const dropped = SqlTestFixture::DropTableRecursively(stmt, TableNamed("DiaRoot"));
+
+    // Four tables, four drops — DiaLeft and DiaLeaf are reached twice each but must be
+    // dropped only once.
+    CHECK(dropped.size() == 4);
+    CHECK(CountDropped(dropped, "DiaLeft") == 1);
+    CHECK(CountDropped(dropped, "DiaLeaf") == 1);
+
+    // Dependants are still dropped before what they depend on.
+    CHECK(DropIndexOf(dropped, "DiaLeaf") < DropIndexOf(dropped, "DiaLeft"));
+    CHECK(DropIndexOf(dropped, "DiaLeaf") < DropIndexOf(dropped, "DiaRight"));
+    CHECK(DropIndexOf(dropped, "DiaLeft") < DropIndexOf(dropped, "DiaRoot"));
+    CHECK(DropIndexOf(dropped, "DiaRight") < DropIndexOf(dropped, "DiaRoot"));
+
+    CHECK_FALSE(TableExists(stmt, "DiaRoot"));
+    CHECK_FALSE(TableExists(stmt, "DiaLeft"));
+    CHECK_FALSE(TableExists(stmt, "DiaRight"));
+    CHECK_FALSE(TableExists(stmt, "DiaLeaf"));
+}

--- a/src/tests/Utils.hpp
+++ b/src/tests/Utils.hpp
@@ -752,7 +752,17 @@ class SqlTestFixture
                                            "FROM sys.foreign_keys AS fk WHERE fk.referenced_object_id = OBJECT_ID('{}')",
                                            qualifiedName));
         while (cursor.FetchRow())
-            result.emplace_back(cursor.GetColumn<std::string>(1), cursor.GetColumn<std::string>(2));
+        {
+            // Retrieve strictly in ascending column order and in separate statements. GetColumn()
+            // maps onto SQLGetData, and the SQL Server ODBC driver does not support out-of-order
+            // retrieval — asking for column 2 before column 1 fails with
+            // "07009 Invalid Descriptor Index". Passing both calls as arguments to a single
+            // emplace_back() would leave their relative order unspecified, which really does differ
+            // between compilers (Clang evaluates left-to-right here, GCC right-to-left).
+            auto referencingTable = cursor.GetColumn<std::string>(1);
+            auto constraintName = cursor.GetColumn<std::string>(2);
+            result.emplace_back(std::move(referencingTable), std::move(constraintName));
+        }
         return result;
     }
 

--- a/src/tests/Utils.hpp
+++ b/src/tests/Utils.hpp
@@ -17,9 +17,11 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <format>
 #include <mutex>
+#include <optional>
 #include <ostream>
 #include <ranges>
 #include <set>
@@ -636,6 +638,13 @@ class SqlTestFixture
     /// visited set see two different tables and defeat the cycle detection, so both sides are
     /// normalized to the form the emitted @c DROP @c TABLE statement uses.
     ///
+    /// @note This makes the traversal blind to schemas: two same-named tables in different
+    ///       schemas (@c dbo.Foo and @c sales.Foo) collapse into one visited entry, so only
+    ///       whichever the connection's default schema resolves gets dropped and the other
+    ///       survives. The fixture is single-schema by construction — @ref GetAllTableNames
+    ///       queries only the default schema — so this cannot arise today, and the drop
+    ///       statement itself was already schema-blind before the visited set existed.
+    ///
     /// @param name The table name to normalize.
     /// @return @p name with catalog and schema cleared.
     static Lightweight::SqlSchema::FullyQualifiedTableName CanonicalTableName(
@@ -677,93 +686,108 @@ class SqlTestFixture
         state.dropped.emplace_back(canonicalTable);
     }
 
+    /// RAII switch that suspends SQLite's foreign-key enforcement for its lifetime.
+    ///
+    /// Mirrors the library-internal guard in @c SqlMigration.cpp, which lives in an anonymous
+    /// namespace inside that translation unit and is therefore not reachable from here. The
+    /// contract worth copying verbatim: read the previous value and restore *that* (a caller may
+    /// deliberately have enforcement off), release the read cursor before issuing the next
+    /// statement (reusing a statement with an open cursor is an invalid-cursor-state error on the
+    /// SQLite ODBC driver), and never let the destructor throw.
+    ///
+    /// On every other backend the constructor is a no-op, because they express cascading drops in
+    /// the DDL itself — see @ref DropTableBreakingCycles.
+    class SqliteForeignKeysGuard
+    {
+      public:
+        /// @param connection The connection whose foreign-key enforcement to suspend.
+        explicit SqliteForeignKeysGuard(Lightweight::SqlConnection& connection):
+            _connection { connection }
+        {
+            // Capability check rather than a server-type test: SQLite is the backend that rebuilds
+            // tables for schema changes, and the only one whose formatter ignores `cascade`.
+            if (!connection.RequiresTableRebuildForSchemaChange())
+                return;
+
+            auto enabled = false;
+            {
+                auto stmt = Lightweight::SqlStatement { connection };
+                auto cursor = stmt.ExecuteDirect("PRAGMA foreign_keys");
+                enabled = cursor.FetchRow() && cursor.GetColumn<int64_t>(1) != 0;
+            }
+            if (!enabled)
+                return; // Already off — leave it that way, and restore nothing.
+
+            auto stmt = Lightweight::SqlStatement { connection };
+            (void) stmt.ExecuteDirect("PRAGMA foreign_keys = OFF");
+            _restore = true;
+        }
+
+        ~SqliteForeignKeysGuard()
+        {
+            if (!_restore)
+                return;
+            try
+            {
+                auto stmt = Lightweight::SqlStatement { _connection };
+                (void) stmt.ExecuteDirect("PRAGMA foreign_keys = ON");
+            }
+            catch (...)
+            {
+                WarnRestoreFailed();
+            }
+        }
+
+        SqliteForeignKeysGuard(SqliteForeignKeysGuard const&) = delete;
+        SqliteForeignKeysGuard& operator=(SqliteForeignKeysGuard const&) = delete;
+        SqliteForeignKeysGuard(SqliteForeignKeysGuard&&) = delete;
+        SqliteForeignKeysGuard& operator=(SqliteForeignKeysGuard&&) = delete;
+
+      private:
+        /// Reports a failed restore.
+        ///
+        /// A destructor must not propagate, but silently leaving foreign-key enforcement disabled
+        /// would turn every later foreign-key assertion into a false pass — so the failure is
+        /// routed to the active logger instead of being dropped. Marked @c noexcept so the "must
+        /// not throw" requirement is enforced by the language rather than by a second empty
+        /// @c catch block.
+        static void WarnRestoreFailed() noexcept
+        {
+            Lightweight::SqlLogger::GetLogger().OnWarning(
+                "SqliteForeignKeysGuard: failed to restore PRAGMA foreign_keys = ON");
+        }
+
+        Lightweight::SqlConnection& _connection;
+        bool _restore = false;
+    };
+
     /// Executes the @c DROP @c TABLE for @p table.
+    ///
+    /// The dialect lives in @c SqlQueryFormatter::DropTable, which already knows how each backend
+    /// spells a cascading drop — PostgreSQL appends @c CASCADE, SQL Server emits dynamic SQL that
+    /// drops every incoming foreign key through @c sys.foreign_keys first. Only SQLite needs
+    /// anything here, because it has neither @c CASCADE nor @c DROP @c CONSTRAINT and its formatter
+    /// consequently ignores the flag; suspending foreign-key enforcement is the one remaining way
+    /// to drop a table that closes a cycle.
     ///
     /// @param stmt        Statement to execute the DDL on.
     /// @param table       The table to drop.
-    /// @param closesCycle When true, @p table is still referenced by a table that cannot be
-    ///                    dropped beforehand because it sits on the same foreign-key cycle. The
-    ///                    referencing constraints are then removed (or their enforcement
-    ///                    suspended) using whatever the backend offers:
-    ///                    PostgreSQL drops them along with the table via @c CASCADE, SQL Server
-    ///                    needs an explicit @c ALTER @c TABLE @c DROP @c CONSTRAINT per incoming
-    ///                    foreign key, and SQLite — which has no @c DROP @c CONSTRAINT at all —
-    ///                    only needs its per-connection @c PRAGMA @c foreign_keys switched off
-    ///                    for the duration of the drop.
+    /// @param closesCycle When true, @p table is still referenced by a table that cannot be dropped
+    ///                    beforehand because it sits on the same foreign-key cycle, so the
+    ///                    referencing constraints have to be broken as part of the drop.
     static void DropTableBreakingCycles(Lightweight::SqlStatement& stmt,
                                         Lightweight::SqlSchema::FullyQualifiedTableName const& table,
                                         bool closesCycle)
     {
-        using Lightweight::SqlServerType;
+        auto foreignKeysGuard = std::optional<SqliteForeignKeysGuard> {};
+        if (closesCycle)
+            foreignKeysGuard.emplace(stmt.Connection());
 
-        auto const dropStatement = std::format("DROP TABLE IF EXISTS \"{}\"", table.table);
-        switch (stmt.Connection().ServerType())
-        {
-            case SqlServerType::POSTGRESQL:
-                // CASCADE drops the *constraints* referencing this table (not the tables
-                // themselves), which is exactly what breaking a cycle needs.
-                (void) stmt.ExecuteDirect(dropStatement + " CASCADE");
-                return;
-            case SqlServerType::SQLITE:
-                if (!closesCycle)
-                    break;
-                // SQLite cannot drop a single constraint, but foreign key enforcement is a
-                // per-connection switch, and the implicit row removal of DROP TABLE is the only
-                // thing it would trip over here.
-                (void) stmt.ExecuteDirect("PRAGMA foreign_keys = OFF");
-                (void) stmt.ExecuteDirect(dropStatement);
-                (void) stmt.ExecuteDirect("PRAGMA foreign_keys = ON");
-                return;
-            case SqlServerType::MICROSOFT_SQL:
-                if (!closesCycle)
-                    break;
-                for (auto const& [referencingTable, constraintName]: MssqlIncomingForeignKeys(stmt, table))
-                    (void) stmt.ExecuteDirect(
-                        std::format("ALTER TABLE {} DROP CONSTRAINT {}", referencingTable, constraintName));
-                break;
-            case SqlServerType::MYSQL:
-                if (!closesCycle)
-                    break;
-                // MySQL/MariaDB refuse to drop a referenced parent table; the check is a
-                // session-level switch, mirroring the SQLite approach above.
-                (void) stmt.ExecuteDirect("SET FOREIGN_KEY_CHECKS = 0");
-                (void) stmt.ExecuteDirect(dropStatement);
-                (void) stmt.ExecuteDirect("SET FOREIGN_KEY_CHECKS = 1");
-                return;
-            case SqlServerType::UNKNOWN:
-                break;
-        }
-        (void) stmt.ExecuteDirect(dropStatement);
-    }
-
-    /// Looks up every foreign key pointing at @p table on SQL Server.
-    ///
-    /// @param stmt  Statement to query @c sys.foreign_keys through.
-    /// @param table The referenced (primary key side) table.
-    /// @return Pairs of (bracket-quoted referencing table, bracket-quoted constraint name).
-    static std::vector<std::pair<std::string, std::string>> MssqlIncomingForeignKeys(
-        Lightweight::SqlStatement& stmt, Lightweight::SqlSchema::FullyQualifiedTableName const& table)
-    {
-        auto const qualifiedName = table.schema.empty() ? table.table : std::format("{}.{}", table.schema, table.table);
-        auto result = std::vector<std::pair<std::string, std::string>> {};
-        auto cursor =
-            stmt.ExecuteDirect(std::format("SELECT QUOTENAME(OBJECT_SCHEMA_NAME(fk.parent_object_id)) + '.' + "
-                                           "QUOTENAME(OBJECT_NAME(fk.parent_object_id)), QUOTENAME(fk.name) "
-                                           "FROM sys.foreign_keys AS fk WHERE fk.referenced_object_id = OBJECT_ID('{}')",
-                                           qualifiedName));
-        while (cursor.FetchRow())
-        {
-            // Retrieve strictly in ascending column order and in separate statements. GetColumn()
-            // maps onto SQLGetData, and the SQL Server ODBC driver does not support out-of-order
-            // retrieval — asking for column 2 before column 1 fails with
-            // "07009 Invalid Descriptor Index". Passing both calls as arguments to a single
-            // emplace_back() would leave their relative order unspecified, which really does differ
-            // between compilers (Clang evaluates left-to-right here, GCC right-to-left).
-            auto referencingTable = cursor.GetColumn<std::string>(1);
-            auto constraintName = cursor.GetColumn<std::string>(2);
-            result.emplace_back(std::move(referencingTable), std::move(constraintName));
-        }
-        return result;
+        // An empty schema means "the connection's default schema", which is what the formatter
+        // resolves it to — deliberately not a hard-coded "dbo".
+        for (auto const& query: stmt.Connection().QueryFormatter().DropTable(
+                 /*schema=*/"", table.table, /*ifExists=*/true, /*cascade=*/closesCycle))
+            (void) stmt.ExecuteDirect(query);
     }
 
     static void DropTableIfExists(Lightweight::SqlConnection& conn, std::string const& tableName)

--- a/src/tests/Utils.hpp
+++ b/src/tests/Utils.hpp
@@ -22,9 +22,11 @@
 #include <mutex>
 #include <ostream>
 #include <ranges>
+#include <set>
 #include <string>
 #include <string_view>
 #include <tuple>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -590,13 +592,168 @@ class SqlTestFixture
         return result;
     }
 
-    static void DropTableRecursively(Lightweight::SqlStatement& stmt,
-                                     Lightweight::SqlSchema::FullyQualifiedTableName const& table)
+    /// Bookkeeping for a single (possibly multi-rooted) recursive drop.
+    ///
+    /// A schema's foreign-key graph is not a tree. It contains self edges (Chinook's
+    /// @c Employee.ReportsTo references @c Employee), longer cycles (@c A -> @c B -> @c A) and
+    /// diamonds (two independent paths onto the same table). Walking it without remembering
+    /// where we have been recurses forever on the first two and drops a table twice on the third.
+    struct RecursiveDropState
     {
-        auto const dependantTables = Lightweight::SqlSchema::AllForeignKeysTo(stmt, table);
-        for (auto const& dependantTable: dependantTables)
-            DropTableRecursively(stmt, dependantTable.foreignKey.table);
-        (void) stmt.ExecuteDirect(std::format("DROP TABLE IF EXISTS \"{}\"", table.table));
+        /// Tables the traversal has already descended into; each is dropped at most once.
+        std::set<Lightweight::SqlSchema::FullyQualifiedTableName> visited;
+
+        /// Tables currently on the traversal stack. An edge onto one of them is a back edge,
+        /// i.e. proof of a foreign-key cycle, and must not be followed.
+        std::set<Lightweight::SqlSchema::FullyQualifiedTableName> onStack;
+
+        /// The tables that were dropped, in the order they were dropped.
+        std::vector<Lightweight::SqlSchema::FullyQualifiedTableName> dropped;
+    };
+
+    /// Drops @p table together with every table that (transitively) references it.
+    ///
+    /// Dependants are dropped before the table they depend on. Where the foreign-key graph
+    /// contains a cycle no such order exists, so the incoming constraints of the table that
+    /// closes the cycle are taken out of the way first — see @ref DropTableBreakingCycles.
+    ///
+    /// @param stmt  Statement to execute the DDL on.
+    /// @param table The table to drop.
+    /// @return The tables that were dropped, in the order they were dropped, without duplicates.
+    static std::vector<Lightweight::SqlSchema::FullyQualifiedTableName> DropTableRecursively(
+        Lightweight::SqlStatement& stmt, Lightweight::SqlSchema::FullyQualifiedTableName const& table)
+    {
+        auto state = RecursiveDropState {};
+        DropTableRecursively(stmt, table, state);
+        return std::move(state.dropped);
+    }
+
+    /// Reduces @p name to the identity this fixture actually drops by: the bare table name.
+    ///
+    /// A name handed in by a caller carries no catalog/schema, while the very same table read
+    /// back from a foreign-key constraint comes fully qualified (PostgreSQL fills in
+    /// @c test/public, SQL Server @c master/dbo). Comparing the raw structs would make the
+    /// visited set see two different tables and defeat the cycle detection, so both sides are
+    /// normalized to the form the emitted @c DROP @c TABLE statement uses.
+    ///
+    /// @param name The table name to normalize.
+    /// @return @p name with catalog and schema cleared.
+    static Lightweight::SqlSchema::FullyQualifiedTableName CanonicalTableName(
+        Lightweight::SqlSchema::FullyQualifiedTableName const& name)
+    {
+        return { .catalog = {}, .schema = {}, .table = name.table };
+    }
+
+    /// Drops @p table and its dependants, carrying @p state across the whole traversal.
+    ///
+    /// @param stmt  Statement to execute the DDL on.
+    /// @param table The table to drop.
+    /// @param state Visited / on-stack bookkeeping, also collecting the dropped tables.
+    static void DropTableRecursively(Lightweight::SqlStatement& stmt,
+                                     Lightweight::SqlSchema::FullyQualifiedTableName const& table,
+                                     RecursiveDropState& state)
+    {
+        auto const canonicalTable = CanonicalTableName(table);
+        if (!state.visited.insert(canonicalTable).second)
+            return; // Already handled via another path of a diamond — never drop it twice.
+
+        state.onStack.insert(canonicalTable);
+        auto closesCycle = false;
+        for (auto const& constraint: Lightweight::SqlSchema::AllForeignKeysTo(stmt, canonicalTable))
+        {
+            auto const dependantTable = CanonicalTableName(constraint.foreignKey.table);
+            if (state.onStack.contains(dependantTable))
+            {
+                // Back edge (a self-reference when dependantTable == table): the dependant is
+                // still being processed further up the stack, so it cannot be dropped first.
+                closesCycle = true;
+                continue;
+            }
+            DropTableRecursively(stmt, dependantTable, state);
+        }
+        state.onStack.erase(canonicalTable);
+
+        DropTableBreakingCycles(stmt, canonicalTable, closesCycle);
+        state.dropped.emplace_back(canonicalTable);
+    }
+
+    /// Executes the @c DROP @c TABLE for @p table.
+    ///
+    /// @param stmt        Statement to execute the DDL on.
+    /// @param table       The table to drop.
+    /// @param closesCycle When true, @p table is still referenced by a table that cannot be
+    ///                    dropped beforehand because it sits on the same foreign-key cycle. The
+    ///                    referencing constraints are then removed (or their enforcement
+    ///                    suspended) using whatever the backend offers:
+    ///                    PostgreSQL drops them along with the table via @c CASCADE, SQL Server
+    ///                    needs an explicit @c ALTER @c TABLE @c DROP @c CONSTRAINT per incoming
+    ///                    foreign key, and SQLite — which has no @c DROP @c CONSTRAINT at all —
+    ///                    only needs its per-connection @c PRAGMA @c foreign_keys switched off
+    ///                    for the duration of the drop.
+    static void DropTableBreakingCycles(Lightweight::SqlStatement& stmt,
+                                        Lightweight::SqlSchema::FullyQualifiedTableName const& table,
+                                        bool closesCycle)
+    {
+        using Lightweight::SqlServerType;
+
+        auto const dropStatement = std::format("DROP TABLE IF EXISTS \"{}\"", table.table);
+        switch (stmt.Connection().ServerType())
+        {
+            case SqlServerType::POSTGRESQL:
+                // CASCADE drops the *constraints* referencing this table (not the tables
+                // themselves), which is exactly what breaking a cycle needs.
+                (void) stmt.ExecuteDirect(dropStatement + " CASCADE");
+                return;
+            case SqlServerType::SQLITE:
+                if (!closesCycle)
+                    break;
+                // SQLite cannot drop a single constraint, but foreign key enforcement is a
+                // per-connection switch, and the implicit row removal of DROP TABLE is the only
+                // thing it would trip over here.
+                (void) stmt.ExecuteDirect("PRAGMA foreign_keys = OFF");
+                (void) stmt.ExecuteDirect(dropStatement);
+                (void) stmt.ExecuteDirect("PRAGMA foreign_keys = ON");
+                return;
+            case SqlServerType::MICROSOFT_SQL:
+                if (!closesCycle)
+                    break;
+                for (auto const& [referencingTable, constraintName]: MssqlIncomingForeignKeys(stmt, table))
+                    (void) stmt.ExecuteDirect(
+                        std::format("ALTER TABLE {} DROP CONSTRAINT {}", referencingTable, constraintName));
+                break;
+            case SqlServerType::MYSQL:
+                if (!closesCycle)
+                    break;
+                // MySQL/MariaDB refuse to drop a referenced parent table; the check is a
+                // session-level switch, mirroring the SQLite approach above.
+                (void) stmt.ExecuteDirect("SET FOREIGN_KEY_CHECKS = 0");
+                (void) stmt.ExecuteDirect(dropStatement);
+                (void) stmt.ExecuteDirect("SET FOREIGN_KEY_CHECKS = 1");
+                return;
+            case SqlServerType::UNKNOWN:
+                break;
+        }
+        (void) stmt.ExecuteDirect(dropStatement);
+    }
+
+    /// Looks up every foreign key pointing at @p table on SQL Server.
+    ///
+    /// @param stmt  Statement to query @c sys.foreign_keys through.
+    /// @param table The referenced (primary key side) table.
+    /// @return Pairs of (bracket-quoted referencing table, bracket-quoted constraint name).
+    static std::vector<std::pair<std::string, std::string>> MssqlIncomingForeignKeys(
+        Lightweight::SqlStatement& stmt, Lightweight::SqlSchema::FullyQualifiedTableName const& table)
+    {
+        auto const qualifiedName = table.schema.empty() ? table.table : std::format("{}.{}", table.schema, table.table);
+        auto result = std::vector<std::pair<std::string, std::string>> {};
+        auto cursor =
+            stmt.ExecuteDirect(std::format("SELECT QUOTENAME(OBJECT_SCHEMA_NAME(fk.parent_object_id)) + '.' + "
+                                           "QUOTENAME(OBJECT_NAME(fk.parent_object_id)), QUOTENAME(fk.name) "
+                                           "FROM sys.foreign_keys AS fk WHERE fk.referenced_object_id = OBJECT_ID('{}')",
+                                           qualifiedName));
+        while (cursor.FetchRow())
+            result.emplace_back(cursor.GetColumn<std::string>(1), cursor.GetColumn<std::string>(2));
+        return result;
     }
 
     static void DropTableIfExists(Lightweight::SqlConnection& conn, std::string const& tableName)
@@ -623,6 +780,9 @@ class SqlTestFixture
                 [[fallthrough]];
             case SqlServerType::SQLITE:
             case SqlServerType::UNKNOWN: {
+                // One shared state across the whole sweep: a table reached as a dependant of an
+                // earlier root must not be visited (nor dropped) again when its own turn comes.
+                auto state = RecursiveDropState {};
                 auto const tableNames = GetAllTableNames(stmt);
                 for (auto const& tableName: tableNames)
                 {
@@ -634,7 +794,8 @@ class SqlTestFixture
                                              .catalog = {},
                                              .schema = {},
                                              .table = tableName,
-                                         });
+                                         },
+                                         state);
                 }
                 break;
             }
@@ -660,7 +821,10 @@ class SqlTestFixture
         }
     }
 
-  private:
+    /// Lists the names of all tables the connection's default schema currently holds.
+    ///
+    /// @param stmt Statement to run the catalog query on.
+    /// @return The table names, as reported by @c SQLTables.
     static std::vector<std::string> GetAllTableNames(Lightweight::SqlStatement& stmt)
     {
         using namespace std::string_literals;
@@ -691,6 +855,7 @@ class SqlTestFixture
         return result;
     }
 
+  private:
     static inline std::vector<std::string> m_createdTables;
 };
 


### PR DESCRIPTION
Fixes #531

## Root cause

`SqlTestFixture::DropTableRecursively` (`src/tests/Utils.hpp`) walked the foreign-key graph with no
memory of where it had been:

```cpp
auto const dependantTables = SqlSchema::AllForeignKeysTo(stmt, table);
for (auto const& dependantTable: dependantTables)
    DropTableRecursively(stmt, dependantTable.foreignKey.table);   // <-- may be `table` itself
(void) stmt.ExecuteDirect(std::format("DROP TABLE IF EXISTS \"{}\"", table.table));
```

`AllForeignKeysTo(t)` returns the constraints for which `t` is the *referenced* side, so
`foreignKey.table` is the dependant. For a self-referencing foreign key that dependant **is** `t`,
and the function calls itself with an identical argument until the stack is exhausted — SIGSEGV.
Chinook's `Employee.ReportsTo` is the canonical trigger; because the cleanup runs in the
`SqlTestFixture` constructor, the crash surfaces in whatever unrelated test happens to run next.

A self edge is only the simplest case. The same unbounded recursion occurs for any longer cycle
(`A -> B -> A`), and a diamond — two paths reaching the same table, or two distinct FK constraints
between the same table pair — made the traversal descend into and `DROP TABLE` the same table twice.

## The fix

The traversal now carries a `RecursiveDropState`:

* `visited` — every table is descended into, and dropped, **at most once**. This is what makes
  diamonds safe.
* `onStack` — tables currently on the traversal stack. An edge onto one of them is a back edge,
  i.e. proof of a cycle, and is deliberately **not** followed. A self edge is just the degenerate
  case where the back edge points at the current table.

Table identity is normalized to the bare table name (`CanonicalTableName`). This turned out to be
load-bearing: a name handed in by a caller carries no catalog/schema, while the very same table read
back from a foreign-key constraint comes fully qualified (PostgreSQL fills in `test/public`, SQL
Server `master/dbo`). Comparing the raw structs made the visited set see two different tables and
defeated the cycle detection outright — the PostgreSQL run of the new tests failed exactly this way
before the normalization was added. The bare name is also precisely the identity the emitted
`DROP TABLE "<name>"` statement uses, so the two cannot drift.

`DropAllTablesInDatabase` shares one state across its whole sweep, so a table already dropped as a
dependant of an earlier root is not revisited when its own turn comes.

## How true cycles are handled, per backend

A table that closes a cycle is still referenced by a table that cannot be dropped beforehand, so
there is no dependency order to drop in. `DropTableBreakingCycles` therefore removes the incoming
constraints (or suspends their enforcement) using what each backend actually offers — this is the
part where the three differ substantially, so a single portable statement does not exist:

| Backend | Mechanism | Why |
|---|---|---|
| **PostgreSQL** | `DROP TABLE IF EXISTS "t" CASCADE` | `CASCADE` drops the *constraints* that reference `t`, not the referencing tables. It is exactly cycle-breaking and nothing more, so it is applied unconditionally — matching what the existing PostgreSQL branch of `DropAllTablesInDatabase` already did. |
| **SQL Server** | `ALTER TABLE <parent> DROP CONSTRAINT <fk>` for every incoming FK, resolved through `sys.foreign_keys` | SQL Server has no `DROP TABLE ... CASCADE` and refuses to drop a referenced table. The constraint *name* is required and `SqlSchema::ForeignKeyConstraint` does not carry one, hence the catalog lookup. Only performed when a cycle was actually detected, so the common path costs nothing extra. |
| **SQLite** | `PRAGMA foreign_keys = OFF` around the drop, then back `ON` | SQLite has no `ALTER TABLE ... DROP CONSTRAINT` at all. Enforcement is a per-connection switch, and the implicit row removal of `DROP TABLE` is the only thing it would trip over. The fixture already turns this pragma `ON` at connection setup, so restoring it is correct. |
| MySQL | `SET FOREIGN_KEY_CHECKS = 0` around the drop | Same shape as SQLite. Not covered by the CI matrix; included for completeness rather than verified. |

For the non-cycle case nothing changed: dependants are still dropped before the table they depend
on, and the plain `DROP TABLE IF EXISTS` is used.

`DropTableRecursively` now returns the tables it dropped, in drop order — that is what lets the
regression test assert on the traversal instead of on side effects.

## Regression test

Three cases in `src/tests/SqlSchemaDbTests.cpp`, all run against every backend:

1. **Self-referencing FK** — `SelfRef.ref_SelfRef -> SelfRef.id`, the Chinook `Employee.ReportsTo`
   shape in miniature.
2. **Two-table cycle** — `CycleA <-> CycleB`. Built with a forward reference on SQLite (which
   resolves FK targets lazily and has no `ADD CONSTRAINT`) and with `ALTER TABLE ... ADD CONSTRAINT`
   elsewhere.
3. **Diamond** — `DiaRoot <- DiaLeft, DiaRight <- DiaLeaf`, plus `DiaLeft` referencing `DiaRoot`
   through *two* separate constraints. Asserts four drops for four tables, no duplicates, and that
   dependants are still ordered before what they depend on.

Verified to fail without the fix by reverting the traversal body to the old code (keeping the new
return value so the test still compiled):

| Case | sqlite3 | mssql2022 | postgres |
|---|---|---|---|
| self-referencing FK | SIGSEGV | SIGSEGV | SIGSEGV |
| two-table cycle | SIGSEGV | SIGSEGV | SIGSEGV |
| diamond | passes¹ | double drop of `DiaLeft` | double drop of `DiaLeft` |

¹ The SQLite ODBC driver does not populate `FK_NAME`, so `SqlSchema` collapses two constraints
between the same table pair into a single entry — the duplicate edge is simply not visible there.
The redundant *drop* of the plain two-path diamond is self-masking on a live database on every
backend (the first drop removes the constraint, so the second path no longer sees the dependant);
the duplicated-constraint variant is what makes it observable.

## Databases tested

Full suite, `clang-debug` preset (clang-tidy + ASan/UBSan, `PEDANTIC_COMPILER_WERROR=ON`), each on a
freshly (re)created database:

```
./out/build/clang-debug/src/tests/LightweightTest --test-env=sqlite3
  test cases:  1244 |  1243 passed | 1 skipped     assertions: 12737 | 12737 passed

./out/build/clang-debug/src/tests/LightweightTest --test-env=mssql2022
  test cases:  1244 |  1241 passed | 3 skipped     assertions: 12692 | 12692 passed

./out/build/clang-debug/src/tests/LightweightTest --test-env=postgres
  test cases:  1244 |  1242 passed | 2 skipped     assertions: 12657 | 12657 passed
```

* `sqlite3` — SQLite 3.49.1 via the SQLite3 ODBC driver
* `mssql2022 (Docker)` — Microsoft SQL Server 16.00.4250, ODBC Driver 18
* `postgres (Docker 16.4)` — PostgreSQL 16.4.0, PostgreSQL Unicode driver

`clang-format` clean, no new clang-tidy findings, no `NOLINT` added.

## Risk assessment

* **Scope** — test infrastructure only (`src/tests/`). No library header, no public API, no ABI
  surface; nothing under `src/Lightweight/` is touched.
* **Per-DBMS** — the added cycle-breaking SQL only executes when a cycle is actually detected
  (except PostgreSQL's `CASCADE`, which the fixture's PostgreSQL cleanup path already used).
  The `sys.foreign_keys` query is SQL Server-only and guarded by the server-type switch, so no
  other backend can ever see it.
* **Cost** — one extra catalog query per *cycle-closing* table on SQL Server; no additional query on
  the common acyclic path. The shared visited set across `DropAllTablesInDatabase` strictly reduces
  the number of `AllForeignKeysTo` round trips on schemas with shared dependants.
* **Behavioural change for callers** — `DropTableRecursively` gained a return value and a
  three-argument overload; the existing two-argument call shape is unchanged and the return value is
  ignorable. `GetAllTableNames` moved from `private` to `public` so the regression test can assert
  that tables are really gone.
* **Not addressed here** — while testing I hit a pre-existing, unrelated fixture issue: the
  `TEMPLATE_LIST_TEST_CASE` in `DataBinderTests.cpp` calls
  `SqlTestFixture::DropAllTablesInDatabase` without a fixture instance ever having been constructed,
  so the static `testDatabaseName` is unset and the cleanup silently drops nothing on SQL Server.
  It reproduces identically on `master` and is left alone.

---

## Follow-up commit 2 — SQL Server `07009 Invalid Descriptor Index` (CI regression)

The first commit turned all three SQL Server CI legs red with 106 failing test cases, while my local
`clang-debug` runs were green. Root cause:

```cpp
result.emplace_back(cursor.GetColumn<std::string>(1), cursor.GetColumn<std::string>(2));
```

**The order in which function arguments are evaluated is unspecified.** `GetColumn()` maps onto
`SQLGetData`, and the SQL Server ODBC driver does not support out-of-order retrieval — asking for
column 2 before column 1 fails with `07009 Invalid Descriptor Index`. Clang evaluates these
arguments left-to-right and happens to produce the legal order; GCC evaluates them right-to-left and
does not. CI's database test binary is the **GCC 14 `gcc-release`** artifact, which is exactly why
nothing local caught it. SQLite and PostgreSQL were unaffected because their drivers permit
out-of-order `SQLGetData`.

The throw happened inside `DropTableBreakingCycles` → `DropAllTablesInDatabase` → the
`SqlTestFixture` **constructor**, so the cyclic tables survived and every subsequent fixture-based
test failed in its own constructor — one bad fetch cascading into a whole-suite failure.

Fixed by retrieving into named locals in ascending column order, which removes the dependency on
evaluation order entirely. Two independent reproductions:

* **Direct probe** — reading column 2 before column 1 of a plain `SELECT 'aa' AS a, 'bb' AS b`
  raises the identical error at the identical source location (`SqlStatement.hpp:1934`); ascending
  order passes. This also rules out stale `SQLBindCol` bindings as the cause: the probe uses a
  pristine statement.
* **End-to-end** — a GCC build of the full suite against `mssql2022` went from **548 failed test
  cases to 0**, with `Utils.hpp:566` (the fixture constructor) and the
  `SELECT QUOTENAME(OBJECT_SCHEMA_NAME(fk.…` query visible in the failing trace.

A scan of the tree found no other place where two `GetColumn` calls share one expression.

## Follow-up commit 3 — whole-database SqlBackup test isolation (macOS leg)

`SqlBackup::Backup()` with no table filter captures the **entire** database, and `SqlTestFixture`
drops tables in its *constructor*, not its destructor — so every test leaves its tables live until
the next fixture-based test runs. A plain `TEST_CASE` calling `Backup()` therefore backed up whatever
the previously executed tests left behind. The suite deliberately stores values wider than the
declared column width (legal on SQLite/PostgreSQL under character semantics), and `RowArrayCursor`
sizes its bulk-fetch buffer from `SQLDescribeColW`'s `columnSize` and hard-fails on any cell that
exceeds it. Which test blows up is pure lottery — five runs have now hit it on three databases under
five different test names.

**25 test cases** that back up the whole database now derive from `SqlTestFixture`:

| File | converted |
|---|---:|
| `SqlBackup/Tests.cpp` | 15 |
| `SqlBackup/ProductionReadinessTests.cpp` | 3 |
| `SqlBackup/RobustnessTests.cpp` | 3 |
| `SqlBackup/AllColumnTypesTests.cpp` | 1 |
| `SqlBackup/MultiPkTests.cpp` | 1 |
| `SqlBackup/SqlBackupCompositeFKTests.cpp` | 1 |
| `SqlBackup/SqlBackupIndexTests.cpp` | 1 |

Deliberately **left** as plain `TEST_CASE` (checked individually, not skipped wholesale):

* Pure unit tests that never open a connection — the five `ParseSchema` cases, `TableFilter
  patterns`, `Compression Method Support`, `Error counting in ProgressManager`,
  `DeleteStaleSubChunks`, and the restore-of-missing/invalid-file error paths.
* Tests that back up **through a table filter** and are therefore already isolated from unrelated
  tables — `multi-window PK-range table`, `PK-range windows fall back…`, `Backup with Table Filter`.

`SqlBackupIndexTests` and `SqlBackupCompositeFKTests` additionally called
`SqlTestFixture::DropAllTablesInDatabase()` *statically* from a plain `TEST_CASE`. That only works
once some fixture has been constructed and set the static `testDatabaseName`, so it silently dropped
nothing on SQL Server when the test ran early — the same latent pattern noted below for
`DataBinderTests.cpp`. Deriving from the fixture makes those calls well-defined.

`EncodingRoundTripTests.cpp` is untouched — already converted in #527.

Verified by seeding the database with a table whose `VARCHAR(16)` column holds 200 bytes and running
`SqlBackup: Schema-only restore from full backup`: as a plain `TEST_CASE` it fails with the exact CI
error at `Tests.cpp:1858`; as a `TEST_CASE_METHOD` it passes.

**Still open, not fixed here:** the `SqlBackup` tests write to fixed *relative* zip filenames
(`backup_test.zip`, `all_types_backup.zip`, …) in the working directory, so two suite processes
sharing a directory clobber each other. That is a separate isolation defect, not adjacent to this
change, and deserves its own issue.

## Databases tested (final, all three commits)

Every run on a freshly recreated database, full suite. Both toolchains, because the evaluation-order
bug proves one compiler is not enough:

| | sqlite3 | mssql2022 | postgres |
|---|---|---|---|
| **clang-debug** (clang-tidy + ASan/UBSan) | 1243 passed / 1 skipped | 1241 passed / 3 skipped | 1242 passed / 2 skipped |
| **gcc-debug** (matches CI's GCC 14 artifact) | 1242 passed / 1 skipped | 1240 passed / 3 skipped | 1241 passed / 2 skipped |

0 failures in all six runs. `sqlite3` = SQLite 3.49.1; `mssql2022` = SQL Server 16.00.4250 (Docker),
ODBC Driver 18; `postgres` = PostgreSQL 16.4.0 (Docker).

The GCC runs exclude `Async.Task: deep symmetric-transfer chain does not overflow the stack`, which
SIGSEGVs in a GCC **debug** build on this host from thread stack size — unrelated to this PR and not
reproducible in the `gcc-release` configuration CI actually ships.

`clang-format` clean, no new clang-tidy findings, no `NOLINT` added.

---

## Follow-up commits 4 & 5 — review findings

### Finding 1 — dialect knowledge moved back into `SqlQueryFormatter` (commit 4)

`DropTableBreakingCycles` carried its own per-backend `DROP TABLE` knowledge: a `CASCADE` clause for
PostgreSQL, a hand-written `sys.foreign_keys` query plus an `ALTER TABLE … DROP CONSTRAINT` loop for
SQL Server, a `PRAGMA` toggle for SQLite, a `SET FOREIGN_KEY_CHECKS` toggle for MySQL. AGENT.md puts
per-DBMS branching in `SqlQueryFormatter` overrides only, and
`SqlQueryFormatter::DropTable(schema, table, ifExists, cascade)` already implements every one of
those cases.

**The substitution worked cleanly — no obstacle.** The ~75-line `switch` plus
`MssqlIncomingForeignKeys` collapsed to:

```cpp
auto foreignKeysGuard = std::optional<SqliteForeignKeysGuard> {};
if (closesCycle)
    foreignKeysGuard.emplace(stmt.Connection());

for (auto const& query: stmt.Connection().QueryFormatter().DropTable(
         /*schema=*/"", table.table, /*ifExists=*/true, /*cascade=*/closesCycle))
    (void) stmt.ExecuteDirect(query);
```

I verified the three formatters produce exactly what the hand-written code did:
`SqlQueryFormatter::FormatTableName("", t)` yields `"t"` — byte-identical quoting to the statement it
replaces. The SQLite pragma legitimately stays, since `SQLiteFormatter::DropTable` ignores `cascade`.

Three things improve beyond the deduplication:

* The formatter resolves an empty schema to `SCHEMA_NAME()`, not a hard-coded `dbo`. My copy
  re-derived it through `OBJECT_ID()`, which silently matches nothing for a login whose default
  schema isn't `dbo` — the exact failure the formatter carries a comment about.
* `OBJECT_ID('{}')` interpolated the table name unescaped, so it mis-parsed a name containing `.`
  and broke outright on one containing a quote. The suite does create tables with unusual names
  ("Order Details"). Gone with the function — as is its dead schema-qualification branch, whose only
  caller passed a `CanonicalTableName` with an always-empty schema.
* **`CASCADE` is now gated on `closesCycle` for PostgreSQL too**, where it used to be unconditional.
  As the review noted, that meant the PG leg would pass even if the cycle logic were broken. It now
  carries real regression value: forcing `cascade=false` makes the two-table-cycle test **fail** on
  PostgreSQL, and pass again when restored.

MySQL loses its special case deliberately: `SqlQueryFormatter::Get()` maps `SqlServerType::MYSQL` to
`nullptr`, so there is no MySQL formatter and the fixture cannot meaningfully support that backend.
Untested code pretending otherwise is worse than its absence.

### Finding 2 — SQLite pragma toggle is now RAII (commit 5)

The old toggle was three bare `ExecuteDirect` calls. `ExecuteDirect` throws, so a throw on the `DROP`
skipped the re-enable and left foreign-key enforcement **off** for the rest of that connection's life
— every later foreign-key assertion on it would then pass for the wrong reason. It also restored a
hard-coded `ON`, clobbering a caller who deliberately had enforcement off
(`SqlBackup/Restore.cpp:744` does exactly that).

Replaced with `SqliteForeignKeysGuard`, mirroring the library-internal guard in `SqlMigration.cpp`
— which lives in an anonymous namespace inside that translation unit and so cannot be reused from a
test header. Contract copied across: gate on the `RequiresTableRebuildForSchemaChange()` *capability*
rather than a server-type test, read the previous `PRAGMA` value and restore **that**, release the
read cursor before the next statement (reusing a statement with an open cursor is an
invalid-cursor-state error on the SQLite ODBC driver), and never propagate from the destructor.

One deliberate divergence: the library version needs `NOLINT(bugprone-empty-catch)` for the inner
swallow around its logging call. This one routes the failure through a `noexcept` helper, so the
single `catch` block is non-empty and "must not throw" is enforced by the language — no suppression,
per AGENT.md.

### Finding 3 — `CanonicalTableName` schema limitation documented

Added a `@note`: two same-named tables in different schemas collapse into one visited entry, so only
whichever the default schema resolves gets dropped. It cannot arise today — `GetAllTableNames`
queries only the default schema — and the emitted `DROP` was already schema-blind before the visited
set existed. Documented rather than fixed, since fixing it would mean qualifying the drop, which is a
larger behavioural change than this PR should carry.

### Finding 4 — resolved by finding 1

`MssqlIncomingForeignKeys` is deleted outright, taking the dead branch and the unescaped
interpolation with it.

## Reported, deliberately not fixed here

Two **pre-existing** descending-order `SQLGetData` reads — the same hazard as commit 2, but sequenced
rather than unsequenced, so they are deterministic rather than compiler-dependent:

* `src/Lightweight/SqlSchema.cpp:124-129` — `AllForeignKeysFromSqlite` reads columns 1, 2, 4, 5, then
  **3**.
* `src/Lightweight/SqlMigration.cpp:929-931` — reads column **7**, then column **2**.

Both are SQLite-only paths where the driver buffers the row, so they work today; they would break on
any driver without `SQL_GD_ANY_ORDER`. Out of scope for this PR — flagged for a separate issue.

`EncodingRoundTripTests.cpp` is intentionally left as a plain `TEST_CASE` here: it is already
converted on #527, and converting it again would conflict.

## Databases tested (final, all four commits)

Each on a freshly recreated database, full suite:

| build | sqlite3 | mssql2022 | postgres |
|---|---|---|---|
| **clang-debug** (clang-tidy + ASan/UBSan) | 1243 passed / 1 skipped | 1241 passed / 3 skipped | 1242 passed / 2 skipped |
| **gcc-release** (matches CI's test artifact) | — | 1241 passed / 3 skipped | — |

0 failures. `sqlite3` = SQLite 3.49.1; `mssql2022` = SQL Server 16.00.4250 (Docker), ODBC Driver 18;
`postgres` = PostgreSQL 16.4.0 (Docker). `clang-format` clean, no new clang-tidy findings, no
`NOLINT` added — the guard's single `catch` is non-empty by construction.

One sqlite3 run showed a single unrelated failure in `IngestPlugins — pluginManager == &central is a
no-op merge` ("Duplicate migration timestamp … 'pre' conflicts with 'pre'"). It passes in isolation
and on a clean re-run (1243 passed / 0 failed). Cause: `PluginDiscoveryTests.cpp:38` names its temp
directory from `steady_clock` (monotonic since boot) rather than a PID, so two suite processes
started close together on the same host can share `/tmp/lightweight-plugindisco-<n>` and see each
other's plugin files. Another agent was running the suite concurrently on this machine. Same class of
defect as the fixed-relative zip filenames noted above — pre-existing, unrelated to this PR, worth
its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
