### PR TITLE
fix(SqlQuery): bind WhereIn values instead of inlining them

### DIFF
--- a/docs/sql-to-lightweight.md
+++ b/docs/sql-to-lightweight.md
@@ -176,6 +176,10 @@ auto rows = dm.Query<Employee>().WhereIn(FieldNameOf<&Employee::department>, dep
 
 `WhereIn` accepts any range (`std::vector`, `std::set`, an initializer list) or a sub-select query.
 
+The values become bound parameters — `IN (?, ?, ?)` — whenever the query carries a bindings
+vector, which is always the case for `DataMapper` queries. On the low-level `SqlQueryBuilder`
+without one, they are inlined into the SQL text as escaped literals instead.
+
 An **empty** range means "match nothing", and emits `WHERE 1 = 0` rather than omitting the condition.
 This matters most for `Delete()`: `dm.FromTable("Employees").Delete().WhereIn("department_id", ids)`
 with an empty `ids` deletes no rows, instead of every row in the table.

--- a/src/Lightweight/SqlQuery/Core.hpp
+++ b/src/Lightweight/SqlQuery/Core.hpp
@@ -1145,7 +1145,36 @@ template <typename LiteralType>
 detail::RawSqlCondition SqlWhereClauseBuilder<Derived>::PopulateSqlSetExpression(LiteralType const& values)
 {
     using namespace std::string_view_literals;
+
+    using ValueType = std::ranges::range_value_t<LiteralType>;
+
+    // Mirrors the dispatch in AppendLiteralValue: these types have no parameter representation and
+    // must stay inline in the SQL text. Everything else becomes a parameter marker whenever the
+    // caller supplied a bindings vector, so that the statement stays reusable across differing
+    // IN-sets and the driver — not this builder — encodes the value.
+    constexpr bool isBindable =
+        !(std::is_same_v<ValueType, SqlQualifiedTableColumnName> || detail::OneOf<ValueType, SqlNullType, std::nullopt_t>
+          || std::is_same_v<ValueType, SqlWildcardType> || std::is_same_v<ValueType, detail::RawSqlCondition>);
+
+    auto& searchCondition = SearchCondition();
+
     std::ostringstream fragment;
+
+    auto const appendValue = [&](auto const& value) {
+        if constexpr (isBindable)
+        {
+            if (searchCondition.inputBindings)
+            {
+                fragment << '?';
+                searchCondition.inputBindings->emplace_back(value);
+                return;
+            }
+        }
+        std::string valueString;
+        PopulateLiteralValueInto(value, valueString);
+        fragment << valueString;
+    };
+
     fragment << '(';
 #if !defined(__cpp_lib_ranges_enumerate)
     int index { -1 };
@@ -1159,9 +1188,7 @@ detail::RawSqlCondition SqlWhereClauseBuilder<Derived>::PopulateSqlSetExpression
         if (index > 0)
             fragment << ", "sv;
 
-        std::string valueString;
-        PopulateLiteralValueInto(value, valueString);
-        fragment << valueString;
+        appendValue(value);
     }
     fragment << ')';
     return detail::RawSqlCondition { fragment.str() };

--- a/src/Lightweight/SqlQuery/Core.hpp
+++ b/src/Lightweight/SqlQuery/Core.hpp
@@ -1160,13 +1160,27 @@ detail::RawSqlCondition SqlWhereClauseBuilder<Derived>::PopulateSqlSetExpression
 
     std::ostringstream fragment;
 
+    // String literals decay to a raw character pointer inside an initializer list (and inside a
+    // built-in array), and SqlVariant cannot be constructed from one: std::variant's converting
+    // constructor is ambiguous between std::string and std::string_view. Hand such elements over as
+    // views, mirroring the dedicated char-array overload of Where().
+    auto const asBindable = [](auto const& value) -> decltype(auto) {
+        using Decayed = std::decay_t<decltype(value)>;
+        if constexpr (detail::OneOf<Decayed, char*, char const*>)
+            return std::string_view { value };
+        else if constexpr (detail::OneOf<Decayed, char16_t*, char16_t const*>)
+            return std::u16string_view { value };
+        else
+            return (value);
+    };
+
     auto const appendValue = [&](auto const& value) {
         if constexpr (isBindable)
         {
             if (searchCondition.inputBindings)
             {
                 fragment << '?';
-                searchCondition.inputBindings->emplace_back(value);
+                searchCondition.inputBindings->emplace_back(asBindable(value));
                 return;
             }
         }

--- a/src/tests/DataMapper/ReadTests.cpp
+++ b/src/tests/DataMapper/ReadTests.cpp
@@ -38,13 +38,14 @@ TEST_CASE_METHOD(SqlTestFixture, "Query.WhereIn binds its values", "[DataMapper]
          })
         dm.Create(person);
 
-    CHECK(dm.Query<Person>().WhereIn(FieldNameOf<&Person::name>, std::vector { "O'Brien"s, "Jane Doe"s }).All().size() == 2);
+    CHECK(dm.Query<Person>().WhereIn(FieldNameOf<Member(Person::name)>, std::vector { "O'Brien"s, "Jane Doe"s }).All().size()
+          == 2);
 
     // The quoted name on its own, to pin down that it is the apostrophe-bearing row that matches.
-    CHECK(dm.Query<Person>().WhereIn(FieldNameOf<&Person::name>, std::vector { "O'Brien"s }).All().size() == 1);
+    CHECK(dm.Query<Person>().WhereIn(FieldNameOf<Member(Person::name)>, std::vector { "O'Brien"s }).All().size() == 1);
 
     // An empty IN-set matches nothing.
-    CHECK(dm.Query<Person>().WhereIn(FieldNameOf<&Person::name>, std::vector<std::string> {}).All().empty());
+    CHECK(dm.Query<Person>().WhereIn(FieldNameOf<Member(Person::name)>, std::vector<std::string> {}).All().empty());
 }
 
 TEST_CASE_METHOD(SqlTestFixture, "Query", "[DataMapper]")

--- a/src/tests/DataMapper/ReadTests.cpp
+++ b/src/tests/DataMapper/ReadTests.cpp
@@ -23,6 +23,30 @@ using namespace Lightweight;
 
 // NOLINTBEGIN(bugprone-unchecked-optional-access)
 
+TEST_CASE_METHOD(SqlTestFixture, "Query.WhereIn binds its values", "[DataMapper]")
+{
+    // DataMapper queries always carry a bindings vector, so WhereIn goes through parameter markers
+    // rather than inlined literals. The apostrophe is the tell: a bound value reaches the driver
+    // untouched, without the query builder having to escape it into the SQL text.
+    auto dm = DataMapper();
+
+    dm.CreateTable<Person>();
+    for (auto& person: std::array {
+             Person { .id = SqlGuid::Create(), .name = "O'Brien", .is_active = true, .age = 42 },
+             Person { .id = SqlGuid::Create(), .name = "Jane Doe", .is_active = true, .age = 36 },
+             Person { .id = SqlGuid::Create(), .name = "Jimbo Jones", .is_active = false, .age = 69 },
+         })
+        dm.Create(person);
+
+    CHECK(dm.Query<Person>().WhereIn(FieldNameOf<&Person::name>, std::vector { "O'Brien"s, "Jane Doe"s }).All().size() == 2);
+
+    // The quoted name on its own, to pin down that it is the apostrophe-bearing row that matches.
+    CHECK(dm.Query<Person>().WhereIn(FieldNameOf<&Person::name>, std::vector { "O'Brien"s }).All().size() == 1);
+
+    // An empty IN-set matches nothing.
+    CHECK(dm.Query<Person>().WhereIn(FieldNameOf<&Person::name>, std::vector<std::string> {}).All().empty());
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "Query", "[DataMapper]")
 {
     auto dm = DataMapper();

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -714,6 +714,21 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn binds its values when 
             CHECK(std::get<std::string_view>(inputBindings[2].value) == "b"sv);
         });
 
+    // String literals decay to `char const*` inside an initializer list, which SqlVariant cannot be
+    // constructed from directly — they must still bind rather than fail to compile.
+    CheckSqlQueryBuilder(
+        [&](SqlQueryBuilder& q) {
+            inputBindings.clear();
+            return q.FromTable("That").Update(&inputBindings).Set("a", 1).WhereIn("foo", { "O'Brien", "b" });
+        },
+        QueryExpectations::All(R"(UPDATE "That" SET "a" = ?
+                                  WHERE "foo" IN (?, ?))"),
+        [&]() {
+            REQUIRE(inputBindings.size() == 3);
+            CHECK(std::get<std::string_view>(inputBindings[1].value) == "O'Brien"sv);
+            CHECK(std::get<std::string_view>(inputBindings[2].value) == "b"sv);
+        });
+
     // An empty IN-set still short-circuits to the always-false condition and binds nothing.
     CheckSqlQueryBuilder(
         [&](SqlQueryBuilder& q) {

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -665,6 +665,66 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn", "[SqlQueryBuilder]")
                                                    WHERE "foo" IN (1, 2, 3))"));
 }
 
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn binds its values when bindings are requested", "[SqlQueryBuilder]")
+{
+    using namespace std::string_view_literals;
+
+    // When the caller supplies a bindings vector, every literal must become a parameter marker —
+    // otherwise the statement cannot be reused across differing IN-sets and the values bypass the
+    // driver's own literal encoding.
+    std::vector<SqlVariant> inputBindings;
+
+    CheckSqlQueryBuilder(
+        [&](SqlQueryBuilder& q) {
+            inputBindings.clear();
+            return q.FromTable("That").Update(&inputBindings).Set("a", 1).WhereIn("foo", std::vector { 10, 20, 30 });
+        },
+        QueryExpectations::All(R"(UPDATE "That" SET "a" = ?
+                                  WHERE "foo" IN (?, ?, ?))"),
+        [&]() {
+            // The SET value binds before the WHERE values, matching the order of the markers.
+            REQUIRE(inputBindings.size() == 4);
+            CHECK(std::get<int>(inputBindings[0].value) == 1);
+            CHECK(std::get<int>(inputBindings[1].value) == 10);
+            CHECK(std::get<int>(inputBindings[2].value) == 20);
+            CHECK(std::get<int>(inputBindings[3].value) == 30);
+        });
+
+    // The initializer_list overload binds as well.
+    CheckSqlQueryBuilder(
+        [&](SqlQueryBuilder& q) {
+            inputBindings.clear();
+            return q.FromTable("That").Update(&inputBindings).Set("a", 1).WhereIn("foo", { 10, 20 });
+        },
+        QueryExpectations::All(R"(UPDATE "That" SET "a" = ?
+                                  WHERE "foo" IN (?, ?))"),
+        [&]() { REQUIRE(inputBindings.size() == 3); });
+
+    // Strings are handed over verbatim rather than being escaped into the SQL text.
+    CheckSqlQueryBuilder(
+        [&](SqlQueryBuilder& q) {
+            inputBindings.clear();
+            return q.FromTable("That").Update(&inputBindings).Set("a", 1).WhereIn("foo", std::vector { "O'Brien"sv, "b"sv });
+        },
+        QueryExpectations::All(R"(UPDATE "That" SET "a" = ?
+                                  WHERE "foo" IN (?, ?))"),
+        [&]() {
+            REQUIRE(inputBindings.size() == 3);
+            CHECK(std::get<std::string_view>(inputBindings[1].value) == "O'Brien"sv);
+            CHECK(std::get<std::string_view>(inputBindings[2].value) == "b"sv);
+        });
+
+    // An empty IN-set still short-circuits to the always-false condition and binds nothing.
+    CheckSqlQueryBuilder(
+        [&](SqlQueryBuilder& q) {
+            inputBindings.clear();
+            return q.FromTable("That").Update(&inputBindings).Set("a", 1).WhereIn("foo", std::vector<int> {});
+        },
+        QueryExpectations::All(R"(UPDATE "That" SET "a" = ?
+                                  WHERE 1 = 0)"),
+        [&]() { REQUIRE(inputBindings.size() == 1); });
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.WhereIn accepts a range without a member empty()", "[SqlQueryBuilder]")
 {
     // A built-in array is an input_range but has no `.empty()` member, so the emptiness check must


### PR DESCRIPTION
`WhereIn` serialized its values into the SQL text even when the caller had supplied a bindings
vector, so `IN (1, 2, 3)` was emitted where `IN (?, ?, ?)` was asked for. That defeats
prepared-statement reuse across differing IN-sets and bypasses the driver's own literal encoding.
`DataMapper` queries always carry a bindings vector, so every `DataMapper` `WhereIn` was affected.

The values now become parameter markers and are pushed onto the bindings vector, mirroring the
dispatch `AppendLiteralValue` already uses — the types that have no parameter representation
(`NULL`, wildcard, qualified column name, raw SQL) stay inline.

Two paths are deliberately unchanged: without a bindings vector the values are still inlined as
escaped literals, and an empty IN-set still short-circuits to `1 = 0`.

This completes the last open sub-item of #561; the other two shipped in #568.

Fixes #561