### PR TITLE
pool: wire up SqlLogger::OnConnectionIdle/OnConnectionReuse

### DIFF
--- a/src/Lightweight/DataMapper/Pool.hpp
+++ b/src/Lightweight/DataMapper/Pool.hpp
@@ -140,6 +140,7 @@ class Pool
         requires(Config.growthStrategy == GrowthStrategy::UnboundedGrow)
     {
         DropAsyncBackend(*dm);
+        SqlLogger::GetLogger().OnConnectionIdle(dm->Connection());
         std::scoped_lock lock(_mutex);
         _idleDataMappers.push_back(std::move(dm));
     }
@@ -178,6 +179,8 @@ class Pool
             // abandonment; a synchronous waiter is never abandoned), but guard defensively.
             if (node->state != WaiterNode::State::Parked)
                 continue;
+            // Handed directly to a waiter, never idled: a reuse, not an idle transition.
+            SqlLogger::GetLogger().OnConnectionReuse(dm->Connection());
             node->state = WaiterNode::State::Fulfilled;
             node->mapper = std::move(dm); // hand off ownership; _checkedOut stays (transferred)
             if (node->kind == WaiterNode::Kind::Async)
@@ -185,6 +188,7 @@ class Pool
             node->cv.notify_one(); // wake the blocked Acquire(); it consumes node->mapper
             return nullptr;
         }
+        SqlLogger::GetLogger().OnConnectionIdle(dm->Connection());
         _idleDataMappers.push_back(std::move(dm));
         --_checkedOut;
         return nullptr;
@@ -197,7 +201,10 @@ class Pool
         DropAsyncBackend(*dm);
         std::scoped_lock lock(_mutex);
         if (_idleDataMappers.size() < Config.maxSize)
+        {
+            SqlLogger::GetLogger().OnConnectionIdle(dm->Connection());
             _idleDataMappers.push_back(std::move(dm));
+        }
     }
 
   public:
@@ -246,6 +253,7 @@ class Pool
             auto dm = std::move(_idleDataMappers.back());
             _idleDataMappers.pop_back();
             ++_checkedOut;
+            SqlLogger::GetLogger().OnConnectionReuse(dm->Connection());
             return PooledDataMapper(*this, std::move(dm));
         }
         if (_checkedOut < Config.maxSize)
@@ -279,6 +287,7 @@ class Pool
         // get a data mapper from the pool
         auto dm = std::move(_idleDataMappers.back());
         _idleDataMappers.pop_back();
+        SqlLogger::GetLogger().OnConnectionReuse(dm->Connection());
         return PooledDataMapper(*this, std::move(dm));
     }
 
@@ -476,6 +485,7 @@ class Pool
                 pool._idleDataMappers.pop_back();
                 if constexpr (Config.growthStrategy == GrowthStrategy::BoundedWait)
                     ++pool._checkedOut;
+                SqlLogger::GetLogger().OnConnectionReuse(acquired->Connection());
                 return false; // do not suspend — resume immediately
             }
             // Only BoundedWait bounds the pool and parks coroutines on exhaustion. The non-blocking

--- a/src/tests/Async/AsyncPoolTests.cpp
+++ b/src/tests/Async/AsyncPoolTests.cpp
@@ -14,6 +14,7 @@
 #include <Lightweight/DataMapper/DataMapper.hpp>
 #include <Lightweight/DataMapper/Pool.hpp>
 #include <Lightweight/Lightweight.hpp>
+#include <Lightweight/SqlLogger.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -24,6 +25,48 @@
 
 using namespace Lightweight;
 using namespace Lightweight::Async;
+
+namespace
+{
+
+/// Counts SqlLogger::OnConnectionIdle / OnConnectionReuse invocations, leaving every other hook a no-op.
+class CapturingConnectionLogger: public SqlLogger::Null
+{
+  public:
+    int idleCount = 0;
+    int reuseCount = 0;
+
+    void OnConnectionIdle(SqlConnection const& /*connection*/) override
+    {
+        ++idleCount;
+    }
+    void OnConnectionReuse(SqlConnection const& /*connection*/) override
+    {
+        ++reuseCount;
+    }
+};
+
+/// RAII helper that installs a replacement SqlLogger for the scope's lifetime and restores the
+/// previous one on destruction, mirroring the pattern used in SqlLoggerTests.cpp.
+struct LoggerSwap
+{
+    SqlLogger* previous;
+    explicit LoggerSwap(SqlLogger& replacement):
+        previous { &SqlLogger::GetLogger() }
+    {
+        SqlLogger::SetLogger(replacement);
+    }
+    ~LoggerSwap()
+    {
+        SqlLogger::SetLogger(*previous);
+    }
+    LoggerSwap(LoggerSwap const&) = delete;
+    LoggerSwap& operator=(LoggerSwap const&) = delete;
+    LoggerSwap(LoggerSwap&&) = delete;
+    LoggerSwap& operator=(LoggerSwap&&) = delete;
+};
+
+} // namespace
 
 TEST_CASE_METHOD(SqlTestFixture, "Async.Pool: AcquireAsync acquires, queries and returns", "[Async][Pool]")
 {
@@ -236,4 +279,103 @@ TEST_CASE_METHOD(SqlTestFixture,
     // The sync waiter's released mapper fulfilled the async waiter; drive its resumption to finish cleanly.
     appLoop.Drain();
     REQUIRE(asyncTask.IsReady());
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "Pool: Return() reports an idled mapper via SqlLogger::OnConnectionIdle", "[Pool]")
+{
+    CapturingConnectionLogger capture;
+    LoggerSwap const swap { capture };
+
+    // initialSize = 0 so Acquire() below constructs a fresh mapper rather than reusing a pre-populated one.
+    auto pool = Pool<PoolConfig { .initialSize = 0, .maxSize = 4, .growthStrategy = GrowthStrategy::BoundedOverflow }>();
+    CHECK(capture.idleCount == 0);
+
+    {
+        auto mapper = pool.Acquire();
+        CHECK(capture.idleCount == 0);
+        CHECK(capture.reuseCount == 0); // fresh construction, not a reuse
+    } // returned here -> parked back into the idle list (no waiter to hand off to)
+
+    CHECK(capture.idleCount == 1);
+    CHECK(capture.reuseCount == 0);
+}
+
+TEST_CASE_METHOD(SqlTestFixture,
+                 "Pool: Acquire() reports handing back an idle mapper via SqlLogger::OnConnectionReuse",
+                 "[Pool]")
+{
+    CapturingConnectionLogger capture;
+    LoggerSwap const swap { capture };
+
+    // initialSize = 1 pre-populates one idle mapper, so this first Acquire() is already a reuse.
+    auto pool = Pool<PoolConfig { .initialSize = 1, .maxSize = 4, .growthStrategy = GrowthStrategy::BoundedOverflow }>();
+
+    {
+        auto mapper = pool.Acquire();
+    } // reuses the pre-populated mapper, then idles it again on return
+    CHECK(capture.idleCount == 1);
+    CHECK(capture.reuseCount == 1);
+
+    {
+        auto mapper = pool.Acquire();
+    } // reuses it again
+    CHECK(capture.reuseCount == 2);
+    CHECK(capture.idleCount == 2); // returned again -> idled a second time
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "Pool: Acquire() creating a fresh mapper does not report a reuse", "[Pool]")
+{
+    CapturingConnectionLogger capture;
+    LoggerSwap const swap { capture };
+
+    // initialSize = 0 so the very first Acquire() must construct a fresh DataMapper, not reuse one.
+    auto pool = Pool<PoolConfig { .initialSize = 0, .maxSize = 4, .growthStrategy = GrowthStrategy::BoundedOverflow }>();
+
+    auto mapper = pool.Acquire();
+    CHECK(capture.reuseCount == 0);
+}
+
+TEST_CASE_METHOD(SqlTestFixture,
+                 "Pool: BoundedWait idle-park path (ReturnLocked, no waiter) reports OnConnectionIdle",
+                 "[Pool]")
+{
+    CapturingConnectionLogger capture;
+    LoggerSwap const swap { capture };
+
+    auto pool = Pool<PoolConfig { .initialSize = 1, .maxSize = 1, .growthStrategy = GrowthStrategy::BoundedWait }>();
+
+    {
+        auto mapper = pool.Acquire();
+    } // no parked waiter -> ReturnLocked idles it
+
+    CHECK(capture.idleCount == 1);
+}
+
+TEST_CASE_METHOD(SqlTestFixture,
+                 "Pool: BoundedWait hand-off to a parked waiter is a reuse, not an idle transition",
+                 "[Pool]")
+{
+    ThreadPoolExecutor dbWorkers { 1 };
+    ManualExecutor appLoop;
+    CapturingConnectionLogger capture;
+    LoggerSwap const swap { capture };
+
+    auto pool = Pool<PoolConfig { .initialSize = 1, .maxSize = 1, .growthStrategy = GrowthStrategy::BoundedWait }>();
+
+    std::optional holder { pool.Acquire() }; // exhaust the pool: reuses the pre-populated mapper
+    CHECK(capture.idleCount == 0);
+    CHECK(capture.reuseCount == 1);
+
+    auto task = pool.AcquireAsync(dbWorkers, appLoop);
+    task.GetHandle().resume();     // park on the exhausted pool
+    REQUIRE_FALSE(task.IsReady()); // suspended (parked)
+
+    // Returning the held mapper hands it directly to the parked waiter (FIFO): a reuse, never an idle
+    // transition, since the mapper is never placed into _idleDataMappers.
+    holder.reset();
+    CHECK(capture.idleCount == 0);
+    CHECK(capture.reuseCount == 2);
+
+    appLoop.Drain();
+    REQUIRE(task.IsReady());
 }


### PR DESCRIPTION
## Summary

Fixes #548. `Pool<Config>::Acquire()`/`Return()` never called the already-declared `SqlLogger::OnConnectionIdle`/`OnConnectionReuse` hooks (`SqlLogger.hpp:79,82`), even though `OnConnectionOpened`/`OnConnectionClosed` already fire from `SqlConnection`'s own constructor/destructor. The pool's fresh-vs-reused and checked-out-vs-idle transitions were completely unobservable from an `SqlLogger` subclass.

## Root cause

`Pool<Config>` has multiple places that either hand a mapper back to a caller from `_idleDataMappers` (a **reuse**) or park a returned mapper into `_idleDataMappers` (an **idle** transition), and none of them called the corresponding `SqlLogger` hook:

- `Acquire()` (`BoundedWait` overload and the non-blocking overload) — pop-from-idle branch
- `AsyncAcquireAwaitable::await_suspend` — the non-suspending fast path that pops from `_idleDataMappers`
- `ReturnLocked` (`BoundedWait`) — both the hand-off-to-a-parked-waiter branch (a reuse, since the mapper never touches the idle list) and the no-waiter idle-park branch
- `Return()` for `UnboundedGrow` and `BoundedOverflow` — the idle-park branch

## Change

Added the corresponding `SqlLogger::GetLogger().OnConnectionReuse(...)`/`OnConnectionIdle(...)` call at each of the above sites, keyed on which list operation actually happens — not on the calling overload — so a direct hand-off to a waiter is logged as a reuse and never double-logged as idle-then-reused.

## Tests

Added `AsyncPoolTests.cpp`: a `CapturingConnectionLogger` (extends `SqlLogger::Null`) counting `OnConnectionIdle`/`OnConnectionReuse` calls, installed via the existing `LoggerSwap` RAII pattern. New cases cover:
- `Return()` idling a fresh mapper (`BoundedOverflow`)
- `Acquire()` reusing a pre-populated/idled mapper vs. constructing fresh
- `BoundedWait`'s `ReturnLocked` idle-park path (no waiter)
- `BoundedWait`'s hand-off-to-a-parked-waiter path (asserts it's a reuse, not an idle transition)

All new tests fail without the fix (confirmed before applying it) and pass after.

## Databases tested
- `sqlite3` — 1392/1393 passed, 1 skipped, 13488 assertions
- `mssql2022` (Docker, `mcr.microsoft.com/mssql/server:2022-latest`) — 1390/1393 passed, 3 skipped, 13462 assertions
- `postgres` (Docker, `postgres:16.4`) — 1391/1393 passed, 2 skipped, 13416 assertions

## Compilers tested
- `cl-release` (MSVC) only — this environment has no GCC/Clang toolchain (Windows-only, no WSL/MinGW), so `gcc-release` and `clang-debug`/clang-tidy from AGENT.md's checklist could not be run locally. CI will cover those legs.

## Performance impact
None expected: each new call is a single virtual dispatch through the existing `SqlLogger` singleton (already used identically for `OnConnectionOpened`/`OnConnectionClosed`/`OnWarning`), on the pool's acquire/return path which already does mutex work; the default `SqlLogger::Null` hooks are no-ops.

## Risk assessment
Low. No behavior change to pool semantics (growth strategy, FIFO fairness, checked-out counting) — purely additive observability calls on paths already covered by existing tests, which all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)