### PR TITLE
Overhaul the documentation: scope, API modules, missing guides, corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Documentation is available at [https://lastrada-software.github.io/Lightweight/]
 | **Backup & restore** | Parallel chunked dump/restore, msgpack + zip + sha256, archive diffing | [sql-backup.md](docs/sql-backup.md), [sql-backup-format.md](docs/sql-backup-format.md) |
 | **Async API** | C++23 coroutines: `Task<T>`, executors, strand, stdexec bridge, async `DataMapper` | [async.md](docs/async.md) |
 | **Connection pooling** | Compile-time-configured pool, async-aware, recycles connections across mappers | [async.md](docs/async.md) |
+| **Logging & tracing** | Pluggable `SqlLogger`: warnings/errors, full SQL trace, or your own sink | [logging.md](docs/logging.md) |
+| **Schema introspection** | Read tables, columns, keys and indexes back out of a live database | [schema-introspection.md](docs/schema-introspection.md) |
 | **Custom data types** | `SqlDataBinder<T>` specialization for your own types, with Unicode support | [data-binder.md](docs/data-binder.md) |
 | **`dbtool` CLI** | Migrations, backup/restore, backup diffing, schema inspection — ~20 commands | [dbtool.md](docs/dbtool.md) |
 | **`dbtool-gui`** | Qt/QML desktop app for migrations, backup and ad-hoc queries | [dbtool.md](docs/dbtool.md) |

--- a/README.md
+++ b/README.md
@@ -96,16 +96,6 @@ Being explicit here saves you from discovering these by reading the source.
   no cross-table consistency guarantee. Quiesce writers if you need a consistent point-in-time dump.
   See [sql-backup.md](docs/sql-backup.md).
 
-## Versioning and stability
-
-Releases are calendar-versioned as `v0.YYYYMMDD.0`. The leading `0.` is part of that scheme and is
-**not** a statement that the library is unfinished — it is in production use, and the test suite runs
-against SQLite, PostgreSQL and SQL Server 2017/2019/2022 on every change.
-
-That said, the project does not currently make a formal semver compatibility promise: the public API
-is stable in practice, but a breaking change can land in any release. Pin an exact tag if you need
-reproducible builds, and read the release notes before upgrading.
-
 ## Namespace
 
 All functionality is placed inside a `Lightweight` namespace, we also provide an alias for this namespace `Light`, that is slightly shorter.

--- a/README.md
+++ b/README.md
@@ -328,9 +328,49 @@ layout in [sql-backup-format.md](docs/sql-backup-format.md).
 ## Asynchronous API
 
 Async entry points are added directly to the types you already use (`SqlConnection`, `DataMapper`,
-`Pool`), suffixed with `Async`, and return `Async::Task<T>`. Queries go through the same fluent
-builder as the synchronous API. Note that this is **thread-offload**, not protocol-level async — see
-[async.md](docs/async.md), which explains why and what that means for your thread budget.
+`Pool`), suffixed with `Async`, and return `Async::Task<T>`. Enable it once by saying where blocking
+ODBC calls run and where your coroutine resumes:
+
+```cpp
+#include <Lightweight/Async/ManualExecutor.hpp>
+#include <Lightweight/Async/ThreadPoolExecutor.hpp>
+#include <Lightweight/DataMapper/DataMapper.hpp>
+
+using namespace Lightweight;
+
+Async::ThreadPoolExecutor dbWorkers { 4 }; // 4 background DB threads
+Async::ManualExecutor     appLoop;         // your app thread pumps this
+
+DataMapper dm;
+dm.Connection().EnableAsync(dbWorkers, appLoop);
+```
+
+Queries then go through the *same* fluent builder — start the chain with `QueryAsync<Record>()`
+instead of `Query<Record>()`, and every finisher returns a `Task` of its usual result:
+
+```cpp
+Async::Task<void> Handle(DataMapper& dm, SqlGuid userId)
+{
+    auto active = co_await dm.QueryAsync<User>()
+                            .Where(FieldNameOf<&User::is_active>, "=", true)
+                            .OrderBy(FieldNameOf<&User::name>)
+                            .First(10);              // Task<std::vector<User>>
+
+    auto total = co_await dm.QueryAsync<User>().Count();   // Task<std::size_t>
+
+    auto user = User { .name = "Alice" };
+    co_await dm.CreateAsync(user);                   // INSERT off-thread
+    co_await dm.DeleteAsync(user);
+}
+```
+
+Two things to know before you build on this. It is **thread-offload**, not protocol-level async: your
+application thread never blocks, but a worker thread does. And the async operands are captured **by
+reference**, so keep the whole expression inside the `co_await` — hoisting a builder into a local and
+awaiting it later is a use-after-free.
+
+[async.md](docs/async.md) covers executors, cancellation, transactions, single- versus multi-threaded
+drive models, and the `std::execution` bridge.
 
 ## Using SQLite for testing on Windows operating system
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,53 @@
-# Lightweight, an ODBC SQL API for C++23
+# Lightweight, a C++23 database library
 
-**Lightweight** is a thin and modern C++ ODBC wrapper for **easy** and **fast** raw database access.
+**Lightweight** is a modern C++23 database library for **Microsoft SQL Server**, **PostgreSQL** and
+**SQLite** over ODBC — with a data mapper and typed relationships, versioned schema migrations,
+parallel backup and restore, an async coroutine API, connection pooling, and CLI/GUI tooling.
+
+It is layered: use the thin ODBC wrapper (`SqlConnection`, `SqlStatement`) when you want raw SQL and
+full control, the query builder when you want composable typed SQL, or the `DataMapper` when you
+want records and relationships mapped for you. The layers interoperate — you can drop from one to
+the next at any point without leaving the library.
+
 Documentation is available at [https://lastrada-software.github.io/Lightweight/](https://lastrada-software.github.io/Lightweight/).
 
-It supports both low-level access to the SQL API as well as provides hight level abstraction that allow easy database access.
+## Features
 
-Here you can see an example of datamapper usage (our tool for the high level abstraction)
+| Area | What it gives you | Guide |
+|------|-------------------|-------|
+| **Raw SQL access** | `SqlConnection`, `SqlStatement`, prepared statements, batched execution, block-prefetch | [usage.md](docs/usage.md) |
+| **Query builder** | Composable typed `SELECT`/`INSERT`/`UPDATE`/`DELETE`, joins, filtering, ordering, pagination | [sqlquery.md](docs/sqlquery.md) |
+| **Data mapper** | Struct-to-table mapping, CRUD, `Field<>` with primary keys and nullability | [usage.md](docs/usage.md) |
+| **Relationships** | `BelongsTo`, `HasMany`, `HasOneThrough`, `HasManyThrough`, `CompositeForeignKey` | [composite-keys-design.md](docs/composite-keys-design.md) |
+| **Schema migrations** | Versioned migrations, checksums, dependency ordering, plugin loading, rollback | [sql-migrations.md](docs/sql-migrations.md) |
+| **Backup & restore** | Parallel chunked dump/restore, msgpack + zip + sha256, archive diffing | [sql-backup.md](docs/sql-backup.md), [sql-backup-format.md](docs/sql-backup-format.md) |
+| **Async API** | C++23 coroutines: `Task<T>`, executors, strand, stdexec bridge, async `DataMapper` | [async.md](docs/async.md) |
+| **Connection pooling** | Compile-time-configured pool, async-aware, recycles connections across mappers | [async.md](docs/async.md) |
+| **Custom data types** | `SqlDataBinder<T>` specialization for your own types, with Unicode support | [data-binder.md](docs/data-binder.md) |
+| **`dbtool` CLI** | Migrations, backup/restore, backup diffing, schema inspection — ~20 commands | [dbtool.md](docs/dbtool.md) |
+| **`dbtool-gui`** | Qt/QML desktop app for migrations, backup and ad-hoc queries | [dbtool.md](docs/dbtool.md) |
+| **`ddl2cpp`** | Generates C++ records from an existing schema, inferring relations automatically | [ddl2cpp-relation-generation.md](docs/ddl2cpp-relation-generation.md) |
+
+Coming from SQL? [sql-to-lightweight.md](docs/sql-to-lightweight.md) is a side-by-side cookbook that
+shows the Lightweight equivalent of a given piece of SQL in each of the three layers.
+See also [best-practices.md](docs/best-practices.md) and [how-to.md](docs/how-to.md).
+
+## Why ODBC?
+
+ODBC is a deliberate trade-off, not an accident of history. Every other ecosystem — and within C++
+every ergonomic peer (sqlpp23, sqlgen, ormpp, sqlite_orm, libpqxx, Drogon) — talks native wire
+protocols per database. Lightweight targets ODBC because it buys **one API, one build, and one set
+of semantics across SQL Server, PostgreSQL and SQLite**, with per-database differences funnelled
+through a single dispatch point (`SqlQueryFormatter`) rather than scattered across the codebase. For
+applications that must ship against more than one database, that is worth a great deal.
+
+What it costs, stated plainly:
+
+- **Driver deployment.** Your users need the right ODBC driver installed and registered, and driver
+  quality varies. Some behaviours are driver-build-specific rather than database-specific.
+- **No protocol-level bulk path.** There is no `COPY`-class fast path; bulk work goes through
+  array/parameter binding, which is fast but not as fast as a native bulk loader.
+- **No protocol-level async.** See the async limitation below.
 
 ## Supported platforms
 
@@ -21,15 +63,56 @@ a modern enough C++ compiler.
 - PostgreSQL
 - SQLite3
 
+`SqlServerType` also lists a `MYSQL` enumerator, but **MySQL is not supported**:
+`SqlQueryFormatter::Get()` returns `nullptr` for it, so no query can be formatted. The enumerator is
+a placeholder for possible future work — do not rely on it.
+
+## Known limitations
+
+Being explicit here saves you from discovering these by reading the source.
+
+- **The query builder is not a complete SQL surface.** It has no `HAVING`, CTEs,
+  `UNION`/`EXCEPT`/`INTERSECT`, `RETURNING`, upsert, window functions, or multi-row
+  `INSERT ... VALUES` (bulk goes through array binding instead). The intended escape hatches are
+  `SqlFieldExpression`, `WhereRaw(...)`, and `DataMapper::Query<T>(sql, ...)` — reach for them when
+  you need SQL the builder does not model. For `RETURNING` specifically, `SqlStatement` can execute
+  it directly, with driver caveats documented in [how-to.md](docs/how-to.md).
+- **Async is thread-offload, not protocol-level non-blocking.** ODBC's own async execution is not
+  portable, so each blocking ODBC call is offloaded to a worker thread and your coroutine resumes on
+  a scheduler you choose. Your application thread never blocks, but *some* thread does. See
+  [async.md](docs/async.md) for the full rationale.
+- **No identity map or unit of work.** Loading the same row twice yields two unrelated objects.
+  `BelongsTo` holds a deep copy; `HasMany` builds fresh `shared_ptr`s on every load.
+- **Lazy loaders use a thread-local mapper, not the one that loaded the record.** Relation
+  auto-loading goes through `DataMapper::AcquireThreadLocal()`, which is constructed from
+  `SqlConnection::DefaultConnectionString()`. A lazy load therefore runs on a *different connection*,
+  **outside your caller's transaction**, and fails outright if no default connection string is
+  configured. If that matters to your code, load relations explicitly instead of touching them
+  lazily.
+- **No eager-loading / preload API.** Touching a relation across N records issues N queries.
+- **Backup is online, with no snapshot.** Tables are read while writes continue, so an archive has
+  no cross-table consistency guarantee. Quiesce writers if you need a consistent point-in-time dump.
+  See [sql-backup.md](docs/sql-backup.md).
+
+## Versioning and stability
+
+Releases are calendar-versioned as `v0.YYYYMMDD.0`. The leading `0.` is part of that scheme and is
+**not** a statement that the library is unfinished — it is in production use, and the test suite runs
+against SQLite, PostgreSQL and SQL Server 2017/2019/2022 on every change.
+
+That said, the project does not currently make a formal semver compatibility promise: the public API
+is stable in practice, but a breaking change can land in any release. Pin an exact tag if you need
+reproducible builds, and read the release notes before upgrading.
+
 ## Namespace
 
-All functionality is placed inside a `Lightweight` namespace, we also provide an alias for this namespace `Light`, that is slightly shorter. 
+All functionality is placed inside a `Lightweight` namespace, we also provide an alias for this namespace `Light`, that is slightly shorter.
 
 ## High level API
 
 High level API of the library provided by the type `DataMapper`
 
-### Simple one record example 
+### Simple one record example
 
 Example of its usage to save/load/update/delete entry in the database for one table
 
@@ -96,6 +179,10 @@ struct Email
 };
 ```
 
+`BelongsTo` models the **many-to-one** side of a foreign key — the record that *owns* the foreign-key
+column. Many `Email`s can point at one `User`. For the other relationship kinds see `HasMany`,
+`HasOneThrough`, `HasManyThrough` and `CompositeForeignKey`.
+
 In the presented example we used rename of the columns, for more details see how-to\#rename-column-name page.
 you can query the email and get access to the user record as well
 
@@ -104,6 +191,10 @@ auto dm = Light::DataMapper();
 auto email = dm.QuerySingle<Email>(some_email_id).value_or(Email{});
 auto user_name = email.user->name; // lazily loads the user record
 ```
+
+> **Note:** lazy loading (`email.user->name` above) does *not* use `dm`. It uses a thread-local
+> `DataMapper` built from the default connection string, so it runs on a different connection and
+> outside any transaction `dm` may be in. See [Known limitations](#known-limitations).
 
 ### Mapping query results to a simple struct
 
@@ -205,6 +296,41 @@ for (auto const& [a, b, c]: records)
 }
 ```
 
+## Schema migrations
+
+Migrations are versioned, checksummed C++ definitions applied in dependency order, with rollback and
+plugin loading. They can be driven from your application or from the `dbtool` CLI:
+
+```sh
+dbtool status         # what is applied, what is pending
+dbtool migrate        # apply everything pending
+dbtool rollback-to 20260101120000
+```
+
+See [sql-migrations.md](docs/sql-migrations.md) for writing migrations and
+[dbtool.md](docs/dbtool.md) for the full command reference.
+
+## Backup and restore
+
+Lightweight ships a backup engine — parallel chunked dump and restore into a zip archive of msgpack
+chunks with sha256 integrity, plus archive diffing:
+
+```sh
+dbtool backup --output snapshot.zip
+dbtool restore --input snapshot.zip
+dbtool backup-diff --left old.zip --right new.zip
+```
+
+Backups are taken **online, without a snapshot**, so there is no cross-table consistency guarantee —
+see [Known limitations](#known-limitations). Details in [sql-backup.md](docs/sql-backup.md), archive
+layout in [sql-backup-format.md](docs/sql-backup-format.md).
+
+## Asynchronous API
+
+Async entry points are added directly to the types you already use (`SqlConnection`, `DataMapper`,
+`Pool`), suffixed with `Async`, and return `Async::Task<T>`. Queries go through the same fluent
+builder as the synchronous API. Note that this is **thread-offload**, not protocol-level async — see
+[async.md](docs/async.md), which explains why and what that means for your thread budget.
 
 ## Using SQLite for testing on Windows operating system
 
@@ -268,6 +394,9 @@ Finally, compile and run the example
 ``` sh
 cmake --build build && ./build/src/examples/example
 ```
+
+`ddl2cpp` also infers relationships from the schema's foreign keys — see
+[ddl2cpp-relation-generation.md](docs/ddl2cpp-relation-generation.md).
 
 ## Compile using C++26 reflection support
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ auto user_name = email.user->name; // lazily loads the user record
 
 ### Mapping query results to a simple struct
 
-If you have a SQL query that returns some values, but it does not corresponds to the existing table in the database, you can map the result to a simple struct.
+If you have a SQL query that returns some values, but it does not correspond to an existing table in the database, you can map the result to a simple struct.
 The struct must have fields that match the columns in the query. The fields can be of any type that can be converted from the column type. The struct can have more fields than the columns in the query, but the fields that match the columns must be in the same order as the columns in the query.
 
 ```cpp
@@ -218,19 +218,17 @@ struct SimpleStruct
 
 void SimpleStructExample(DataMapper& dm)
 {
-    if (auto maybeObject = dm.Query<SimpleString>(
-        "SELECT A.pk, B.pk, A.c1, A.c2, B.c1, B.c2 FROM A LEFT JOIN B ON A.pk = B.pk"); maybeObject)
-    ))
-    {
-        for (auto const& obj : *maybeObject)
-            std::println("{}", DataMapper::Inspect(obj));
-    }
+    auto const records = dm.Query<SimpleStruct>(
+        "SELECT A.pk, B.pk, A.c1, A.c2, B.c1, B.c2 FROM A LEFT JOIN B ON A.pk = B.pk");
+
+    for (auto const& obj: records)
+        std::println("{}", DataMapper::Inspect(obj));
 }
 ```
 
 ### Mapping query to multiple struct
 
-We also provide an API to create SQL queries, this can be usefull if you want to use information from existing structures.
+We also provide an API to create SQL queries, this can be useful if you want to use information from existing structures.
 The following example shows how to create a query that joins multiple tables and maps the result to multiple structs.
 Consider the following structs
 
@@ -282,7 +280,7 @@ SELECT "A"."id", "A"."number", "A"."name", "A"."description", "B"."id", "B"."tit
  ORDER BY "A"."id" ASC
 ```
 
-Now you can execute it and get the result as a `std::vector<std::tuple<CustomBindingA, CustomBindingB, ParfOfC>` like this
+Now you can execute it and get the result as a `std::vector<std::tuple<CustomBindingA, CustomBindingB, PartOfC>>` like this
 
 ```cpp
 struct PartOfC
@@ -374,7 +372,7 @@ Generate header file from the existing database by providing connection string t
  ./build/src/tools/ddl2cpp --connection-string "DRIVER=SQLite3;Database=test.db" --make-aliases --naming-convention CamelCase  --output ./src/examples/example.hpp --generate-example
 ```
 
-You can also avoid all those command line arguments by creating a config file that muts be in your
+You can also avoid all those command line arguments by creating a config file that must be in your
 current working directory or in one of its parent directories.
 The config file must be named `ddl2cpp.yml` and must contain the following content:
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -64,6 +64,8 @@ message(STATUS "Doxygen found: ${DOXYGEN_EXECUTABLE}")
     "${PROJECT_SOURCE_DIR}/docs/dbtool.md"
     "${PROJECT_SOURCE_DIR}/docs/sql-migrations.md"
     "${PROJECT_SOURCE_DIR}/docs/async.md"
+    "${PROJECT_SOURCE_DIR}/docs/composite-keys-design.md"
+    "${PROJECT_SOURCE_DIR}/docs/ddl2cpp-relation-generation.md"
     "${PROJECT_SOURCE_DIR}/docs/announcement-reddit.md"
   )
   doxygen_add_docs(doc

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -64,6 +64,8 @@ message(STATUS "Doxygen found: ${DOXYGEN_EXECUTABLE}")
     "${PROJECT_SOURCE_DIR}/docs/dbtool.md"
     "${PROJECT_SOURCE_DIR}/docs/sql-migrations.md"
     "${PROJECT_SOURCE_DIR}/docs/async.md"
+    "${PROJECT_SOURCE_DIR}/docs/logging.md"
+    "${PROJECT_SOURCE_DIR}/docs/schema-introspection.md"
     "${PROJECT_SOURCE_DIR}/docs/composite-keys-design.md"
     "${PROJECT_SOURCE_DIR}/docs/ddl2cpp-relation-generation.md"
   )

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -66,7 +66,6 @@ message(STATUS "Doxygen found: ${DOXYGEN_EXECUTABLE}")
     "${PROJECT_SOURCE_DIR}/docs/async.md"
     "${PROJECT_SOURCE_DIR}/docs/composite-keys-design.md"
     "${PROJECT_SOURCE_DIR}/docs/ddl2cpp-relation-generation.md"
-    "${PROJECT_SOURCE_DIR}/docs/announcement-reddit.md"
   )
   doxygen_add_docs(doc
     ${DOCS_SOURCES}

--- a/docs/dbtool.md
+++ b/docs/dbtool.md
@@ -296,6 +296,109 @@ Useful for:
 - Baseline migrations when setting up an existing database
 - Skipping migrations that were applied manually
 
+### rollback-to-release \<VERSION\>
+
+Rolls back every migration applied after the named release:
+
+```bash
+dbtool rollback-to-release 1.0.0
+```
+
+The release's own migrations are kept; only what came after is reverted.
+
+### releases
+
+Lists the releases declared by the registered migrations, with each one's migration count and
+whether it is fully applied:
+
+```bash
+dbtool releases
+```
+
+### rewrite-checksums
+
+Rewrites `schema_migrations.checksum` so the stored checksums match what the current code
+generates:
+
+```bash
+dbtool rewrite-checksums --yes
+```
+
+Use this **only** after a regeneration that changed the byte shape of a migration without changing
+its meaning — for example a formatting change in generated DDL. If the logic actually changed, the
+checksum mismatch is a real warning and rewriting it hides a genuine divergence. Because it edits
+migration bookkeeping, it refuses to run without `--yes` — there is no interactive prompt, the
+command simply exits. See [Checksum Mismatches](#checksum-mismatches).
+
+### hard-reset
+
+Drops every table the registered migrations own, plus the `schema_migrations` table, and leaves
+tables it does not own untouched:
+
+```bash
+dbtool hard-reset --yes
+dbtool migrate
+```
+
+The pairing with `migrate` is the point: `hard-reset` returns the database to "no migrations
+applied" so the full set can be replayed from scratch. Which tables count as migration-owned is
+computed by folding the registered migration plan, not by guessing from the live schema, so user
+tables survive. Like `rewrite-checksums`, it refuses to run without `--yes`.
+
+`--dry-run` prints the three groups it computed — tables to drop, migration-declared but absent, and
+user-owned tables it will preserve — without touching anything.
+
+### unicode-upgrade-tables
+
+Rewrites legacy `VARCHAR`/`CHAR` columns to `NVARCHAR`/`NCHAR` where the registered migrations now
+declare wide types:
+
+```bash
+dbtool unicode-upgrade-tables --dry-run
+dbtool unicode-upgrade-tables --yes
+```
+
+This exists for databases created before a migration switched a column to a wide type: the
+migration history is already marked applied, so nothing would otherwise re-run to widen the
+existing columns. Run it with `--dry-run` first to see the planned `ALTER` statements.
+
+### exec \<QUERY\>
+
+Executes an SQL query and prints any result set:
+
+```bash
+dbtool exec "SELECT COUNT(*) FROM Users"
+```
+
+Pass `-` as the argument, or omit it entirely, to read the query from stdin:
+
+```bash
+echo "SELECT * FROM Users WHERE id = 1" | dbtool exec -
+dbtool exec < query.sql
+```
+
+### list-profiles
+
+Lists the profiles defined in the configuration file (see [Configuration](#configuration)):
+
+```bash
+dbtool list-profiles
+```
+
+### resolve-secret \<REF\>
+
+Resolves a single secret reference and prints it to stdout, without connecting to any database:
+
+```bash
+dbtool resolve-secret env:DB_PASSWORD
+dbtool resolve-secret file:/run/secrets/db_password
+dbtool resolve-secret stdin:
+```
+
+This is a debugging aid for configuration: it lets you confirm that a `env:` / `file:` / `stdin:`
+reference in a profile resolves to what you expect, before a connection failure sends you looking
+in the wrong place.
+
 ## Backup & Restore
 
 ### backup
@@ -393,10 +496,16 @@ common table is identical and both archives hold the same set of tables, or `1` 
 | `--quiet`, `-q` | Suppress progress output | |
 | `--dry-run`, `-n` | Preview without executing | |
 | `--no-lock` | Skip migration locking | |
-| `--schema-only` | For backup/restore: skip data. For `diff`: skip the data diff. | |
-| `--no-color` | Disable ANSI colors in `diff` output (auto-disabled when not at a tty) | |
-| `--max-rows <N>` | Cap rows scanned per table for `diff` data mode | `0` (unlimited) |
+| `--schema-only` | For backup/restore: skip data, transferring schema only | |
+| `--memory-limit <SIZE>` | Memory limit for restore (accepts the size suffixes below) | |
+| `--batch-size <N>` | Rows per batch for restore | |
+| `--ignore-table <NAME>` | For `backup-diff`: report differences in this table but do not fail. Repeatable. | |
+| `--profile <NAME>` | Named profile from the configuration file | store default |
+| `--up-to <TIMESTAMP>` | Upper bound for migration commands | no bound |
 | `--max-retries <N>` | Maximum retry attempts for transient errors | `3` |
+| `--verbose`, `-v` | Emit extra informational output (e.g. shadowed plugins) | |
+| `--yes`, `-y` | Confirm destructive actions without prompting | |
+| `--show-examples` | Print usage examples and exit | |
 | `--help` | Show help message | |
 
 ### Size Suffixes

--- a/docs/dbtool.md
+++ b/docs/dbtool.md
@@ -1,4 +1,4 @@
-# dbtool - Database Management CLI {#dbtool}
+# dbtool - Database Management CLI
 
 ## Overview
 
@@ -655,5 +655,5 @@ If migration locking fails:
 
 ## See Also
 
-- @ref sql-migrations - Guide to writing SQL migrations in C++
+- [sql-migrations.md](sql-migrations.md) - Guide to writing SQL migrations in C++
 - @ref Lightweight::SqlMigration::MigrationManager - C++ API for managing migrations

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1,6 +1,6 @@
 # How to
 
-The following is a list of some topics that you might find usefull
+The following is a list of some topics that you might find useful
 
 ## Rename column name
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,111 @@
+# Logging and tracing
+
+Lightweight routes every interesting database event — connections opening and closing, statements
+being prepared, parameters being bound, rows being fetched, warnings and errors — through a single
+`SqlLogger` interface. Installing a logger is how you see what the library is actually sending to
+the database, and it is the first tool to reach for when a query misbehaves on one DBMS but not
+another.
+
+There is exactly one active logger process-wide. It is retrieved with `SqlLogger::GetLogger()` and
+replaced with `SqlLogger::SetLogger()`.
+
+## The built-in loggers
+
+| Logger | Use it for |
+|--------|-----------|
+| `SqlLogger::NullLogger()` | Discards everything. The default — logging costs nothing unless you opt in. |
+| `SqlLogger::StandardLogger()` | Warnings and errors only. A sensible production choice. |
+| `SqlLogger::TraceLogger()` | Everything: prepare, bind, execute, fetch, connection lifecycle, scoped timers. Use while diagnosing. |
+
+Switching to full tracing is a single call:
+
+```cpp
+#include <Lightweight/Lightweight.hpp>
+
+Light::SqlLogger::SetLogger(Light::SqlLogger::TraceLogger());
+```
+
+The test binary exposes this as `--trace-sql` (see `src/tests/Utils.hpp`), which is the same switch
+behind a command-line flag.
+
+## Redirecting the output
+
+Both built-in loggers write through a `MessageWriter` sink, which you can replace to route messages
+into your own logging framework instead of the default output:
+
+```cpp
+auto& logger = Light::SqlLogger::TraceLogger();
+logger.SetLoggingSink([](std::string message) {
+    MyApp::Log::Debug("{}", message);
+});
+```
+
+Call `SetLoggingSink({})` to restore the default sink.
+
+## Writing a custom logger
+
+For anything beyond redirecting text — counting queries, feeding metrics, failing a test when an
+unexpected statement runs — derive from `SqlLogger::Null` and override just the hooks you care
+about. `Null` supplies empty implementations for all of them, so you only write what you need:
+
+```cpp
+class QueryCounter final: public Light::SqlLogger::Null
+{
+  public:
+    size_t executed = 0;
+    size_t rowsFetched = 0;
+
+    void OnExecute(std::string_view const& /*query*/) override { ++executed; }
+    void OnFetchRow() override { ++rowsFetched; }
+};
+
+QueryCounter counter;
+Light::SqlLogger::SetLogger(counter);
+```
+
+Deriving from `SqlLogger` directly is also possible, but almost every hook is pure virtual — you
+would have to implement all of them.
+
+The hooks available are:
+
+| Hook | Fires when |
+|------|-----------|
+| `OnWarning` / `OnError` | A warning or an ODBC error is raised. Two `OnError` overloads: one for a bare `SqlError`, one for a full `SqlErrorInfo` with SQL state and native code. |
+| `OnConnectionOpened` / `OnConnectionClosed` | A connection is established or torn down. |
+| `OnConnectionIdle` / `OnConnectionReuse` | A pooled connection goes idle or is handed out again. |
+| `OnExecuteDirect` | A statement is executed without preparation. |
+| `OnPrepare` / `OnExecute` / `OnExecuteBatch` | A statement is prepared, executed, or executed as a batch. |
+| `OnBind` | A parameter is bound. Only called when the logger was constructed with `SupportBindLogging::Yes`. |
+| `OnFetchRow` / `OnFetchBlock` / `OnFetchEnd` | Rows are fetched one at a time, in a prefetch block, or the result set is exhausted. |
+| `OnScopedTimerStart` / `OnScopedTimerStop` | A scoped timing region opens or closes. |
+
+`OnFetchBlock` has a default no-op implementation, so an existing logger keeps compiling when
+block-prefetch reporting is added.
+
+## Restoring the previous logger
+
+`SetLogger` does not take ownership, so the logger must outlive its installation. In tests, where
+loggers are swapped repeatedly, an RAII guard keeps this honest:
+
+```cpp
+struct LoggerSwap
+{
+    Light::SqlLogger* previous;
+
+    explicit LoggerSwap(Light::SqlLogger& replacement):
+        previous { &Light::SqlLogger::GetLogger() }
+    {
+        Light::SqlLogger::SetLogger(replacement);
+    }
+
+    ~LoggerSwap() { Light::SqlLogger::SetLogger(*previous); }
+
+    LoggerSwap(LoggerSwap const&) = delete;
+    LoggerSwap& operator=(LoggerSwap const&) = delete;
+};
+```
+
+## See also
+
+- [best-practices.md](best-practices.md) — when tracing points at a real performance problem.
+- [dbtool.md](dbtool.md) — the CLI, which reports migration and backup progress directly.

--- a/docs/schema-introspection.md
+++ b/docs/schema-introspection.md
@@ -1,0 +1,107 @@
+# Schema introspection
+
+`SqlSchema` reads an existing database's structure back out into plain C++ structures: tables,
+columns, primary keys, foreign keys in both directions, and indexes. It is the layer `ddl2cpp` is
+built on, and it is public API — reach for it when you need to inspect a schema you did not define
+in C++, or generate something from it.
+
+Everything lives in the `Lightweight::SqlSchema` namespace and works through an ordinary
+`SqlStatement`, so it obeys the same connection and transaction rules as the rest of the library.
+
+## Reading every table
+
+```cpp
+#include <Lightweight/Lightweight.hpp>
+
+auto stmt = Light::SqlStatement {};
+
+std::vector<Light::SqlSchema::Table> const tables =
+    Light::SqlSchema::ReadAllTables(stmt, /* database */ "MyDatabase");
+```
+
+The `schema` parameter is optional and defaults to the driver's notion of the default schema. For
+SQL Server that is typically `dbo`; SQLite has no schemas at all.
+
+Reading a large schema is not instant, so `ReadAllTables` accepts a progress callback that fires
+per table:
+
+```cpp
+auto const tables = Light::SqlSchema::ReadAllTables(
+    stmt,
+    "MyDatabase",
+    /* schema */ {},
+    [](std::string_view tableName, size_t current, size_t total) {
+        std::println("[{}/{}] {}", current, total, tableName);
+    });
+```
+
+Two further optional parameters follow: a `TableReadyCallback`, invoked as soon as one table's
+schema is complete so you can stream results instead of waiting for the whole database, and a
+`TableFilterPredicate`, which skips reading columns and constraints for tables you do not care
+about. Filtering at that level is much cheaper than reading everything and discarding it.
+
+## What you get back
+
+`Table` describes one table:
+
+| Field | Meaning |
+|-------|---------|
+| `schema`, `name` | Where the table lives and what it is called. |
+| `columns` | Ordered `Column` definitions. |
+| `primaryKeys` | Column names forming the primary key — more than one for a composite key. |
+| `foreignKeys` | Foreign keys declared *on* this table. |
+| `externalForeignKeys` | Foreign keys on *other* tables pointing *at* this one. |
+| `indexes` | Indexes excluding the primary-key index. |
+
+`externalForeignKeys` is what makes relation inference possible: `foreignKeys` gives you the
+`BelongsTo` side, and `externalForeignKeys` gives you the `HasMany` side of the same relationship.
+
+Each `Column` carries its name, a portable `SqlColumnTypeDefinition`, the raw
+`dialectDependantTypeString` as the driver reported it, plus `isNullable`, `isUnique`, `size`,
+`decimalDigits`, `isAutoIncrement`, `isPrimaryKey`, `isForeignKey`, an optional
+`foreignKeyConstraint`, and `defaultValue`.
+
+Keep both type representations in mind: `type` is the normalized form to compare or map against,
+while `dialectDependantTypeString` is what the database actually said and is the better thing to
+show a human when a type does not round-trip as expected.
+
+## Following relationships directly
+
+When you only need the edges and not whole tables:
+
+```cpp
+auto const table = Light::SqlSchema::FullyQualifiedTableName {
+    .catalog = {}, .schema = {}, .table = "Orders"
+};
+
+auto const incoming = Light::SqlSchema::AllForeignKeysTo(stmt, table);   // who points at Orders
+auto const outgoing = Light::SqlSchema::AllForeignKeysFrom(stmt, table); // what Orders points at
+```
+
+## Turning a description back into DDL
+
+`MakeCreateTablePlan` converts a `Table` (or a whole `TableList`) into a `SqlCreateTablePlan`, which
+the query formatter renders as `CREATE TABLE` for the target DBMS. Because the plan goes through
+`SqlQueryFormatter`, a schema read from PostgreSQL can be emitted as SQL Server DDL without you
+writing per-dialect code:
+
+```cpp
+auto const plan = Light::SqlSchema::MakeCreateTablePlan(tables);
+```
+
+The `TableList` overload maps each table independently and **preserves the order you pass in** — it
+does not topologically sort by foreign-key dependency. If the target DBMS enforces that a referenced
+table exists before the referencing one, order the list yourself before calling it.
+
+## Event-driven reading
+
+For very large schemas, or when you want to react as the schema is read rather than materialize all
+of it, implement the `EventHandler` interface and pass it to the `ReadAllTables` overload that takes
+one. It is a SAX-style callback interface: `OnTables`, `OnTable` (return `false` to skip a table),
+`OnPrimaryKeys`, `OnForeignKey`, `OnColumn`, `OnExternalForeignKey`, `OnIndexes`, and `OnTableEnd`.
+
+## See also
+
+- [ddl2cpp-relation-generation.md](ddl2cpp-relation-generation.md) — how `ddl2cpp` turns this data into records and relations.
+- [sql-migrations.md](sql-migrations.md) — defining schema from C++ rather than reading it.
+- [sqlquery.md](sqlquery.md) — the DDL surface of the query builder.

--- a/docs/sql-backup.md
+++ b/docs/sql-backup.md
@@ -3,7 +3,7 @@
 This page explains how the backup engine (`Lightweight::SqlBackup::Backup` / `Restore`)
 works: its pipeline, parallelism model, memory and disk profile, fault tolerance, and the
 consistency guarantees you can (and cannot) expect. For the on-disk archive layout, see
-[sql-backup-format.md](sql-backup-format.md); for the CLI, see @ref dbtool "dbtool.md"
+[sql-backup-format.md](sql-backup-format.md); for the CLI, see [dbtool.md](dbtool.md)
 (`dbtool backup` / `dbtool restore`).
 
 ## Overview
@@ -107,4 +107,4 @@ restored replica.
 ## See also
 
 - [sql-backup-format.md](sql-backup-format.md) — archive layout and msgpack chunk format.
-- @ref dbtool "dbtool.md" — `dbtool backup` / `dbtool restore` CLI usage.
+- [dbtool.md](dbtool.md) — `dbtool backup` / `dbtool restore` CLI usage.

--- a/docs/sql-migrations.md
+++ b/docs/sql-migrations.md
@@ -1,4 +1,4 @@
-# SQL Migrations {#sql-migrations}
+# SQL Migrations
 
 ## Introduction
 
@@ -482,6 +482,6 @@ infrastructure — `dbtool hard-reset` drops it alongside
 
 ## See Also
 
-- @ref dbtool - Command-line tool for managing migrations
+- [dbtool.md](dbtool.md) - Command-line tool for managing migrations
 - @ref Lightweight::SqlMigrationQueryBuilder - Query builder API reference
 - @ref Lightweight::SqlMigration::MigrationManager - Migration manager API reference

--- a/docs/sql-to-lightweight.md
+++ b/docs/sql-to-lightweight.md
@@ -828,7 +828,7 @@ migration.CreateTable("Appointment")
 auto const plan = migration.GetPlan();
 ```
 
-See [sql-migrations.md](#sql-migrations) and [sqlquery.md](sqlquery.md) for the full DDL surface
+See [sql-migrations.md](sql-migrations.md) and [sqlquery.md](sqlquery.md) for the full DDL surface
 (`AlterTable`, `Index`, `UniqueIndex`, `Timestamps`, `DropTable`, ...).
 
 ---
@@ -914,6 +914,6 @@ indentation). To change an example:
 
 - [usage.md](usage.md) — getting started: connections, prepared statements, the `DataMapper` CRUD loop.
 - [sqlquery.md](sqlquery.md) — the query-builder DSL in depth.
-- [sql-migrations.md](#sql-migrations) — schema creation and migrations.
+- [sql-migrations.md](sql-migrations.md) — schema creation and migrations.
 - [best-practices.md](best-practices.md) — choosing between the layers, performance notes.
 - [async.md](async.md) — the coroutine / async API.

--- a/docs/sqlquery.md
+++ b/docs/sqlquery.md
@@ -2,8 +2,8 @@
 
 SQL Query builder class is the starting point of building sql queries to execute.
 
-## Create or Modife database schema 
-To create a database you need to use `Migration()` function provided by the `SqlQueryBuilder` class, then use API defined in `SqlMigrationQueryBuilder` to construct sql query to migrate to another schema or create a databse with the given schema. Detailed documentation can be found on separate documentation pages for each of the classes in the hirerarchy, here we present overall usage of the library.  Following options exist.
+## Create or Modify database schema 
+To create a database you need to use `Migration()` function provided by the `SqlQueryBuilder` class, then use API defined in `SqlMigrationQueryBuilder` to construct sql query to migrate to another schema or create a database with the given schema. Detailed documentation can be found on separate documentation pages for each of the classes in the hierarchy, here we present overall usage of the library.  Following options exist.
 
 * `CreateTable(tableName)`
 Following calls can be chained, for example `CreateTable("test").Column(first).Column(second)...`
@@ -33,9 +33,9 @@ Available functions:
   - `ForeignKey(std::string columnName, SqlColumnTypeDefinition columnType, SqlForeignKeyReferenceDefinition foreignKey)`
     + creates a new nullable foreign key column, non-nullable version is a `RequiredForeignKey` function. 
   - Additional function that change specification of the created columns with the following usage: `CreateTable("test").Column(first).UniqueIndex()`.
-    + `Unique()` enables the UNIQUE constrain on the last declared column.
-    + `Index()` enables the INDEX constrain on the last declared column.
-    + `UniqueIndex()` enables the UNIQUE and INDEX constrain on the last declared column.
+    + `Unique()` enables the UNIQUE constraint on the last declared column.
+    + `Index()` enables the INDEX constraint on the last declared column.
+    + `UniqueIndex()` enables the UNIQUE and INDEX constraint on the last declared column.
 
 * `AlterTable(tableName)` 
   Available functions:
@@ -53,7 +53,7 @@ Available functions:
     + drop an index from the table for the specified column.
 
 * `DropTable(tableName)`
-  - Drops table with the given name, please make sure that no foreign key constrains restricts execution of this query for the given table.
+  - Drops table with the given name, please make sure that no foreign key constraint restricts execution of this query for the given table.
 
 
 ### Example

--- a/docs/sqlquery.md
+++ b/docs/sqlquery.md
@@ -22,7 +22,7 @@ Available functions:
       (`SMALLINT IDENTITY`). Declare `Bigint` (the default) unless you specifically want that limit.
     + Upgrading to a Lightweight version that changes the emitted DDL text also changes the checksum
       stored for migrations that were already applied — see
-      [dbtool: Checksum Mismatches](dbtool.md#checksum-mismatches).
+      @ref checksum-mismatches "dbtool: Checksum Mismatches".
   - `Column(std::string columnName, SqlColumnTypeDefinition columnType)`, `Column(SqlColumnDeclaration column)`
     + create a column specified by a name and type
     + for precise control on the column specification `SqlColumnDeclaration` can be used as an argument. 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -205,12 +205,10 @@ struct SimpleStruct
 
 void SimpleStructExample(DataMapper& dm)
 {
-    if (auto maybeObject = dm.Query<SimpleString>(
-        "SELECT A.pk, B.pk, A.c1, A.c2, B.c1, B.c2 FROM A LEFT JOIN B ON A.pk = B.pk"); maybeObject)
-    ))
-    {
-        for (auto const& obj : *maybeObject)
-            std::println("{}", DataMapper::Inspect(obj));
-    }
+    auto const records = dm.Query<SimpleStruct>(
+        "SELECT A.pk, B.pk, A.c1, A.c2, B.c1, B.c2 FROM A LEFT JOIN B ON A.pk = B.pk");
+
+    for (auto const& obj: records)
+        std::println("{}", DataMapper::Inspect(obj));
 }
 ```

--- a/src/Lightweight/Async/Async.hpp
+++ b/src/Lightweight/Async/Async.hpp
@@ -13,6 +13,13 @@
 #include <utility>
 #include <variant>
 
+/// @defgroup Async Asynchronous API
+/// @brief C++23 coroutine API: tasks, executors and the offload backend.
+///
+/// Async entry points are added directly to the types you already use (@c SqlConnection,
+/// @c DataMapper, @c Pool), suffixed with @c Async. Note that this is a thread-offload model
+/// rather than protocol-level non-blocking I/O.
+
 namespace Lightweight::Async
 {
 

--- a/src/Lightweight/Async/AsyncSqlTransaction.hpp
+++ b/src/Lightweight/Async/AsyncSqlTransaction.hpp
@@ -16,6 +16,7 @@ class SqlConnection;
 namespace Lightweight::Async
 {
 
+/// @ingroup Async
 /// A distinct coroutine-based SQL transaction.
 ///
 /// Unlike the high- and low-level async methods (which are added directly to the existing

--- a/src/Lightweight/Async/Backend.hpp
+++ b/src/Lightweight/Async/Backend.hpp
@@ -11,6 +11,7 @@
 namespace Lightweight::Async
 {
 
+/// @ingroup Async
 /// Per-connection asynchronous execution backend.
 ///
 /// A backend owns (or references) the execution context used to run a connection's blocking

--- a/src/Lightweight/Async/CancellationToken.hpp
+++ b/src/Lightweight/Async/CancellationToken.hpp
@@ -6,6 +6,7 @@
 namespace Lightweight::Async
 {
 
+/// @ingroup Async
 /// Thrown when an asynchronous operation is abandoned because cancellation was requested
 /// before (or instead of) it producing a result.
 class OperationCancelledError: public std::runtime_error

--- a/src/Lightweight/Async/Executor.hpp
+++ b/src/Lightweight/Async/Executor.hpp
@@ -14,6 +14,7 @@ namespace Lightweight::Async
 /// is a small, copyable closure.
 using Work = std::function<void()>;
 
+/// @ingroup Async
 /// Interface for an executor that runs posted work items.
 ///
 /// Executors are injected (dependency injection) and owned by the caller; the async layer
@@ -34,6 +35,7 @@ class IExecutor
     virtual void Post(Work work) = 0;
 };
 
+/// @ingroup Async
 /// Interface for scheduling the resumption of a suspended coroutine.
 ///
 /// Kept separate from @ref IExecutor::Post so resumption can be expressed as a bare
@@ -55,6 +57,7 @@ class IResumeScheduler
     virtual void Resume(std::coroutine_handle<> handle) = 0;
 };
 
+/// @ingroup Async
 /// An executor that runs work synchronously on the calling thread.
 ///
 /// Useful for tests and for degenerate single-threaded configurations where no thread

--- a/src/Lightweight/Async/ManualExecutor.hpp
+++ b/src/Lightweight/Async/ManualExecutor.hpp
@@ -11,6 +11,7 @@
 namespace Lightweight::Async
 {
 
+/// @ingroup Async
 /// An executor that runs work only when explicitly pumped by the owning thread.
 ///
 /// This is the "app thread" / event-loop resume target for the single-threaded model:

--- a/src/Lightweight/Async/StrandExecutor.hpp
+++ b/src/Lightweight/Async/StrandExecutor.hpp
@@ -10,6 +10,7 @@
 namespace Lightweight::Async
 {
 
+/// @ingroup Async
 /// Serializes work over an underlying executor (an Asio-style "strand").
 ///
 /// All work posted to a given strand runs one item at a time, in FIFO order, even though

--- a/src/Lightweight/Async/Task.hpp
+++ b/src/Lightweight/Async/Task.hpp
@@ -191,6 +191,7 @@ namespace detail
 
 } // namespace detail
 
+/// @ingroup Async
 /// A lazy, move-only C++23 coroutine task.
 ///
 /// A @c Task<T> represents an asynchronous computation that yields a value of type @c T

--- a/src/Lightweight/Async/ThreadOffloadBackend.hpp
+++ b/src/Lightweight/Async/ThreadOffloadBackend.hpp
@@ -8,6 +8,7 @@
 namespace Lightweight::Async
 {
 
+/// @ingroup Async
 /// Portable async backend that offloads blocking ODBC work to a worker thread.
 ///
 /// Every blocking operation for the connection runs on a per-connection @ref StrandExecutor

--- a/src/Lightweight/Async/ThreadPoolExecutor.hpp
+++ b/src/Lightweight/Async/ThreadPoolExecutor.hpp
@@ -10,6 +10,7 @@
 namespace Lightweight::Async
 {
 
+/// @ingroup Async
 /// A fixed-size pool of worker threads that run posted work concurrently.
 ///
 /// This is the default "DB worker" offload target: blocking ODBC calls are posted here and

--- a/src/Lightweight/DataMapper/BelongsTo.hpp
+++ b/src/Lightweight/DataMapper/BelongsTo.hpp
@@ -28,7 +28,11 @@ auto inline Unwrap = [](auto v) {
     return v.get();
 };
 
-/// @brief Represents a one-to-one relationship.
+/// @brief Represents the many-to-one side of a foreign-key relationship.
+///
+/// This is the record that *owns* the foreign-key column: many records holding a `BelongsTo` may
+/// reference the same target record. For a one-to-one relation through a join table, see
+/// `HasOneThrough`; for the inverse (one-to-many) side, see `HasMany`.
 ///
 /// The `TheReferencedField` parameter is the field in the other record that references the current record,
 /// in the form of `&OtherRecord::Field`.

--- a/src/Lightweight/DataMapper/Pool.hpp
+++ b/src/Lightweight/DataMapper/Pool.hpp
@@ -16,9 +16,16 @@
 #include <stdexcept>
 #include <vector>
 
+/// @defgroup ConnectionPool Connection Pooling
+/// @brief A thread-safe pool of @c DataMapper instances, configured at compile time.
+///
+/// The growth strategy, initial size and maximum size are supplied as a @c PoolConfig
+/// template parameter, so the policy is fixed at the type level rather than at runtime.
+
 namespace Lightweight
 {
 
+/// @ingroup ConnectionPool
 /// Enum to define growth strategies of the pool
 ///
 enum class GrowthStrategy : uint8_t
@@ -39,6 +46,7 @@ enum class GrowthStrategy : uint8_t
     UnboundedGrow,
 };
 
+/// @ingroup ConnectionPool
 /// Structure to hold the configuration of the pool, including the initial size, maximum size and growth strategy.
 /// Structure is used as a template parameter for the Pool class to configure its behavior at compile time.
 struct PoolConfig
@@ -54,6 +62,7 @@ struct PoolConfig
     GrowthStrategy growthStrategy { GrowthStrategy::BoundedWait };
 };
 
+/// @ingroup ConnectionPool
 /// A thread-safe pool of DataMapper instances with the policy configured by the PoolConfig template parameter.
 /// The pool allows acquiring and returning DataMapper instances, and manages the lifecycle of these instances according to
 /// the specified growth strategy.
@@ -61,6 +70,7 @@ template <PoolConfig Config>
 class Pool
 {
   public:
+    /// @ingroup ConnectionPool
     /// A wrapper around a DataMapper that returns it to the pool when destroyed
     /// can be created only from the Pool and is move-only to ensure it is always
     /// returned to the pool when it goes out of scope

--- a/src/Lightweight/SqlBackup/SqlBackup.hpp
+++ b/src/Lightweight/SqlBackup/SqlBackup.hpp
@@ -14,6 +14,12 @@
 #include <string_view>
 #include <vector>
 
+/// @defgroup Backup Backup and Restore
+/// @brief Parallel chunked database dump and restore, with archive diffing.
+///
+/// Backups are taken online without a snapshot, so an archive carries no cross-table
+/// consistency guarantee.
+
 namespace Lightweight::SqlBackup
 {
 
@@ -33,6 +39,7 @@ enum class CompressionMethod : std::int32_t
     Xz = 95,     ///< XZ compression (ZIP_CM_XZ)
 };
 
+/// @ingroup Backup
 /// Configuration for backup operations including compression and chunking.
 struct BackupSettings
 {
@@ -71,6 +78,7 @@ struct BackupSettings
     bool forceMssqlConcurrency = false;
 };
 
+/// @ingroup Backup
 /// Configuration for restore operations including memory management.
 struct RestoreSettings
 {
@@ -155,6 +163,7 @@ struct TableInfo
     size_t rowCount = 0;
 };
 
+/// @ingroup Backup
 /// Progress information for backup/restore operations status updates.
 struct Progress
 {
@@ -184,6 +193,7 @@ struct Progress
     std::string message;
 };
 
+/// @ingroup Backup
 /// The interface for progress updates.
 struct ProgressManager
 {
@@ -256,6 +266,7 @@ struct ProgressManager
     }
 };
 
+/// @ingroup Backup
 /// Base class for progress managers that tracks errors automatically.
 class ErrorTrackingProgressManager: public ProgressManager
 {

--- a/src/Lightweight/SqlBackup/SqlBackupFormats.hpp
+++ b/src/Lightweight/SqlBackup/SqlBackupFormats.hpp
@@ -21,6 +21,7 @@ using BackupValue = std::variant<std::monostate, // NULL
                                  std::vector<uint8_t> // Binary
                                  >;
 
+/// @ingroup Backup
 /// Represents a batch of backup data in column-oriented format.
 struct ColumnBatch
 {
@@ -64,6 +65,7 @@ struct ColumnBatch
     }
 };
 
+/// @ingroup Backup
 /// Interface for writing backup chunks.
 struct ChunkWriter
 {
@@ -94,6 +96,7 @@ struct ChunkWriter
     virtual void Clear() = 0;
 };
 
+/// @ingroup Backup
 /// Interface for reading backup chunks.
 struct ChunkReader
 {

--- a/src/Lightweight/SqlBackup/TableFilter.hpp
+++ b/src/Lightweight/SqlBackup/TableFilter.hpp
@@ -16,6 +16,7 @@ namespace Lightweight::SqlBackup
     #pragma warning(disable : 4251) // STL types in DLL interface
 #endif
 
+/// @ingroup Backup
 /// Filters tables by name patterns with glob-style wildcards.
 ///
 /// Supports:

--- a/src/Lightweight/SqlConnectInfo.hpp
+++ b/src/Lightweight/SqlConnectInfo.hpp
@@ -23,6 +23,7 @@ namespace Lightweight
 /// a value <= 1 disables prefetch.
 constexpr std::size_t PrefetchDepthDefault = 1000;
 
+/// @ingroup CoreApi
 /// Represents an ODBC connection string.
 struct SqlConnectionString
 {
@@ -61,6 +62,7 @@ LIGHTWEIGHT_API SqlConnectionString BuildConnectionString(SqlConnectionStringMap
 /// opened for writing.
 [[nodiscard]] LIGHTWEIGHT_API bool EnsureSqliteDatabaseFileExists(SqlConnectionString const& connectionString);
 
+/// @ingroup CoreApi
 /// Represents a connection data source as a DSN, username, password, and timeout.
 struct [[nodiscard]] SqlConnectionDataSource
 {

--- a/src/Lightweight/SqlConnection.hpp
+++ b/src/Lightweight/SqlConnection.hpp
@@ -91,7 +91,11 @@ class SqlConnection final
         return m_connectionId;
     }
 
-    /// Closes the connection (attempting to put it back into the connect[[ion pool).
+    /// Closes the connection, freeing the underlying ODBC handles.
+    ///
+    /// This does not return the connection to any pool: `SqlConnection` owns its handles outright.
+    /// Connection pooling is provided separately by `Lightweight::Pool` in
+    /// `DataMapper/Pool.hpp`, which recycles pooled `DataMapper` instances.
     LIGHTWEIGHT_API void Close() noexcept;
 
     /// Connects to the given database with the given username and password.

--- a/src/Lightweight/SqlConnection.hpp
+++ b/src/Lightweight/SqlConnection.hpp
@@ -27,6 +27,13 @@
 #include <sqlspi.h>
 #include <sqltypes.h>
 
+/// @defgroup CoreApi Core API
+/// @brief The low-level SQL API: connections, statements, result cursors and transactions.
+///
+/// This is the thin layer directly over ODBC. Use it when you want to write SQL yourself and
+/// keep full control over binding and fetching. The higher-level @ref DataMapper and
+/// @ref QueryBuilder layers are built on top of these types and interoperate with them.
+
 namespace Lightweight
 {
 
@@ -34,6 +41,7 @@ class SqlQueryBuilder;
 class SqlMigrationQueryBuilder;
 class SqlQueryFormatter;
 
+/// @ingroup CoreApi
 /// @brief Represents a connection to a SQL database.
 class SqlConnection final
 {

--- a/src/Lightweight/SqlError.hpp
+++ b/src/Lightweight/SqlError.hpp
@@ -20,6 +20,7 @@
 namespace Lightweight
 {
 
+/// @ingroup CoreApi
 /// @brief Represents an ODBC SQL error.
 ///
 /// NOTE: This is a simple wrapper around the SQL return codes. It is not meant to be

--- a/src/Lightweight/SqlLogger.hpp
+++ b/src/Lightweight/SqlLogger.hpp
@@ -17,6 +17,7 @@ class SqlConnection;
 
 struct SqlVariant;
 
+/// @ingroup CoreApi
 /// Represents a logger for SQL operations.
 class SqlLogger
 {

--- a/src/Lightweight/SqlMigration.hpp
+++ b/src/Lightweight/SqlMigration.hpp
@@ -462,12 +462,11 @@ namespace SqlMigration
         /// into a per-table view of "the final shape" plus a chronological list of
         /// data steps and surviving indexes/releases. Used by:
         ///
-        ///   - `dbtool fold` to emit a self-contained baseline (`.cpp` plugin or `.sql`)
         ///   - `HardReset` to know which tables the migrations would have created
         ///   - `UnicodeUpgradeTables` to know which char/varchar columns the migrations
         ///     now declare wide
         ///
-        /// All three are pure operations — `FoldRegisteredMigrations` itself never
+        /// Both are pure operations — `FoldRegisteredMigrations` itself never
         /// executes a single statement. See `FoldRegisteredMigrations` for the API.
         struct PlanFoldingResult
         {

--- a/src/Lightweight/SqlSchema.hpp
+++ b/src/Lightweight/SqlSchema.hpp
@@ -156,6 +156,7 @@ namespace SqlSchema
         return std::tie(a.first, a.second) < std::tie(b.first, b.second);
     }
 
+    /// @ingroup CoreApi
     /// Holds the definition of a column in a SQL table as read from the database schema.
     struct Column
     {
@@ -235,6 +236,7 @@ namespace SqlSchema
                                        std::string_view schema,
                                        EventHandler& eventHandler);
 
+    /// @ingroup CoreApi
     /// Holds the definition of a table in a SQL database as read from the database schema.
     struct Table
     {

--- a/src/Lightweight/SqlScopedLock.hpp
+++ b/src/Lightweight/SqlScopedLock.hpp
@@ -14,6 +14,7 @@
 namespace Lightweight
 {
 
+/// @ingroup CoreApi
 /// RAII-style cross-process advisory lock.
 ///
 /// Provides a distributed locking mechanism so that only one process at a

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -57,6 +57,7 @@ class RowArrayCursor;
 
 /// @brief High level API for (prepared) raw SQL statements
 ///
+/// @ingroup CoreApi
 /// SQL prepared statement lifecycle:
 /// 1. Prepare the statement
 /// 2. Optionally bind output columns to local variables
@@ -461,6 +462,7 @@ class [[nodiscard]] SqlStatement final: public SqlDataBinderCallback
     SQLSMALLINT m_expectedParameterCount {};       // The number of parameters expected by the query
 };
 
+/// @ingroup CoreApi
 /// API for reading an SQL query result set.
 class [[nodiscard]] SqlResultCursor
 {

--- a/src/Lightweight/SqlTransaction.hpp
+++ b/src/Lightweight/SqlTransaction.hpp
@@ -60,6 +60,7 @@ enum class SqlTransactionMode : std::uint8_t
     ROLLBACK,
 };
 
+/// @ingroup CoreApi
 /// Represents an exception that occurred during a SQL transaction.
 ///
 /// @see SqlTransaction::Commit(), SqlTransaction::Rollback()
@@ -73,6 +74,7 @@ class SqlTransactionException: public std::runtime_error
     }
 };
 
+/// @ingroup CoreApi
 /// Represents a transaction to a SQL database.
 ///
 /// This class is used to control the transaction manually. It disables the auto-commit mode when constructed,


### PR DESCRIPTION
The documentation was good where it existed but invisible from the front door, and carried gaps and errors only visible by reading source. This branch works through all of it.

Started from #565 (README undersells the library) and grew to cover the hosted site's structure, three undocumented subsystems, eight undocumented CLI commands, and a broken example that had been copy-pasted into two pages.

## Front door

The README — which is also the docs landing page, via `DOXYGEN_USE_MDFILE_AS_MAINPAGE` — described Lightweight as a thin ODBC wrapper with a data mapper. Migrations, the backup engine, the async layer, pooling, `dbtool`, `dbtool-gui` and `ddl2cpp` were undiscoverable despite each already having a guide in `docs/`.

- Lead with a positioning statement covering the real scope, then a feature table linking every subsystem to its guide, plus sections for migrations, backup/restore and async.
- Explain the ODBC choice and what it costs: driver deployment, no `COPY`-class bulk path, no protocol-level async.
- Add "Known limitations": query-builder gaps and their escape hatches, async being thread-offload, no identity map, no eager loading, snapshot-less online backup, and the lazy-loader callout — relation access goes through `AcquireThreadLocal()`, so it runs on a different connection outside the caller's transaction.
- Document MySQL as unsupported (`SqlQueryFormatter::Get()` returns `nullptr` for it) rather than removing the enumerator, which would be an API change.
- Expand the async section from prose into a worked example: enabling async, the `QueryAsync` builder, record-level methods, and the two things that bite first — thread-offload semantics, and by-reference capture meaning the whole expression must stay inside the `co_await`.

## API reference structure

The site published 280 classes but defined only five module groups, none covering the low-level API, async, backup or pooling — so `SqlBackup`'s 24 classes and `Async`'s 22 were reachable only through a flat alphabetical list. This was the half of #565's landing-page complaint the README table did not address.

Added `CoreApi`, `Async`, `Backup` and `ConnectionPool` groups, each with a `@brief` saying when to reach for that layer. The site now has nine modules covering 175 types.

Also dropped `announcement-reddit.md` from the generated site — it is a Reddit announcement post, and says so in its own second line.

## Newly documented

- `docs/logging.md` — `SqlLogger`: the three built-in loggers, redirecting output through a `MessageWriter` sink, deriving a custom logger from `SqlLogger::Null`, the full hook table, and an RAII guard for restoring the previous logger, since `SetLogger` does not take ownership.
- `docs/schema-introspection.md` — `SqlSchema`: `ReadAllTables` with its progress/per-table/filter callbacks, `Table` and `Column`, following foreign keys in both directions, `MakeCreateTablePlan`, and the SAX-style `EventHandler`.
- `dbtool` ships 22 commands; `docs/dbtool.md` documented 14. The eight missing ones are now covered: `rollback-to-release`, `releases`, `rewrite-checksums`, `hard-reset`, `unicode-upgrade-tables`, `exec`, `list-profiles`, `resolve-secret` — including when *not* to use them, since `rewrite-checksums` hides a genuine divergence if migration logic really changed.

Behaviours documented because they are only visible in source: `externalForeignKeys` is what makes the `HasMany` side of a relation inferable; `MakeCreateTablePlan`'s `TableList` overload preserves input order rather than sorting by foreign-key dependency; and the destructive `dbtool` commands refuse to run without `--yes` rather than prompting.

## Corrections

The "simple row retrieval via structs" example did not compile, and was duplicated verbatim in `usage.md` and the README: it called `Query<SimpleString>` when the struct is `SimpleStruct`, carried a stray `))`, and treated the result as an optional when the raw-SQL overload returns `std::vector<Record>` directly.

`docs/dbtool.md`'s option reference listed two flags that do not exist in the tool at all — `--no-color` and `--max-rows` — both described in terms of a `diff` command (it is `backup-diff`), plus `--schema-only` claiming to affect a diff when it only affects backup/restore. Removed, and the nine real options that were missing were added.

Stale doc comments:

- `SqlMigration.hpp` credited `dbtool fold` as a consumer of `PlanFoldingResult`; no such command exists.
- `SqlConnection.hpp` claimed `Close()` returns the connection to a pool `SqlConnection` does not have, and contained a literal `connect[[ion` typo.
- `BelongsTo.hpp` was documented as "a one-to-one relationship"; it is the many-to-one side, and the first relationship a reader meets.

Plus `ParfOfC` and a spelling sweep.

## A build that was broken for anyone on a current Doxygen

The `doc` target failed under Doxygen 1.17 with two "Invalid list item found" errors in `sqlquery.md`, so `LIGHTWEIGHT_DOCS_WARN_AS_ERROR=ON` could not pass locally. CI missed it because ubuntu-24.04 ships Doxygen 1.9.8.

Bisected to a single markdown link carrying an anchor fragment inside a nested list item, which makes 1.17 close the enclosing list — neither reported line was itself at fault. Replaced with Doxygen's own `@ref` form, already the idiom in `sql-backup.md`; the rendered link is unchanged.

## Verification

The docs target builds with zero diagnostics. Every code example in the new guides, the corrected examples, and all nine `async.md` examples were compile-checked against the library headers, as were all 48 code blocks across the remaining guides. Documented `dbtool` commands and flags were diffed against the tool's own dispatch table, and every relative doc link resolves.

Closes #565
