### PR TITLE
fix(QueryFormatter): place DISTINCT before the field list in SelectFirst/SelectRange

### DIFF
--- a/src/Lightweight/QueryFormatter/SQLiteFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/SQLiteFormatter.hpp
@@ -184,9 +184,10 @@ class SQLiteQueryFormatter: public SqlQueryFormatter
                                           size_t count) const override
     {
         std::stringstream sqlQueryString;
-        sqlQueryString << "SELECT " << fields;
+        sqlQueryString << "SELECT ";
         if (distinct)
-            sqlQueryString << " DISTINCT";
+            sqlQueryString << "DISTINCT ";
+        sqlQueryString << fields;
         sqlQueryString << " FROM " << FormatFromTable(fromTable);
         if (!fromTableAlias.empty())
             sqlQueryString << " AS \"" << fromTableAlias << "\"";
@@ -210,9 +211,10 @@ class SQLiteQueryFormatter: public SqlQueryFormatter
                                           std::size_t limit) const override
     {
         std::stringstream sqlQueryString;
-        sqlQueryString << "SELECT " << fields;
+        sqlQueryString << "SELECT ";
         if (distinct)
-            sqlQueryString << " DISTINCT";
+            sqlQueryString << "DISTINCT ";
+        sqlQueryString << fields;
         sqlQueryString << " FROM " << FormatFromTable(fromTable);
         if (!fromTableAlias.empty())
             sqlQueryString << " AS \"" << fromTableAlias << "\"";

--- a/src/Lightweight/QueryFormatter/SqlServerFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/SqlServerFormatter.hpp
@@ -302,9 +302,10 @@ EXEC sp_executesql @sql;)",
     {
         assert(!orderBy.empty());
         std::stringstream sqlQueryString;
-        sqlQueryString << "SELECT " << fields;
+        sqlQueryString << "SELECT ";
         if (distinct)
-            sqlQueryString << " DISTINCT";
+            sqlQueryString << "DISTINCT ";
+        sqlQueryString << fields;
         sqlQueryString << " FROM " << FormatFromTable(fromTable);
         if (!fromTableAlias.empty())
             sqlQueryString << " AS [" << fromTableAlias << ']';

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -132,6 +132,36 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.Distinct.All", "[SqlQue
                                ORDER BY "b" ASC)"));
 }
 
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.Distinct.First", "[SqlQueryBuilder]")
+{
+    CheckSqlQueryBuilder(
+        [](SqlQueryBuilder& q) { return q.FromTable("That").Select().Distinct().Field("field1").OrderBy("id").First(); },
+        QueryExpectations {
+            .sqlite = R"(SELECT DISTINCT "field1" FROM "That"
+                         ORDER BY "id" ASC LIMIT 1)",
+            .postgres = R"(SELECT DISTINCT "field1" FROM "That"
+                           ORDER BY "id" ASC LIMIT 1)",
+            .sqlServer = R"(SELECT DISTINCT TOP 1 "field1" FROM "That"
+                            ORDER BY "id" ASC)",
+        });
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.Distinct.Range", "[SqlQueryBuilder]")
+{
+    CheckSqlQueryBuilder(
+        [](SqlQueryBuilder& q) {
+            return q.FromTable("That").Select().Distinct().Fields("foo", "bar").OrderBy("id").Range(200, 50);
+        },
+        QueryExpectations {
+            .sqlite = R"(SELECT DISTINCT "foo", "bar" FROM "That"
+                         ORDER BY "id" ASC LIMIT 50 OFFSET 200)",
+            .postgres = R"(SELECT DISTINCT "foo", "bar" FROM "That"
+                           ORDER BY "id" ASC LIMIT 50 OFFSET 200)",
+            .sqlServer = R"(SELECT DISTINCT "foo", "bar" FROM "That"
+                            ORDER BY "id" ASC OFFSET 200 ROWS FETCH NEXT 50 ROWS ONLY)",
+        });
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.OrderBy fully qualified", "[SqlQueryBuilder]")
 {
     CheckSqlQueryBuilder(


### PR DESCRIPTION
Fixes #558.

## Problem

`DISTINCT` was appended *after* the field list in three formatter methods, producing

```sql
SELECT "a" DISTINCT FROM "T"
```

which is invalid SQL on every supported backend. `PostgreSqlFormatter` derives from
`SQLiteQueryFormatter` and overrides neither method, so **SQLite, PostgreSQL and SQL Server**
were all affected, for both `.First()` and `.Range()`.

## Change

Reordered three sites so `DISTINCT` directly follows `SELECT`, matching the already-correct
`SQLiteQueryFormatter::SelectAll` and `SqlServerQueryFormatter::SelectFirst`:

- `QueryFormatter/SQLiteFormatter.hpp` — `SelectFirst`
- `QueryFormatter/SQLiteFormatter.hpp` — `SelectRange`
- `QueryFormatter/SqlServerFormatter.hpp` — `SelectRange`

No signature or behaviour change beyond the emitted SQL text.

## Why CI did not catch it

Every existing `Distinct()` test terminated in `.All()` — the one code path that was correct
(`QueryBuilderTests.cpp:127`, `DocExampleTests.cpp:285`, `DataMapper/MiscTests.cpp:666`).

## Test evidence

Two new cases in `src/tests/QueryBuilderTests.cpp`. `CheckSqlQueryBuilder` runs each against
all three formatters, so one case per terminator covers the whole matrix.

**Before the fix — failing:**

```
-------------------------------------------------------------------------------
SqlQueryBuilder.Select.Distinct.First
-------------------------------------------------------------------------------
QueryBuilderTests.cpp:56: FAILED:
  REQUIRE( actual == expected )
with expansion:
  "SELECT "field1" DISTINCT FROM "That"
  ORDER BY "id" ASC LIMIT 1"
  ==
  "SELECT DISTINCT "field1" FROM "That"
  ORDER BY "id" ASC LIMIT 1"

-------------------------------------------------------------------------------
SqlQueryBuilder.Select.Distinct.Range
-------------------------------------------------------------------------------
QueryBuilderTests.cpp:56: FAILED:
  REQUIRE( actual == expected )
with expansion:
  "SELECT "foo", "bar" DISTINCT FROM "That"
  ORDER BY "id" ASC LIMIT 50 OFFSET 200"
  ==
  "SELECT DISTINCT "foo", "bar" FROM "That"
  ORDER BY "id" ASC LIMIT 50 OFFSET 200"

test cases: 3 | 1 passed | 2 failed
assertions: 8 | 6 passed | 2 failed
```

**After the fix — passing:**

```
Filters: "SqlQueryBuilder.Select.Distinct.*"
All tests passed (12 assertions in 3 test cases)
```

## Full suite

| Backend | Result |
|---|---|
| sqlite3 | 1396 cases, 1395 passed, 1 skipped — 13602 assertions passed |
| mssql2022 (Docker, `mcr.microsoft.com/mssql/server:2022-latest`) | 1396 cases, 1393 passed, 3 skipped — 13574 assertions passed |
| postgres (Docker, `postgres:16.4`) | 1396 cases, 1394 passed, 2 skipped — 13527 assertions passed |

Skips are pre-existing `UNSUPPORTED_DATABASE` cases, unrelated to this change.

**Compiler:** `clang-debug` only (PEDANTIC + ASan/UBSan + clang-tidy). AGENT.md also asks for a
`gcc-release` run because CI's database legs execute a GCC build — no gcc preset exists for macOS
in `CMakePresets.json`, so that check was not run locally and is left to CI.

## Risk

Low. Pure SQL-text reordering in three formatter methods; no API, ABI or signature change. The
previous output was rejected by every driver, so no caller can have depended on it.

## Performance

None.
