### PR TITLE
fix(DataMapper): All<Field>() bound a growable column and aborted on MS SQL Server

### DIFF
--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -700,7 +700,30 @@ class DataMapper
 
 namespace detail
 {
-    template <typename FieldType>
+    /// Whether @p T is a column type whose buffer may have to grow while fetching (e.g. a string long
+    /// enough to be truncated into the initially bound buffer).
+    ///
+    /// @tparam T The *value* type of the column, i.e. `Field<...>::ValueType`, never the `Field<...>`
+    ///           wrapper itself.
+    template <typename T>
+    inline constexpr bool IsGrowableColumnType =
+        detail::OneOf<T, std::string, std::wstring, std::u16string, std::u32string, SqlBinary> || IsSqlDynamicString<T>
+        || IsSqlDynamicBinary<T>;
+
+    /// Whether a single output column of value type @p T can safely be bound up front on @p
+    /// sqlServerType.
+    ///
+    /// Takes the column's *value* type, not a `Field<...>` wrapper: the sole caller projects a single
+    /// field and only has `ReferencedFieldTypeOf<Field>` (the ValueType) to hand. This previously
+    /// took the wrapper and gated its whole body on `if constexpr (IsField<FieldType>)`, which a
+    /// ValueType never satisfies - so it silently answered "safe to bind" for every type, including
+    /// the growable ones it exists to exclude.
+    ///
+    /// @tparam T The column's value type.
+    /// @param sqlServerType The server being queried.
+    /// @return `true` if the column may be bound with `BindOutputColumn`, `false` if it has to be read
+    ///         per row with `GetColumn` instead.
+    template <typename T>
     constexpr bool CanSafelyBindOutputColumn(SqlServerType sqlServerType) noexcept
     {
         if (sqlServerType != SqlServerType::MICROSOFT_SQL)
@@ -709,25 +732,17 @@ namespace detail
         // Test if we have some columns that might not be sufficient to store the result (e.g. string truncation),
         // then don't call BindOutputColumn but SQLFetch to get the result, because
         // regrowing previously bound columns is not supported in MS-SQL's ODBC driver, so it seems.
-        bool result = true;
-        if constexpr (IsField<FieldType>)
-        {
-            if constexpr (detail::OneOf<typename FieldType::ValueType,
-                                        std::string,
-                                        std::wstring,
-                                        std::u16string,
-                                        std::u32string,
-                                        SqlBinary>
-                          || IsSqlDynamicString<typename FieldType::ValueType>
-                          || IsSqlDynamicBinary<typename FieldType::ValueType>)
-            {
-                // Known types that MAY require growing due to truncation.
-                result = false;
-            }
-        }
-        return result;
+        return !IsGrowableColumnType<T>;
     }
 
+    /// Whether every output column of @p Record can safely be bound up front on @p sqlServerType.
+    ///
+    /// The record-wide counterpart of @ref CanSafelyBindOutputColumn: one growable member is enough to
+    /// force the whole record onto the per-row `GetColumn` path.
+    ///
+    /// @tparam Record The record being fetched.
+    /// @param sqlServerType The server being queried.
+    /// @return `true` if the columns may be bound with `BindOutputColumns`.
     template <DataMapperRecord Record>
     constexpr bool CanSafelyBindOutputColumns(SqlServerType sqlServerType) noexcept
     {
@@ -737,20 +752,9 @@ namespace detail
         bool result = true;
         EnumerateRecordMembers<Record>([&result]<size_t I, typename Field>() {
             if constexpr (IsField<Field>)
-            {
-                if constexpr (detail::OneOf<typename Field::ValueType,
-                                            std::string,
-                                            std::wstring,
-                                            std::u16string,
-                                            std::u32string,
-                                            SqlBinary>
-                              || IsSqlDynamicString<typename Field::ValueType>
-                              || IsSqlDynamicBinary<typename Field::ValueType>)
-                {
+                if constexpr (IsGrowableColumnType<typename Field::ValueType>)
                     // Known types that MAY require growing due to truncation.
                     result = false;
-                }
-            }
         });
         return result;
     }

--- a/src/tests/DataMapper/MiscTests.cpp
+++ b/src/tests/DataMapper/MiscTests.cpp
@@ -13,6 +13,8 @@
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include <array>
+#include <ranges>
 #include <string_view>
 
 using namespace std::string_view_literals;
@@ -368,6 +370,60 @@ TEST_CASE_METHOD(SqlTestFixture, "TestQuerySparseDynamicData", "[DataMapper]")
     checkSize(2000);
     checkSize(4000);
     checkSize(16000);
+}
+
+// CanSafelyBindOutputColumn takes the column's *value* type, which is all AllImpl() has to hand. These
+// checks pin that contract: taking a `Field<...>` wrapper instead made the trait's answer vacuously
+// "safe to bind" for every type, which is only observable at runtime on MS SQL Server. Asserting it
+// directly catches the regression on any backend, and at compile time.
+static_assert(!detail::CanSafelyBindOutputColumn<std::string>(SqlServerType::MICROSOFT_SQL));
+static_assert(!detail::CanSafelyBindOutputColumn<SqlDynamicAnsiString<16000>>(SqlServerType::MICROSOFT_SQL));
+static_assert(!detail::CanSafelyBindOutputColumn<SqlDynamicUtf16String<16000>>(SqlServerType::MICROSOFT_SQL));
+static_assert(!detail::CanSafelyBindOutputColumn<SqlBinary>(SqlServerType::MICROSOFT_SQL));
+
+// Fixed-width types stay bindable, and every non-MS-SQL backend binds regardless.
+static_assert(detail::CanSafelyBindOutputColumn<int>(SqlServerType::MICROSOFT_SQL));
+static_assert(detail::CanSafelyBindOutputColumn<SqlAnsiString<32>>(SqlServerType::MICROSOFT_SQL));
+static_assert(detail::CanSafelyBindOutputColumn<std::string>(SqlServerType::SQLITE));
+static_assert(detail::CanSafelyBindOutputColumn<std::string>(SqlServerType::POSTGRESQL));
+
+// The record-wide sibling agrees: one growable member is enough to unbind the whole record.
+static_assert(!detail::CanSafelyBindOutputColumns<TestDynamicData>(SqlServerType::MICROSOFT_SQL));
+static_assert(detail::CanSafelyBindOutputColumns<TestDynamicData>(SqlServerType::SQLITE));
+
+TEST_CASE_METHOD(SqlTestFixture, "TestQueryAllSingleDynamicField", "[DataMapper]")
+{
+    // Regression test: the single-field All<Field>() projection over a *growable* column.
+    //
+    // AllImpl() asks CanSafelyBindOutputColumn whether it may bind the output column up front, passing
+    // `value_type` - the field's ValueType. That trait used to take a `Field<...>` wrapper and gate its
+    // whole body on `if constexpr (IsField<FieldType>)`, which a ValueType never satisfies, so it
+    // answered "safe to bind" for every type including the growable ones it exists to exclude. On MS SQL
+    // Server the bound buffer then has to grow mid-fetch, which that driver does not support, and the
+    // SQL_SUCCEEDED assertion in BasicStringBinder.hpp's PostProcessOutputColumn fires.
+    //
+    // The existing All<> coverage projects fixed-width integer fields, which are safe to bind on every
+    // backend - so nothing exercised the decision until this test.
+    auto dm = DataMapper();
+    dm.CreateTable<TestDynamicData>();
+
+    auto const sizes = std::array<size_t, 3> { 5, 4000, 16000 };
+    for (auto const size: sizes)
+    {
+        TestDynamicData row {};
+        row.stringAnsi = std::string(size, 'a');
+        dm.Create(row);
+    }
+
+    auto const values = dm.Query<TestDynamicData>()
+                            .OrderBy(FieldNameOf<Member(TestDynamicData::id)>, SqlResultOrdering::ASCENDING)
+                            .All<Member(TestDynamicData::stringAnsi)>();
+
+    REQUIRE(values.size() == sizes.size());
+    // `std::views::enumerate` is unavailable on the libc++ versions the macOS and C++26-reflection CI
+    // jobs build against, so index into both sequences via `iota` instead.
+    for (auto const index: std::views::iota(size_t { 0 }, sizes.size()))
+        CHECK(values.at(index) == std::string(sizes.at(index), 'a'));
 }
 
 struct TestOptionalDynamicData


### PR DESCRIPTION
`SqlCoreDataMapperQueryBuilder::AllImpl()` — the single-field `All<&Record::field>()` projection —
decides whether it may bind the output column up front by asking
`detail::CanSafelyBindOutputColumn<value_type>`. That trait exists to say *no* for column types whose
buffer may have to grow mid-fetch (`std::string`, `SqlDynamicString`, `SqlBinary`, …), because MS SQL
Server's ODBC driver cannot regrow an already-bound column.

It never said no. The trait took a `Field<...>` **wrapper** and gated its entire body on
`if constexpr (IsField<FieldType>)`, but the only caller passes `ReferencedFieldTypeOf<Field>` — the
field's **ValueType**. A ValueType never satisfies `IsField`, so the body was skipped and the function
returned its `result = true` initialiser for *every* type, growable ones included.

The consequence on MS SQL Server is not a wrong value but an abort: the growable column gets bound, the
driver refuses to regrow it, and the `assert(SQL_SUCCEEDED(sqlResult))` in `BasicStringBinder.hpp`'s
`PostProcessOutputColumn` fires.

```
LightweightTest: .../DataBinder/BasicStringBinder.hpp:501:
  static void Lightweight::SqlDataBinder<T>::PostProcessOutputColumn(...)
  [with AnsiStringType = Lightweight::SqlDynamicString<16000, char>; ...]:
  Assertion `SQL_SUCCEEDED(sqlResult)' failed.
```

Nothing exercised it because the existing `All<Field>()` coverage projects fixed-width integer fields,
which are safe to bind on every backend, so the decision was never put to the test.

## The fix

`CanSafelyBindOutputColumn<T>` now takes the column's **value type** — what the call site actually has —
and tests it directly. The growable-type list moves into `IsGrowableColumnType<T>`, which the
record-wide `CanSafelyBindOutputColumns<Record>` (correct all along, since it is handed a record and
walks its `Field` members) now shares instead of duplicating.

`IsGrowableColumnType` is `inline constexpr` deliberately: a plain namespace-scope `constexpr` in a
public header implies internal linkage, which the `LIGHTWEIGHT_BUILD_MODULES` build rejects.

## Tests

- **`static_assert`s pinning the trait's contract.** The defect was only observable at runtime, on one
  backend. Asserting the trait directly catches it at **compile time on every backend** — and these
  assertions were checked against a standalone reproduction of the old signature, where
  `CanSafelyBindOutputColumn<std::string>(MICROSOFT_SQL)` really does evaluate to `true`, so they do
  fail on the unfixed code rather than merely passing on the fixed one.
- **`TestQueryAllSingleDynamicField`** — the end-to-end reproducer: `All<Member(...)>()` over a
  `SqlDynamicAnsiString<16000>` column at 5, 4000 and 16000 characters, so a row both under and well
  over any plausible initial buffer is fetched.

## Risk

- **Per-DBMS:** behaviour changes on MS SQL Server only — every other backend already short-circuits to
  `true` on the first line. On MS SQL Server a growable single-column projection now takes the
  `GetColumn` path, which is what the code always intended and what `CanSafelyBindOutputColumns` has
  been doing for whole-record fetches.
- **Scope:** one call site (`AllImpl`). Fixed-width projections are unaffected — they were already
  answered `true` and still are.
- **ABI:** none; both functions are `constexpr` implementation details in `namespace detail`.

## Testing

| Compiler / config | Database | Result |
|---|---|---|
| `gcc-14` Debug (`--coverage`) | sqlite3 | 1306 passed, 1 skipped |
| `gcc-14` Debug (`--coverage`) | mssql2022 (Docker) | 1304 passed, 3 skipped |
| `gcc-14` Debug (`--coverage`) | postgres (Docker 16.4) | 1302 passed, 3 pre-existing failures (below) |

`TestQueryAllSingleDynamicField` aborts on MS SQL Server before this change and passes after it. The
`GetColumn` fallback it exercises (`DataMapper.hpp:1216`) goes from **0 hits on every backend** to **3
hits under MS SQL Server**, measured with an instrumented `--coverage` build — that line was previously
unreachable code.

PostgreSQL reports 3 failures in this environment (`SqlVariantDbTests.cpp:240,536`,
`AllColumnTypesTests.cpp:137,154`) — all `BOOLEAN`/`SQL_BIT` assertions in files this PR does not touch.
I checked these out on unmodified `master` and they fail identically there (3 test cases, 4 assertions),
so they are pre-existing and unrelated: the locally installed `psqlodbc` reports `SQL_VARCHAR (12)`
where those tests expect `SQL_BIT (-7)`.

## Note for #534

This also unblocks the last uncovered line of #534's patch coverage: `AllImpl`'s
`value = reader.GetColumn<value_type>(1)` was unreachable on every backend for exactly this reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
