### PR TITLE
build: decouple public headers from <Windows.h>, using a minimal ODBC prelude

### DIFF
--- a/src/Lightweight/DataBinder/Core.hpp
+++ b/src/Lightweight/DataBinder/Core.hpp
@@ -2,17 +2,9 @@
 
 #pragma once
 
-#if defined(_WIN32) || defined(_WIN64)
-    #ifndef NOMINMAX
-        #define NOMINMAX
-    #endif
-    #ifndef WIN32_LEAN_AND_MEAN
-        #define WIN32_LEAN_AND_MEAN
-    #endif
-    #include <Windows.h>
-#endif
-
+// See SqlOdbcPrelude.hpp's header comment for why this replaces a direct <Windows.h> include.
 #include "../Api.hpp"
+#include "../SqlOdbcPrelude.hpp"
 #include "../SqlServerType.hpp"
 
 #include <concepts>

--- a/src/Lightweight/SqlColumnTypeDefinitions.hpp
+++ b/src/Lightweight/SqlColumnTypeDefinitions.hpp
@@ -2,15 +2,8 @@
 
 #pragma once
 
-#if defined(_WIN32) || defined(_WIN64)
-    #ifndef NOMINMAX
-        #define NOMINMAX
-    #endif
-    #ifndef WIN32_LEAN_AND_MEAN
-        #define WIN32_LEAN_AND_MEAN
-    #endif
-    #include <Windows.h>
-#endif
+// See SqlOdbcPrelude.hpp's header comment for why this replaces a direct <Windows.h> include.
+#include "SqlOdbcPrelude.hpp"
 
 #include <cstdint>
 #include <optional>

--- a/src/Lightweight/SqlConnection.hpp
+++ b/src/Lightweight/SqlConnection.hpp
@@ -2,21 +2,13 @@
 
 #pragma once
 
-#if defined(_WIN32) || defined(_WIN64)
-    #ifndef NOMINMAX
-        #define NOMINMAX
-    #endif
-    #ifndef WIN32_LEAN_AND_MEAN
-        #define WIN32_LEAN_AND_MEAN
-    #endif
-    #include <Windows.h>
-#endif
-
+// See SqlOdbcPrelude.hpp's header comment for why this replaces a direct <Windows.h> include.
 #include "Api.hpp"
 #include "Async/Fwd.hpp"
 #include "SqlConnectInfo.hpp"
 #include "SqlError.hpp"
 #include "SqlLogger.hpp"
+#include "SqlOdbcPrelude.hpp"
 #include "SqlServerType.hpp"
 
 #include <atomic>

--- a/src/Lightweight/SqlError.hpp
+++ b/src/Lightweight/SqlError.hpp
@@ -2,17 +2,9 @@
 
 #pragma once
 
-#if defined(_WIN32) || defined(_WIN64)
-    #ifndef NOMINMAX
-        #define NOMINMAX
-    #endif
-    #ifndef WIN32_LEAN_AND_MEAN
-        #define WIN32_LEAN_AND_MEAN
-    #endif
-    #include <Windows.h>
-#endif
-
+// See SqlOdbcPrelude.hpp's header comment for why this replaces a direct <Windows.h> include.
 #include "Api.hpp"
+#include "SqlOdbcPrelude.hpp"
 
 #include <cstdint>
 #include <format>

--- a/src/Lightweight/SqlOdbcPrelude.hpp
+++ b/src/Lightweight/SqlOdbcPrelude.hpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// This header exists so that every Lightweight header needing <sql.h>/<sqlext.h>/<sqlspi.h>/
+// <sqltypes.h> on Windows can include *this* instead of the full <Windows.h> SDK aggregate.
+//
+// Investigation (see https://github.com/LASTRADA-Software/Lightweight/issues/547): the Windows
+// ODBC headers are not self-contained. <sqltypes.h> unconditionally declares
+// `typedef HWND SQLHWND;` on WIN32 (needed only so ODBC's connection-prompt APIs can carry an
+// optional owner window — Lightweight always passes `(SQLHWND) nullptr`, see
+// SqlConnection.cpp's SQLDriverConnectW call, and never dereferences it), and `typedef GUID
+// SQLGUID;` guarded by GUID_DEFINED. <sqlext.h>'s legacy, Windows-8-removed Visual-Studio-tracing
+// section (ODBC_VS_ARGS/FireVSDebugEvent) additionally references BOOL/DWORD/VOID/WCHAR/CHAR/
+// LPWSTR. None of these are otherwise used by Lightweight (grep confirms: only prose comments and
+// the library's own distinct SqlGuid type mention "GUID"); previously the full <Windows.h>
+// prelude was pulled in just so the *parser* could get past these unconditional declarations.
+//
+// Below are the minimal, ABI-stable shapes the Windows SDK's own headers use internally for these
+// symbols (HWND from <um/winuser.h>'s DECLARE_HANDLE expansion; GUID from <shared/guiddef.h>;
+// the rest from <shared/minwindef.h>/<shared/winnt.h>). Defining them here — rather than
+// including <Windows.h> — avoids pulling in the ~150k-line SDK aggregate (macro pollution beyond
+// min/max, compile-time cost, and the ODR/ABI surface of everything Windows.h drags in) while
+// still letting <sql.h> and friends parse.
+//
+// @warning These typedefs must stay byte-identical to the Windows SDK's own definitions: if a
+// consumer's translation unit also includes <Windows.h> (directly or transitively) after this
+// header, the two must be identical or the second one is a hard redefinition error. If a future
+// Windows SDK version adds a new symbol reference to a deprecated/legacy section of <sql.h>/
+// <sqlext.h>/<sqlspi.h>/<sqltypes.h> that isn't covered below, the fix is to extend this file with
+// that symbol's own minimal shape — not to fall back to <Windows.h>.
+#if defined(_WIN32) || defined(_WIN64)
+
+    // Guards <Windows.h>'s own min/max function-like macros from leaking into every consumer TU
+    // that includes this header (directly or transitively) and breaking any later std::min/
+    // std::max/std::numeric_limits<T>::min()/max() call in the same TU (#542). These only take
+    // effect if the consumer later includes the real <Windows.h> themselves; defined only if not
+    // already picked, so an application-wide override still wins.
+    #ifndef NOMINMAX
+        #define NOMINMAX
+    #endif
+    #ifndef WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
+    #endif
+
+// HWND has no symbol-level include guard in the real SDK (only windef.h's own file guard), but
+// a repeated identical forward-declaration + typedef is legal C++, so this is safe even if a
+// consumer's TU later includes the real <Windows.h> too.
+struct HWND__;
+typedef struct HWND__* HWND; // NOLINT(modernize-use-using): mirrors <um/windef.h>'s own typedef.
+
+    #ifndef GUID_DEFINED
+        #define GUID_DEFINED
+typedef struct _GUID // NOLINT(modernize-use-using): mirrors <shared/guiddef.h>'s own typedef.
+{
+    unsigned long Data1;
+    unsigned short Data2;
+    unsigned short Data3;
+    unsigned char Data4[8];
+} GUID;
+    #endif
+
+    #ifndef _MINWINDEF_SHIM_DEFINED
+        #define _MINWINDEF_SHIM_DEFINED
+using BOOL = int;
+using DWORD = unsigned long;
+using WCHAR = wchar_t;
+using LPWSTR = WCHAR*;
+    #endif
+
+    // <um/winnt.h> gates VOID/CHAR/SHORT/LONG/INT as ONE atomic bundle behind a single
+    // `#ifndef VOID` (not one guard per symbol): defining VOID alone here would make a later
+    // real <Windows.h> skip the whole bundle's #ifndef body, silently leaving CHAR/SHORT/LONG/INT
+    // undefined — which is exactly what broke winnt.h's PLONG-using interlocked-intrinsics section
+    // (#547). Reproduce the full bundle atomically so a later winnt.h's #ifndef VOID correctly
+    // finds everything already defined and skips cleanly, instead of partially pre-empting it.
+    #ifndef VOID
+        #define VOID void
+using CHAR = char;
+using SHORT = short;
+using LONG = long;
+        #if !defined(MIDL_PASS)
+using INT = int;
+        #endif
+    #endif
+
+    #include <basetsd.h>
+    #include <sal.h>
+    #include <winapifamily.h>
+#endif

--- a/src/Lightweight/SqlOdbcWide.hpp
+++ b/src/Lightweight/SqlOdbcWide.hpp
@@ -2,18 +2,9 @@
 
 #pragma once
 
-// <sql.h> below needs the Windows prelude established first — see the note in Utils.hpp.
-#if defined(_WIN32) || defined(_WIN64)
-    #ifndef NOMINMAX
-        #define NOMINMAX
-    #endif
-    #ifndef WIN32_LEAN_AND_MEAN
-        #define WIN32_LEAN_AND_MEAN
-    #endif
-    #include <Windows.h>
-#endif
-
+// <sql.h> below needs a few symbols resolved first — see SqlOdbcPrelude.hpp's header comment.
 #include "DataBinder/UnicodeConverter.hpp"
+#include "SqlOdbcPrelude.hpp"
 
 #include <string>
 #include <string_view>

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -2,16 +2,7 @@
 
 #pragma once
 
-#if defined(_WIN32) || defined(_WIN64)
-    #ifndef NOMINMAX
-        #define NOMINMAX
-    #endif
-    #ifndef WIN32_LEAN_AND_MEAN
-        #define WIN32_LEAN_AND_MEAN
-    #endif
-    #include <Windows.h>
-#endif
-
+// See SqlOdbcPrelude.hpp's header comment for why this replaces a direct <Windows.h> include.
 #include "Api.hpp"
 #include "DataBinder/Core.hpp"
 #include "DataBinder/SqlDate.hpp"
@@ -23,6 +14,7 @@
 #include "DataBinder/UnicodeConverter.hpp"
 #include "DataMapper/Record.hpp"
 #include "SqlConnection.hpp"
+#include "SqlOdbcPrelude.hpp"
 #include "SqlQuery.hpp"
 #include "SqlQueryFormatter.hpp"
 #include "SqlServerType.hpp"

--- a/src/Lightweight/SqlTransaction.hpp
+++ b/src/Lightweight/SqlTransaction.hpp
@@ -2,18 +2,10 @@
 
 #pragma once
 
-#if defined(_WIN32) || defined(_WIN64)
-    #ifndef NOMINMAX
-        #define NOMINMAX
-    #endif
-    #ifndef WIN32_LEAN_AND_MEAN
-        #define WIN32_LEAN_AND_MEAN
-    #endif
-    #include <Windows.h>
-#endif
-
+// See SqlOdbcPrelude.hpp's header comment for why this replaces a direct <Windows.h> include.
 #include "SqlConnection.hpp"
 #include "SqlError.hpp"
+#include "SqlOdbcPrelude.hpp"
 
 #include <format>
 #include <source_location>

--- a/src/Lightweight/Utils.hpp
+++ b/src/Lightweight/Utils.hpp
@@ -2,28 +2,15 @@
 
 #pragma once
 
-// <sql.h> below is not self-contained on Windows: the SDK's <sqltypes.h> resolves SQLLEN/SQLULEN/
-// SQLHWND/GUID against the Windows prelude, so <Windows.h> has to come first. Every other header
-// here that reaches an ODBC header opens with the same block; without it this header would only
-// compile when some other header happened to establish the prelude earlier in the translation unit.
-//
-// NOMINMAX/WIN32_LEAN_AND_MEAN guard <Windows.h>'s own min/max function-like macros from leaking
-// into every consumer TU that includes this header (directly or transitively) and breaking any
-// later std::min/std::max/std::numeric_limits<T>::min()/max() call in the same TU (#542). Defined
-// only if the consumer hasn't already picked a value, so an application-wide override still wins.
-#if defined(_WIN32) || defined(_WIN64)
-    #ifndef NOMINMAX
-        #define NOMINMAX
-    #endif
-    #ifndef WIN32_LEAN_AND_MEAN
-        #define WIN32_LEAN_AND_MEAN
-    #endif
-    #include <Windows.h>
-#endif
-
+// <sql.h> below is not self-contained on Windows: the SDK's <sqltypes.h> resolves a handful of
+// symbols (SQLHWND/GUID/etc.) against the Windows prelude. SqlOdbcPrelude.hpp supplies minimal,
+// ABI-stable shims for exactly those symbols instead of pulling in the full <Windows.h> aggregate
+// — see its header comment for the rationale (#547). Every other header here that reaches an ODBC
+// header opens with the same include.
 #include "Api.hpp"
 #include "Description.hpp"
 #include "SqlError.hpp"
+#include "SqlOdbcPrelude.hpp"
 
 #include <reflection-cpp/reflection.hpp>
 


### PR DESCRIPTION
## Summary

Closes #547. The 8 public headers that need `<sql.h>`/`<sqlext.h>`/`<sqlspi.h>`/`<sqltypes.h>` on Windows previously pulled in the full `<Windows.h>` SDK aggregate purely to satisfy those ODBC headers' non-self-contained prelude requirements, exposing every consumer to `Windows.h`'s macro pollution (beyond `min`/`max`), compile-time cost, and ODR/ABI surface — the concern the issue raised.

## Investigation findings

Compiling `<sql.h>`/`<sqlext.h>`/`<sqlspi.h>`/`<sqltypes.h>` in isolation with `cl.exe` (verified directly, not just read) showed they only need `<sal.h>`/`<basetsd.h>`/`<winapifamily.h>` plus a handful of symbols the *parser* requires but Lightweight itself never uses:

- **`SQLHWND`** — `<sqltypes.h>` unconditionally declares `typedef HWND SQLHWND;` on WIN32, needed only so ODBC's connection-prompt APIs can carry an optional owner window. Lightweight always passes `(SQLHWND) nullptr` (`SqlConnection.cpp`'s `SQLDriverConnectW` call) and never dereferences it.
- **`SQLGUID`** — `typedef GUID SQLGUID;` guarded by `GUID_DEFINED`. Grep confirms only prose comments and Lightweight's own distinct `SqlGuid` type ever mention "GUID" — the Windows `GUID` type itself is unused.
- **`BOOL`/`DWORD`/`VOID`/`WCHAR`/`CHAR`/`LPWSTR`** — referenced only by `<sqlext.h>`'s legacy, Windows-8-removed Visual-Studio-tracing section (`ODBC_VS_ARGS`/`FireVSDebugEvent`).

This resolves the `SQL_DATE_STRUCT`/inlining concern from the issue's "known obstacle" section: `SQL_DATE_STRUCT`/`SQL_TIME_STRUCT`/`SQL_TIMESTAMP_STRUCT` are trivial integer-only PODs with **no** Windows dependency at all — they just happen to live in the same monolithic header as the `HWND`/`GUID`-needing declarations. No `.cpp` extraction or loss of `LIGHTWEIGHT_FORCE_INLINE` on the hot binder paths was needed.

## Change

New `src/Lightweight/SqlOdbcPrelude.hpp` supplies minimal, ABI-stable shapes for exactly those symbols instead of `<Windows.h>`. Every affected header now includes it instead of the repeated `<Windows.h>` block:

- `Utils.hpp`, `DataBinder/Core.hpp`, `SqlColumnTypeDefinitions.hpp`, `SqlConnection.hpp`, `SqlError.hpp`, `SqlOdbcWide.hpp`, `SqlStatement.hpp`, `SqlTransaction.hpp`

`SqlDate.hpp`/`SqlDateTime.hpp`/`SqlTime.hpp`/`SqlRawColumn.hpp` and `SqlBackup/ChunkPlanner.hpp` (the issue's 5 "transitive dependency" headers) needed **no direct changes** — they only reach the ODBC headers transitively through `Core.hpp`/`SqlColumnTypeDefinitions.hpp`, which now go through the prelude.

## A real hazard, found and fixed during verification

An earlier version of this patch defined `VOID` alone as `#define VOID void`. That broke the build: `<um/winnt.h>` gates `VOID`/`CHAR`/`SHORT`/`LONG`/`INT` as **one atomic bundle** behind a single `#ifndef VOID` — not one guard per symbol. Predefining `VOID` alone made a transitively-included real `<Windows.h>` (pulled in via a third-party dependency inside `SqlBackup.cpp`, not Lightweight's own code) skip the whole bundle's `#ifndef` body, silently leaving `LONG` undefined and breaking `winnt.h`'s `PLONG`-using interlocked-intrinsics section with cascading syntax errors 9000+ lines later in the file.

The prelude now reproduces the full bundle atomically. Verified by:
1. Compiling the prelude standalone with all 4 ODBC headers (clean, `/W4`, zero warnings).
2. Compiling it combined with a later real `<Windows.h>` in **both** orders (prelude-then-Windows.h and Windows.h-then-prelude) — both clean.
3. Rebuilding the whole project (library + tests + `dbtool` + `ddl2cpp`) and confirming `SqlBackup.cpp` (the file that broke) compiles.

## Tests

No new automated tests were added — this is a header-restructuring change with no observable runtime behavior difference; correctness is verified by the full existing suite compiling and passing unchanged (see below), plus the standalone/combined ODBC-header compile checks above documented in `SqlOdbcPrelude.hpp`'s own comments for future maintainers.

## Databases tested
- `sqlite3` — 1387/1388 passed, 1 skipped, 13466 assertions
- `mssql2022` (Docker, `mcr.microsoft.com/mssql/server:2022-latest`) — 1385/1388 passed, 3 skipped, 13440 assertions
- `postgres` (Docker, `postgres:16.4`) — 1386/1388 passed, 2 skipped, 13394 assertions
- `dbtool` integration suite (`test_dbtool.py`) — SUCCESS on all three databases above

## Compilers tested
- `cl-release` (MSVC) only — this environment has no GCC/Clang toolchain (Windows-only, no WSL/MinGW). `gcc-release`, `clang-debug`/clang-tidy, the C++20 modules build (Linux-only per `CMakePresets.json`), and the C++26 reflection build could not be run locally; CI will cover those legs. Note this change touches only Windows-specific `#if defined(_WIN32) || defined(_WIN64)` code paths — non-Windows builds (`gcc-release`, `clang-debug`, etc.) are textually unaffected by this diff, since the entire prelude body is inside that guard.

## Performance impact
None expected on non-Windows builds (unaffected). On Windows: potential *positive* compile-time impact (no longer parsing the ~150k-line `<Windows.h>` aggregate in every TU that includes one of these 8 headers), not measured precisely in this PR. No runtime impact — this is header-only restructuring; the binder hot paths keep their existing `LIGHTWEIGHT_FORCE_INLINE`.

## Risk assessment
**Medium**, given the atomic-bundle hazard this PR itself uncovered and fixed. Mitigations:
- `SqlOdbcPrelude.hpp` documents the constraint prominently (`@warning` block) so a future contributor extending it for a new SDK-version-introduced symbol knows to check for sibling bundling before adding a lone `#define`/`typedef`.
- Verified in both include orders combined with a real `<Windows.h>`, not just in isolation.
- Confined entirely to `#if defined(_WIN32) || defined(_WIN64)` — zero risk to Linux/macOS builds.
- Full test suite green on all 3 databases plus the dbtool integration suite.

## Follow-ups
- CI should run `gcc-release`/`clang-debug`/the C++20-modules leg/C++26-reflection leg on this branch to confirm no incidental regression (expected: none, since the diff is Windows-guarded) — could not be verified locally on this Windows-only environment.
- Compile-time improvement is plausible but unmeasured; a future PR could add a `src/benchmark/`-style build-time comparison if that's of interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)