### PR TITLE
fix(DataMapper): mark BelongsTo modified on bare foreign-key assignment

### DIFF
--- a/src/Lightweight/DataMapper/BelongsTo.hpp
+++ b/src/Lightweight/DataMapper/BelongsTo.hpp
@@ -152,6 +152,30 @@ class BelongsTo
         return *this;
     }
 
+    /// Assigns a bare foreign-key value, updating the foreign key and marking the field modified.
+    ///
+    /// This is the sibling of Field<T>::operator=(S&&). Without it, `record.fk = someKeyValue`
+    /// would bind to the converting constructor plus move-assignment, and the temporary's
+    /// default-constructed `_modified` (false) would be copied over this field — leaving the
+    /// change invisible to DataMapper::Update(), which gates its SET clause on IsModified().
+    ///
+    /// Any previously loaded record is dropped, since it no longer corresponds to the new key.
+    ///
+    /// @param value The referenced record's primary-key value to point at.
+    /// @return Reference to this field.
+    template <typename S>
+        requires(std::constructible_from<ValueType, S> && !std::same_as<std::remove_cvref_t<S>, BelongsTo>
+                 && !std::same_as<std::remove_cvref_t<S>, ReferencedRecord>
+                 && !std::same_as<std::remove_cvref_t<S>, SqlNullType>)
+    constexpr BelongsTo& operator=(S&& value) noexcept
+    {
+        _referencedFieldValue = ValueType { std::forward<S>(value) };
+        _loaded = false;
+        _record.reset();
+        _modified = true;
+        return *this;
+    }
+
     /// Assigns a referenced record, updating the foreign key and loaded state.
     BelongsTo& operator=(ReferencedRecord& other)
     {

--- a/src/tests/DataMapper/RelationTests.cpp
+++ b/src/tests/DataMapper/RelationTests.cpp
@@ -242,6 +242,57 @@ class ScopedSqlQueryRecorder: public SqlLogger::Null
 } // namespace
 
 TEST_CASE_METHOD(SqlTestFixture,
+                 "BelongsTo: assigning a bare foreign-key value marks the field modified",
+                 "[DataMapper][relations][BelongsTo]")
+{
+    auto dm = DataMapper();
+    dm.CreateTables<User, Email>();
+
+    auto original = User { .name = "Original" };
+    auto target = User { .name = "Target" };
+    dm.Create(original);
+    dm.Create(target);
+
+    auto email = Email { .address = "someone@example.com" };
+    email.user = original;
+    dm.Create(email);
+    REQUIRE_FALSE(email.user.IsModified());
+
+    // Assigning the referenced record's bare primary-key value must mark the field dirty, exactly
+    // as Field<T>::operator=(S&&) does. Without a direct-value assignment overload this binds to
+    // the converting constructor plus move-assignment, which copies the temporary's _modified
+    // (false) over the target.
+    email.user = target.id.Value();
+
+    CHECK(email.user.IsModified());
+    CHECK(email.user.Value() == target.id.Value());
+}
+
+TEST_CASE_METHOD(SqlTestFixture,
+                 "BelongsTo: Update() writes a foreign key assigned as a bare value",
+                 "[DataMapper][relations][BelongsTo]")
+{
+    auto dm = DataMapper();
+    dm.CreateTables<User, Email>();
+
+    auto userA = User { .name = "A" };
+    auto userB = User { .name = "B" };
+    dm.Create(userA);
+    dm.Create(userB);
+
+    auto email = Email { .address = "a@example.com" };
+    email.user = userA;
+    dm.Create(email);
+
+    // Re-point the foreign key by bare value, then persist.
+    email.user = userB.id.Value();
+    dm.Update(email);
+
+    auto const reloaded = dm.QuerySingle<Email>(email.id).value();
+    CHECK(reloaded.user.Value() == userB.id.Value());
+}
+
+TEST_CASE_METHOD(SqlTestFixture,
                  "HasMany resolves its inverse BelongsTo by type, not by member index",
                  "[DataMapper][relations][HasMany]")
 {


### PR DESCRIPTION
Fixes #551.

## Problem

`BelongsTo<>` has no `operator=` accepting the referenced record's bare primary-key value. So
`record.fk = someKeyValue` binds to the variadic converting constructor —

```cpp
template <typename... S>
    requires std::constructible_from<ValueType, S...>
constexpr BelongsTo(S&&... value) noexcept : _referencedFieldValue(std::forward<S>(value)...) {}
```

— whose member-initializer list never touches `_modified` (so it stays default-`false`), and then to
the **move assignment operator**, which does `_modified = other._modified;` — copying that `false`
over whatever state the field already had.

`DataMapper::Update()` gates both its `SET` clause and its parameter binding on `IsModified()`, so
the column was dropped from the `UPDATE` entirely. The call succeeded, nothing was thrown, and the
row's foreign key never changed. When the FK was the only field touched, the statement degenerated
to `UPDATE "Email" SET  WHERE "id" = ?` and the driver rejected it.

`Field<T>::operator=(S&&)` — the sibling type's equivalent case — is correct and sets the dirty bit.
This was the gap.

## Change

Added the direct-value assignment overload to `BelongsTo<>`, constrained so it does not hijack the
`BelongsTo` copy/move, `ReferencedRecord&`, or `SqlNullType` overloads:

```cpp
template <typename S>
    requires(std::constructible_from<ValueType, S> && !std::same_as<std::remove_cvref_t<S>, BelongsTo>
             && !std::same_as<std::remove_cvref_t<S>, ReferencedRecord>
             && !std::same_as<std::remove_cvref_t<S>, SqlNullType>)
constexpr BelongsTo& operator=(S&& value) noexcept
```

It also drops any previously loaded record (`_loaded = false; _record.reset();`), since the cached
record no longer corresponds to the new key — matching what `operator=(SqlNullType)` already does.

## Test evidence

Two cases in `src/tests/DataMapper/RelationTests.cpp`: one asserting the dirty bit directly, one
end-to-end through `Update()` and a re-query.

**Before — failing:**

```
BelongsTo: assigning a bare foreign-key value marks the field modified
RelationTests.cpp:267: FAILED:
  CHECK( email.user.IsModified() )
with expansion:
  false

BelongsTo: Update() writes a foreign key assigned as a bare value
Utils.hpp:576: FAILED:
due to unexpected exception with messages:
  [Lightweight] Execute: UPDATE "Email" SET
   WHERE "id" = ?
  HY000 (1) - [SQLite]near "WHERE": syntax error (1)

test cases: 2 | 2 failed
assertions: 6 | 4 passed | 2 failed
```

The second failure is the empty-`SET` symptom: with the FK not marked modified, nothing remained to
write. (That empty-`SET` statement is itself #560, fixed separately in #567 — here it is the
*consequence* of the missing dirty bit, and this fix removes the cause.)

**After — passing:**

```
All tests passed (6 assertions in 2 test cases)
```

## Full suite

Run with `--rng-seed 1` for reproducibility:

| Backend | Result |
|---|---|
| sqlite3 | 1396 cases, 1395 passed, 1 skipped — 13600 assertions passed |
| mssql2022 (Docker, `mcr.microsoft.com/mssql/server:2022-latest`) | 1396 cases, 1393 passed, 3 skipped — 13572 assertions passed |
| postgres (Docker, `postgres:16.4`) | 1396 cases, 1394 passed, 2 skipped — 13525 assertions passed |

### Pre-existing flaky MSSQL test (not caused by this PR)

An earlier randomized run on this branch hit one failure on MSSQL:

```
Audit metadata duration null when MarkAsApplied
MigrationTests.cpp:876
Utils.hpp:576: FAILED:
due to unexpected exception with message:
  22018 (206) - [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]
  Operand type clash: datetime2 is incompatible with bigint
```

It passes in isolation, so it is order/state-dependent. I re-ran the **same seed (1547595099) with
this PR's changes stashed** — i.e. plain `master` — and got the identical single failure in the
identical test (1394 cases, 1390 passed, 1 failed, 3 skipped). So it is pre-existing on `master` and
unrelated to `BelongsTo`. Worth its own issue; I have not touched it here.

**Compiler:** `clang-debug` only (PEDANTIC + ASan/UBSan + clang-tidy). No gcc preset exists for
macOS in `CMakePresets.json`, so the `gcc-release` run AGENT.md asks for is left to CI.

## Risk

Low, but it does add an overload to a widely used class template, so overload resolution is the
thing to check. The constraint excludes `BelongsTo` itself, `ReferencedRecord`, and `SqlNullType`,
so the existing assignment paths are untouched; a full build of tests, examples, tools and
benchmarks is clean and the suite is green on all three backends.

Behaviour does change for anyone who was assigning a bare key value and *relying* on the field
staying clean — but that only ever silently discarded the write.

## Performance

None.
