### PR TITLE
fix(DataMapper): guard Update() against empty SET and missing primary key

### DIFF
--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -2009,6 +2009,11 @@ void DataMapper::Update(Record& record)
 
     auto query = _connection.Query(RecordTableName<Record>).Update();
 
+    // Tracks whether the fold below contributed at least one assignment to the SET clause.
+    // With no assignments the formatter would emit `UPDATE "T" SET  WHERE ...`, which every
+    // driver rejects as a syntax error, so we skip the statement entirely instead.
+    bool anyFieldModified = false;
+
 #if defined(LIGHTWEIGHT_CXX26_REFLECTION)
     auto constexpr ctx = std::meta::access_context::current();
     template for (constexpr auto el: define_static_array(nonstatic_data_members_of(^^Record, ctx)))
@@ -2017,13 +2022,16 @@ void DataMapper::Update(Record& record)
         if constexpr (FieldWithStorage<FieldType>)
         {
             if (record.[:el:].IsModified())
+            {
                 query.Set(FieldNameOf<el>, SqlWildcard);
+                anyFieldModified = true;
+            }
             if constexpr (IsPrimaryKey<FieldType>)
                 std::ignore = query.Where(FieldNameOf<el>, SqlWildcard);
         }
     }
 #else
-    EnumerateRecordMembers(record, [&query]<size_t I, typename FieldType>(FieldType const& field) {
+    EnumerateRecordMembers(record, [&query, &anyFieldModified]<size_t I, typename FieldType>(FieldType const& field) {
         // for some reason compiler do not want to properly deduce FieldType, so here we
         // directly infer the type from the Record type and index
         using MemberType = RecordMemberTypeOf<I, Record>;
@@ -2031,12 +2039,20 @@ void DataMapper::Update(Record& record)
         if constexpr (FieldWithStorage<MemberType>)
         {
             if (field.IsModified())
+            {
                 query.Set(FieldNameAt<I, Record>, SqlWildcard);
+                anyFieldModified = true;
+            }
             if constexpr (IsPrimaryKey<MemberType>)
                 std::ignore = query.Where(FieldNameAt<I, Record>, SqlWildcard);
         }
     });
 #endif
+
+    // Nothing to write: an UPDATE with an empty SET clause is a no-op by definition.
+    if (!anyFieldModified)
+        return;
+
     _stmt.Prepare(query);
 
     SQLSMALLINT i = 1;

--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -442,11 +442,19 @@ class DataMapper
     /// Updates the record in the database.
     ///
     /// Only fields that have been modified since the record was last loaded or saved are written.
-    /// Fields that were not changed are excluded from the UPDATE statement.
+    /// Fields that were not changed are excluded from the UPDATE statement. If no field is
+    /// modified, the call is a no-op and no statement is executed.
     ///
-    /// @tparam Record The record type to update.
+    /// The record type must have a primary key: the WHERE clause is built exclusively from the
+    /// primary-key fields, so a record without one would produce an UPDATE with no WHERE clause
+    /// and rewrite every row of the table. Use the query builder's Update() with an explicit
+    /// WHERE clause when you need to update a table that has no primary key. UpdateAll() carries
+    /// the same requirement.
+    ///
+    /// @tparam Record The record type to update. Must have a primary key.
     /// @param record  The record to update. Only its modified fields are written to the database.
     template <typename Record>
+        requires HasPrimaryKey<Record>
     void Update(Record& record);
 
     /// @brief Batch-updates a span of records with a single prepared statement.
@@ -2000,6 +2008,7 @@ bool DataMapper::IsModified(Record const& record) const noexcept
 }
 
 template <typename Record>
+    requires HasPrimaryKey<Record>
 void DataMapper::Update(Record& record)
 {
     static_assert(DataMapperRecord<Record>, "Record must satisfy DataMapperRecord");

--- a/src/tests/DataMapper/StateTests.cpp
+++ b/src/tests/DataMapper/StateTests.cpp
@@ -87,6 +87,8 @@ TEST_CASE_METHOD(SqlTestFixture, "DataMapper::Update with no modified fields is 
 
     auto const reloaded = dm.QuerySingle<Person>(person.id);
     REQUIRE(reloaded.has_value());
+    if (!reloaded.has_value())
+        return;
     CHECK(reloaded->name.Value() == person.name.Value());
     CHECK(reloaded->age.Value() == person.age.Value());
 }
@@ -101,10 +103,13 @@ TEST_CASE_METHOD(SqlTestFixture, "DataMapper::Update after a fetch with no chang
 
     auto fetched = dm.QuerySingle<Person>(seed.id);
     REQUIRE(fetched.has_value());
-    REQUIRE_FALSE(dm.IsModified(*fetched));
+    if (!fetched.has_value())
+        return;
+    auto& record = *fetched;
+    REQUIRE_FALSE(dm.IsModified(record));
 
     // A fetched-but-untouched record has every dirty flag cleared, same empty-SET situation.
-    REQUIRE_NOTHROW(dm.Update(*fetched));
+    REQUIRE_NOTHROW(dm.Update(record));
 }
 
 TEST_CASE_METHOD(SqlTestFixture, "DataMapper::IsModified is false for a freshly-fetched record", "[DataMapper]")

--- a/src/tests/DataMapper/StateTests.cpp
+++ b/src/tests/DataMapper/StateTests.cpp
@@ -45,6 +45,41 @@ TEST_CASE_METHOD(SqlTestFixture, "DataMapper::IsModified flips when a Field is a
     CHECK_FALSE(dm.IsModified(person));
 }
 
+TEST_CASE_METHOD(SqlTestFixture, "DataMapper::Update with no modified fields is a no-op", "[DataMapper]")
+{
+    auto dm = DataMapper();
+    dm.CreateTable<Person>();
+
+    auto person = Person { .id = {}, .name = "John Doe", .is_active = true, .age = 30 };
+    dm.Create(person);
+    REQUIRE_FALSE(dm.IsModified(person));
+
+    // Nothing has been touched since Create(), so there is no SET clause to emit. Without an
+    // early-out this builds `UPDATE "Persons" SET  WHERE "id" = ?`, which the driver rejects.
+    REQUIRE_NOTHROW(dm.Update(person));
+
+    auto const reloaded = dm.QuerySingle<Person>(person.id);
+    REQUIRE(reloaded.has_value());
+    CHECK(reloaded->name.Value() == person.name.Value());
+    CHECK(reloaded->age.Value() == person.age.Value());
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "DataMapper::Update after a fetch with no changes is a no-op", "[DataMapper]")
+{
+    auto dm = DataMapper();
+    dm.CreateTable<Person>();
+
+    auto seed = Person { .id = {}, .name = "Alice", .is_active = true, .age = 30 };
+    dm.Create(seed);
+
+    auto fetched = dm.QuerySingle<Person>(seed.id);
+    REQUIRE(fetched.has_value());
+    REQUIRE_FALSE(dm.IsModified(*fetched));
+
+    // A fetched-but-untouched record has every dirty flag cleared, same empty-SET situation.
+    REQUIRE_NOTHROW(dm.Update(*fetched));
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "DataMapper::IsModified is false for a freshly-fetched record", "[DataMapper]")
 {
     auto dm = DataMapper();

--- a/src/tests/DataMapper/StateTests.cpp
+++ b/src/tests/DataMapper/StateTests.cpp
@@ -45,6 +45,33 @@ TEST_CASE_METHOD(SqlTestFixture, "DataMapper::IsModified flips when a Field is a
     CHECK_FALSE(dm.IsModified(person));
 }
 
+// ================================================================================================
+// Update — primary-key requirement
+// ================================================================================================
+
+/// A record with no PrimaryKey-qualified field. DataMapper::Update() builds its WHERE clause
+/// exclusively from primary-key fields, so accepting this type would emit an UPDATE with no
+/// WHERE clause and rewrite every row of the table.
+struct StateTestsNoPrimaryKey
+{
+    Field<SqlAnsiString<25>> name;
+    Field<int> age;
+};
+
+static_assert(!HasPrimaryKey<StateTestsNoPrimaryKey>, "test fixture must genuinely lack a primary key");
+static_assert(HasPrimaryKey<Person>, "test fixture must genuinely have a primary key");
+
+// The guard is a constraint on the declaration rather than a static_assert in the body, so that it
+// is detectable here instead of only firing as a hard error at the call site. The check goes
+// through a variable template because a requires-expression over non-dependent types is diagnosed
+// eagerly by clang rather than yielding false.
+template <typename Record>
+constexpr bool IsUpdatableByDataMapper = requires(DataMapper& dm, Record& record) { dm.Update(record); };
+
+static_assert(!IsUpdatableByDataMapper<StateTestsNoPrimaryKey>,
+              "DataMapper::Update() must not accept a record without a primary key");
+static_assert(IsUpdatableByDataMapper<Person>, "DataMapper::Update() must still accept a record with a primary key");
+
 TEST_CASE_METHOD(SqlTestFixture, "DataMapper::Update with no modified fields is a no-op", "[DataMapper]")
 {
     auto dm = DataMapper();


### PR DESCRIPTION
Fixes #560. Fixes #557.

Two bugs that both live in `DataMapper::Update()` and are entangled — a plain struct with no
`PrimaryKey`-qualified field triggers both at once — so they share a PR. They are **separate
commits** and can be reviewed independently:

| Commit | Issue |
|---|---|
| `079bb371` fix(DataMapper): skip Update() when no field is modified | #560 |
| `979f222d` fix(DataMapper): require a primary key for Update() | #557 |

---

## Commit 1 — #560: empty SET clause

`Update()` built its `SET` clause from the modified fields but never checked the fold produced
anything, so a record with all dirty flags clear generated `UPDATE "T" SET  WHERE "id" = ?`.

Reachable by calling `Update()` on a freshly created or freshly fetched record, or after mutating
through `Field::MutableValue()` (which deliberately does not set the dirty bit).

**Fix:** track whether the `SET` fold contributed an assignment; return early if not. The guard sits
outside the reflection `#if/#else`, so both the reflection-cpp and C++26-reflection branches are
covered.

### Test evidence — `src/tests/DataMapper/StateTests.cpp`

**Before — failing:**

```
DataMapper::Update with no modified fields is a no-op
StateTests.cpp:59: FAILED:
  REQUIRE_NOTHROW( dm.Update(person) )
due to unexpected exception with messages:
  [Lightweight] Execute: UPDATE "Person" SET
   WHERE "id" = ?
  HY000 (1) - [SQLite]near "WHERE": syntax error (1)

DataMapper::Update after a fetch with no changes is a no-op
StateTests.cpp:80: FAILED:
  REQUIRE_NOTHROW( dm.Update(*fetched) )
due to unexpected exception with message:
  HY000 (1) - [SQLite]near "WHERE": syntax error (1)

test cases: 2 | 2 failed
assertions: 7 | 5 passed | 2 failed
```

**After — passing:**

```
All tests passed (10 assertions in 2 test cases)
```

---

## Commit 2 — #557: UPDATE with no WHERE clause

`Update()` adds `WHERE` terms only under `if constexpr (IsPrimaryKey<...>)`, with no fallback when
the fold yields nothing, so a record type without a primary key produced an `UPDATE` with **no
WHERE clause** — rewriting every row. The call succeeded silently.

**Fix:** constrain the declaration and definition with `requires HasPrimaryKey<Record>`, mirroring
the requirement `UpdateAll()` already enforces (`static_assert(HasPrimaryKey<Record>, ...)`).

**Note on mechanism.** The issue suggested a `static_assert` in the body, matching `UpdateAll`. I
used a constraint on the signature instead, because a `static_assert` in a function body is not
detectable and the repo has no compile-failure test harness — meaning that form of the fix could not
carry a regression test at all. As a constraint it is SFINAE-detectable, so the test below can
actually assert it. The diagnostic still names the cause:

```
note: candidate template ignored: constraints not satisfied [with Record = StateTestsNoPrimaryKey]
note: because 'HasPrimaryKey<StateTestsNoPrimaryKey>' evaluated to false
```

Happy to switch to `static_assert` for consistency with `UpdateAll` if you prefer the error message
over the testability — that trade is the one open question in this PR.

### Test evidence

First, a throwaway test demonstrating the actual damage (not committed — it cannot compile once the
guard is in place). Two rows seeded, `Alice/30` and `Bob/40`; one PK-less record updated:

```
TEMP RED evidence for #557
StateTests.cpp:70: warning:  row: name=Alice age=31
StateTests.cpp:70: warning:  row: name=Alice age=31
StateTests.cpp:74: FAILED:
  CHECK( bobCount == 1 )
with expansion:
  0 == 1
```

Both rows were overwritten; Bob's row is gone.

The committed regression test is compile-time. **Before the fix — build fails:**

```
StateTests.cpp:71:15: error: static assertion failed due to requirement
  '!IsUpdatableByDataMapper<StateTestsNoPrimaryKey>':
  DataMapper::Update() must not accept a record without a primary key
   71 | static_assert(!IsUpdatableByDataMapper<StateTestsNoPrimaryKey>,
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

**After the fix — builds clean** and the suite runs (numbers below). The check goes through a
variable template because a `requires`-expression over non-dependent types is diagnosed eagerly by
clang rather than yielding `false`.

### Callers sweep

A full `clang-debug` build of **tests, examples, tools and benchmarks** is clean with the constraint
in place, so no existing caller was updating a PK-less record. Worth noting `DataMapper::Create()`
already does not compile for a PK-less record (its return path is guarded by `HasPrimaryKey`), so
such records were only ever partially supported.

---

## Full suite

| Backend | Result |
|---|---|
| sqlite3 | 1396 cases, 1395 passed, 1 skipped — 13604 assertions passed |
| mssql2022 (Docker, `mcr.microsoft.com/mssql/server:2022-latest`) | 1396 cases, 1393 passed, 3 skipped — 13576 assertions passed |
| postgres (Docker, `postgres:16.4`) | 1396 cases, 1394 passed, 2 skipped — 13529 assertions passed |

Skips are pre-existing `UNSUPPORTED_DATABASE` cases, unrelated to this change.

**Compiler:** `clang-debug` only (PEDANTIC + ASan/UBSan + clang-tidy). No gcc preset exists for
macOS in `CMakePresets.json`, so the `gcc-release` run AGENT.md asks for is left to CI.

## Risk

- **#560:** low. Pure early-out on a path that previously always raised a driver error.
- **#557:** source-breaking *by design* for anyone calling `Update()` with a PK-less record — but
  that call could only ever corrupt data, and nothing in-tree does it. The C++26-reflection branch
  shares the same declaration, so both paths are constrained.

## Performance

`Update()` gains one `bool` and a branch. Records with no modified fields now skip a statement
prepare and execute entirely — strictly less work.
