### PR TITLE
fix(SqlQuery): escape UPDATE SET string literals; empty WhereIn matches nothing

### DIFF
--- a/docs/sql-to-lightweight.md
+++ b/docs/sql-to-lightweight.md
@@ -176,6 +176,10 @@ auto rows = dm.Query<Employee>().WhereIn(FieldNameOf<&Employee::department>, dep
 
 `WhereIn` accepts any range (`std::vector`, `std::set`, an initializer list) or a sub-select query.
 
+An **empty** range means "match nothing", and emits `WHERE 1 = 0` rather than omitting the condition.
+This matters most for `Delete()`: `dm.FromTable("Employees").Delete().WhereIn("department_id", ids)`
+with an empty `ids` deletes no rows, instead of every row in the table.
+
 ### WHERE — NULL / NOT NULL
 
 ```sql

--- a/src/Lightweight/SqlQuery/Core.hpp
+++ b/src/Lightweight/SqlQuery/Core.hpp
@@ -684,8 +684,10 @@ template <typename ColumnName, std::ranges::input_range InputRange>
 inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlWhereClauseBuilder<Derived>::WhereIn(ColumnName const& columnName,
                                                                                  InputRange const& values)
 {
+    // An empty IN-set means "match nothing"; emitting no condition would mean "match everything".
+    // `1 = 0` rather than `FALSE` because SQL Server has no boolean literal.
     if (values.empty())
-        return static_cast<Derived&>(*this);
+        return WhereRaw("1 = 0");
     return Where(columnName, "IN", PopulateSqlSetExpression(values));
 }
 
@@ -695,8 +697,9 @@ template <typename ColumnName, typename T>
 inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlWhereClauseBuilder<Derived>::WhereIn(ColumnName const& columnName,
                                                                                  std::initializer_list<T> const& values)
 {
+    // See the range overload above: an empty IN-set must not silently drop the condition.
     if (values.begin() == values.end())
-        return static_cast<Derived&>(*this);
+        return WhereRaw("1 = 0");
     return Where(columnName, "IN", PopulateSqlSetExpression(values));
 }
 

--- a/src/Lightweight/SqlQuery/Core.hpp
+++ b/src/Lightweight/SqlQuery/Core.hpp
@@ -686,7 +686,10 @@ inline LIGHTWEIGHT_FORCE_INLINE Derived& SqlWhereClauseBuilder<Derived>::WhereIn
 {
     // An empty IN-set means "match nothing"; emitting no condition would mean "match everything".
     // `1 = 0` rather than `FALSE` because SQL Server has no boolean literal.
-    if (values.empty())
+    //
+    // std::ranges::empty rather than values.empty(): the latter requires a member function, which
+    // excludes ranges such as built-in arrays that this overload otherwise handles fine.
+    if (std::ranges::empty(values))
         return WhereRaw("1 = 0");
     return Where(columnName, "IN", PopulateSqlSetExpression(values));
 }

--- a/src/Lightweight/SqlQuery/Update.hpp
+++ b/src/Lightweight/SqlQuery/Update.hpp
@@ -94,9 +94,10 @@ SqlUpdateQueryBuilder& SqlUpdateQueryBuilder::Set(std::string_view columnName, C
         m_values += std::format("{}", value);
     else
     {
-        m_values += '\'';
-        m_values += std::format("{}", value);
-        m_values += '\'';
+        // Route through the formatter rather than quoting by hand: it escapes embedded quotes and
+        // applies the dialect's literal rules (e.g. SQL Server's N'…' + NCHAR() encoding).
+        // SqlInsertQueryBuilder::Set does the same — see Insert.hpp.
+        m_values += m_formatter.StringLiteral(std::format("{}", value));
     }
 
     return *this;

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -1822,6 +1822,21 @@ TEST_CASE("Non-MSSQL StringLiteral has no N prefix", "[SqlQueryFormatter]")
     CHECK(SqlQueryFormatter::PostgrSQL().StringLiteral("hi") == "'hi'");
 }
 
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Update.Set escapes string literals", "[SqlQueryBuilder]")
+{
+    // Without a bindings vector the value is inlined, so it must go through the formatter's
+    // StringLiteral() — same as SqlInsertQueryBuilder::Set does — rather than bare '...' quoting.
+    CheckSqlQueryBuilder([](SqlQueryBuilder& q) { return q.FromTable("T").Update().Set("name", "O'Brien").Where("id", 1); },
+                         QueryExpectations {
+                             .sqlite = R"sql(UPDATE "T" SET "name" = 'O''Brien'
+                                             WHERE "id" = 1)sql",
+                             .postgres = R"sql(UPDATE "T" SET "name" = 'O''Brien'
+                                               WHERE "id" = 1)sql",
+                             .sqlServer = R"sql(UPDATE "T" SET "name" = N'O''Brien'
+                                                WHERE "id" = 1)sql",
+                         });
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "Migration Insert", "[SqlQueryBuilder][Migration]")
 {
     CheckSqlQueryBuilder(

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -665,14 +665,24 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn", "[SqlQueryBuilder]")
                                                    WHERE "foo" IN (1, 2, 3))"));
 }
 
-TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn with empty list", "[SqlQueryBuilder]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn with empty list matches nothing", "[SqlQueryBuilder]")
 {
+    // An empty IN-set means "match nothing". Emitting no condition at all would instead mean
+    // "match everything" — turning `Delete().WhereIn(col, {})` into a full-table delete.
     CheckSqlQueryBuilder([](SqlQueryBuilder& q) { return q.FromTable("That").Delete().WhereIn("foo", std::vector<int> {}); },
-                         QueryExpectations::All(R"(DELETE FROM "That")"));
+                         QueryExpectations::All(R"(DELETE FROM "That"
+                                                   WHERE 1 = 0)"));
 
     CheckSqlQueryBuilder(
         [](SqlQueryBuilder& q) { return q.FromTable("That").Delete().WhereIn("foo", std::initializer_list<int> {}); },
-        QueryExpectations::All(R"(DELETE FROM "That")"));
+        QueryExpectations::All(R"(DELETE FROM "That"
+                                  WHERE 1 = 0)"));
+
+    // It composes with surrounding conditions rather than replacing them.
+    CheckSqlQueryBuilder(
+        [](SqlQueryBuilder& q) { return q.FromTable("That").Delete().Where("bar", 1).WhereIn("foo", std::vector<int> {}); },
+        QueryExpectations::All(R"(DELETE FROM "That"
+                                  WHERE "bar" = 1 AND 1 = 0)"));
 }
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn with strings", "[SqlQueryBuilder]")

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -665,6 +665,16 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn", "[SqlQueryBuilder]")
                                                    WHERE "foo" IN (1, 2, 3))"));
 }
 
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn accepts a range without a member empty()", "[SqlQueryBuilder]")
+{
+    // A built-in array is an input_range but has no `.empty()` member, so the emptiness check must
+    // go through std::ranges::empty rather than calling values.empty() directly.
+    int const values[] = { 1, 2, 3 };
+    CheckSqlQueryBuilder([&](SqlQueryBuilder& q) { return q.FromTable("That").Delete().WhereIn("foo", values); },
+                         QueryExpectations::All(R"(DELETE FROM "That"
+                                                   WHERE "foo" IN (1, 2, 3))"));
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn with empty list matches nothing", "[SqlQueryBuilder]")
 {
     // An empty IN-set means "match nothing". Emitting no condition at all would instead mean


### PR DESCRIPTION
Addresses #561 **partially** — see "Deliberately out of scope" below. Please do **not** auto-close
the issue on merge.

Two of the three sub-items in #561 are correctness bugs and are fixed here, as separate commits:

| Commit | Sub-item |
|---|---|
| `7e0fdc6d` fix(SqlQuery): escape string literals in SqlUpdateQueryBuilder::Set | #561 (1) |
| `3454b8f0` fix(SqlQuery): empty WhereIn now matches nothing instead of everything | #561 (3) |

---

## Commit 1 — unescaped string values in `UPDATE … SET`

The non-bound string path of `SqlUpdateQueryBuilder::Set` quoted by hand (`'` + `format` + `'`), so
a value containing an apostrophe broke out of the literal. `SqlInsertQueryBuilder::Set` already
routes the identical case through `m_formatter.StringLiteral` — this was an inconsistency, not a
policy. The formatter path also restores SQL Server's `N'…' + NCHAR()` encoding, which the UPDATE
path silently lost.

Only reachable when no bindings vector is supplied. **`DataMapper` always binds, so `DataMapper`
users were never affected** — this is the low-level `SqlQueryBuilder` surface.

### Test evidence — `SqlQueryBuilder.Update.Set escapes string literals`

**Before — failing:**

```
QueryBuilderTests.cpp:56: FAILED:
  REQUIRE( actual == expected )
with expansion:
  "UPDATE "T" SET "name" = 'O'Brien'
  WHERE "id" = 1"
  ==
  "UPDATE "T" SET "name" = 'O''Brien'
  WHERE "id" = 1"
```

**After — passing:**

```
All tests passed (4 assertions in 1 test case)
```

Run against all three formatters by `CheckSqlQueryBuilder`; SQL Server expects `N'O''Brien'`.

---

## Commit 2 — empty `WhereIn` was a silent no-op ⚠️ behaviour change

`WhereIn()` returned the builder unchanged for an empty range or initializer list, so the condition
vanished entirely — "match nothing" became "match everything". With `Delete()`, an empty input
vector was a full-table delete.

```cpp
q.FromTable("That").Delete().WhereIn("foo", std::vector<int> {})
// before: DELETE FROM "That"
// after:  DELETE FROM "That" WHERE 1 = 0
```

Both empty overloads now append an always-false condition via the existing junctor machinery, so it
composes with surrounding conditions (`WHERE "bar" = 1 AND 1 = 0`) instead of replacing them.
`1 = 0` rather than `FALSE` because SQL Server has no boolean literal.

### Test evidence — `SqlQueryBuilder.WhereIn with empty list matches nothing`

**Before — failing:**

```
QueryBuilderTests.cpp:56: FAILED:
  REQUIRE( actual == expected )
with expansion:
  "DELETE FROM "That""
  ==
  "DELETE FROM "That"
  WHERE 1 = 0"
```

**After — passing:**

```
All tests passed (10 assertions in 1 test case)
```

The third case in that test covers composition with a preceding `Where`.

### Callers sweep

- **`src/Lightweight/` and `src/tools/`: no internal caller of `WhereIn` at all** — the only hits are
  its own declarations and definitions in `SqlQuery/Core.hpp`. Nothing inside the library builds an
  IN-set that could be empty, so no internal behaviour shifts.
- `src/examples/test_chinook/main.cpp:160` and the doc snippets pass non-empty ranges.
- The previous behaviour **was pinned by a test** — `SqlQueryBuilder.WhereIn with empty list`
  asserted the bare `DELETE FROM "That"`. That expectation is deliberately updated here, and the
  test renamed to say what it now guarantees. Flagging it explicitly since replacing an existing
  assertion is exactly the kind of change that deserves a second look.
- `docs/sql-to-lightweight.md` documents the semantics; `scripts/check-doc-snippets.py` passes
  (41 snippets in sync).

---

## Deliberately out of scope

Sub-item **(2) "`WhereIn` never binds"** is *not* fixed here. Values on that path are escaped via
`MakeEscapedSqlString`, so it is not exploitable — the cost is defeated prepared-statement reuse and
bypassed dialect-specific literal handling. That is a performance/consistency concern rather than a
correctness or security one, so it is left for a separate change. **#561 should stay open for it.**

The issue's "adjacent, lower priority" note about unescaped identifiers is likewise untouched.

---

## Full suite

| Backend | Result |
|---|---|
| sqlite3 | 1395 cases, 1394 passed, 1 skipped — 13601 assertions passed |
| mssql2022 (Docker, `mcr.microsoft.com/mssql/server:2022-latest`) | 1395 cases, 1392 passed, 3 skipped — 13573 assertions passed |
| postgres (Docker, `postgres:16.4`) | 1395 cases, 1393 passed, 2 skipped — 13526 assertions passed |

Skips are pre-existing `UNSUPPORTED_DATABASE` cases, unrelated to this change.

**Compiler:** `clang-debug` only (PEDANTIC + ASan/UBSan + clang-tidy). No gcc preset exists for
macOS in `CMakePresets.json`, so the `gcc-release` run AGENT.md asks for is left to CI.

## Risk

- **Commit 1:** low. Strictly more correct output on a path that previously produced broken SQL for
  any value containing a quote.
- **Commit 2:** the behaviour change is the point of the fix, but it is a change. A caller passing an
  empty range and expecting an unfiltered query will now get zero rows. No in-tree caller does this,
  and the old behaviour could only ever surprise — but it is the one thing worth a maintainer's
  judgement in this PR.

## Performance

Negligible: one extra branch on the empty-IN path, and `StringLiteral()` instead of manual quoting
in `Update::Set`.
