### PR TITLE
fix(QueryFormatter): forward GROUP BY to SelectFirst and SelectCount

### DIFF
--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -1140,7 +1140,8 @@ size_t SqlCoreDataMapperQueryBuilder<Record, Derived, QueryOptions>::CountImpl()
                                         RecordTableName<Record>,
                                         this->_query.searchCondition.tableAlias,
                                         this->_query.searchCondition.tableJoins,
-                                        this->_query.searchCondition.condition));
+                                        this->_query.searchCondition.condition,
+                                        this->_query.groupBy));
     auto reader = stmt.ExecuteWithVariants(_boundInputs);
     if (reader.FetchRow())
         return reader.template GetColumn<size_t>(1);
@@ -1159,6 +1160,7 @@ bool SqlCoreDataMapperQueryBuilder<Record, Derived, QueryOptions>::ExistImpl()
                                               this->_query.searchCondition.tableJoins,
                                               this->_query.searchCondition.condition,
                                               this->_query.orderBy,
+                                              this->_query.groupBy,
                                               1);
 
     stmt.Prepare(query);
@@ -1309,6 +1311,7 @@ std::optional<Record> SqlCoreDataMapperQueryBuilder<Record, Derived, QueryOption
                                         this->_query.searchCondition.tableJoins,
                                         this->_query.searchCondition.condition,
                                         this->_query.orderBy,
+                                        this->_query.groupBy,
                                         1));
     Derived::ReadResult(stmt.Connection().ServerType(), stmt.ExecuteWithVariants(_boundInputs), &record);
     if constexpr (QueryOptions.loadRelations)
@@ -1337,6 +1340,7 @@ auto SqlCoreDataMapperQueryBuilder<Record, Derived, QueryOptions>::FirstImpl() -
                                         this->_query.searchCondition.tableJoins,
                                         this->_query.searchCondition.condition,
                                         this->_query.orderBy,
+                                        this->_query.groupBy,
                                         count));
     if (auto reader = stmt.ExecuteWithVariants(_boundInputs); reader.FetchRow())
         return reader.template GetColumn<ReferencedFieldTypeOf<Field>>(1);
@@ -1358,6 +1362,7 @@ auto SqlCoreDataMapperQueryBuilder<Record, Derived, QueryOptions>::FirstImpl() -
                                         this->_query.searchCondition.tableJoins,
                                         this->_query.searchCondition.condition,
                                         this->_query.orderBy,
+                                        this->_query.groupBy,
                                         1));
 
     auto& record = optionalRecord.emplace();
@@ -1407,6 +1412,7 @@ std::vector<Record> SqlCoreDataMapperQueryBuilder<Record, Derived, QueryOptions>
                                         this->_query.searchCondition.tableJoins,
                                         this->_query.searchCondition.condition,
                                         this->_query.orderBy,
+                                        this->_query.groupBy,
                                         n));
     Derived::ReadResults(stmt.Connection().ServerType(), stmt.ExecuteWithVariants(_boundInputs), &records);
 
@@ -1513,6 +1519,7 @@ template <auto... ReferencedFields>
                                         this->_query.searchCondition.tableJoins,
                                         this->_query.searchCondition.condition,
                                         this->_query.orderBy,
+                                        this->_query.groupBy,
                                         n));
 
     auto reader = stmt.ExecuteWithVariants(_boundInputs);

--- a/src/Lightweight/DataMapper/QueryBuilders.hpp
+++ b/src/Lightweight/DataMapper/QueryBuilders.hpp
@@ -85,7 +85,10 @@ class [[nodiscard]] SqlCoreDataMapperQueryBuilder: public SqlBasicSelectQueryBui
     /// Executes a SELECT COUNT query and returns the number of records found.
     ///
     /// A preceding @c GroupBy is honored, making the query count per group. Since only a single
-    /// value is returned, the count of the first group is what the caller receives.
+    /// value is returned, the caller receives the count of one arbitrary group: the emitted
+    /// SELECT COUNT query carries no ORDER BY (a preceding @c OrderBy does not apply to it), so
+    /// which group's count is read back is unspecified and may differ between database systems
+    /// and between runs.
     [[nodiscard]] auto Count()
     {
         return RunFinisher([this] { return CountImpl(); });

--- a/src/Lightweight/DataMapper/QueryBuilders.hpp
+++ b/src/Lightweight/DataMapper/QueryBuilders.hpp
@@ -83,6 +83,9 @@ class [[nodiscard]] SqlCoreDataMapperQueryBuilder: public SqlBasicSelectQueryBui
     }
 
     /// Executes a SELECT COUNT query and returns the number of records found.
+    ///
+    /// A preceding @c GroupBy is honored, making the query count per group. Since only a single
+    /// value is returned, the count of the first group is what the caller receives.
     [[nodiscard]] auto Count()
     {
         return RunFinisher([this] { return CountImpl(); });

--- a/src/Lightweight/QueryFormatter/SQLiteFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/SQLiteFormatter.hpp
@@ -132,19 +132,25 @@ class SQLiteQueryFormatter: public SqlQueryFormatter
                                           std::string_view fromTable,
                                           std::string_view fromTableAlias,
                                           std::string_view tableJoins,
-                                          std::string_view whereCondition) const override
+                                          std::string_view whereCondition,
+                                          std::string_view groupBy) const override
     {
         auto const formattedTable = FormatFromTable(fromTable);
         if (fromTableAlias.empty())
-            return std::format(
-                "SELECT{} COUNT(*) FROM {}{}{}", distinct ? " DISTINCT" : "", formattedTable, tableJoins, whereCondition);
+            return std::format("SELECT{} COUNT(*) FROM {}{}{}{}",
+                               distinct ? " DISTINCT" : "",
+                               formattedTable,
+                               tableJoins,
+                               whereCondition,
+                               groupBy);
         else
-            return std::format(R"(SELECT{} COUNT(*) FROM {} AS "{}"{}{})",
+            return std::format(R"(SELECT{} COUNT(*) FROM {} AS "{}"{}{}{})",
                                distinct ? " DISTINCT" : "",
                                formattedTable,
                                fromTableAlias,
                                tableJoins,
-                               whereCondition);
+                               whereCondition,
+                               groupBy);
     }
 
     [[nodiscard]] std::string SelectAll(bool distinct,
@@ -181,6 +187,7 @@ class SQLiteQueryFormatter: public SqlQueryFormatter
                                           std::string_view tableJoins,
                                           std::string_view whereCondition,
                                           std::string_view orderBy,
+                                          std::string_view groupBy,
                                           size_t count) const override
     {
         std::stringstream sqlQueryString;
@@ -193,6 +200,7 @@ class SQLiteQueryFormatter: public SqlQueryFormatter
             sqlQueryString << " AS \"" << fromTableAlias << "\"";
         sqlQueryString << tableJoins;
         sqlQueryString << whereCondition;
+        sqlQueryString << groupBy;
         sqlQueryString << orderBy;
         sqlQueryString << " LIMIT " << count;
         return sqlQueryString.str();

--- a/src/Lightweight/QueryFormatter/SqlServerFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/SqlServerFormatter.hpp
@@ -271,6 +271,7 @@ EXEC sp_executesql @sql;)",
                                           std::string_view tableJoins,
                                           std::string_view whereCondition,
                                           std::string_view orderBy,
+                                          std::string_view groupBy,
                                           size_t count) const override
     {
         std::stringstream sqlQueryString;
@@ -284,6 +285,7 @@ EXEC sp_executesql @sql;)",
             sqlQueryString << " AS [" << fromTableAlias << ']';
         sqlQueryString << tableJoins;
         sqlQueryString << whereCondition;
+        sqlQueryString << groupBy;
         sqlQueryString << orderBy;
         return sqlQueryString.str();
     }

--- a/src/Lightweight/SqlQuery/Core.cpp
+++ b/src/Lightweight/SqlQuery/Core.cpp
@@ -23,6 +23,7 @@ std::string Lightweight::detail::ComposedQuery::ToSql() const
                                           searchCondition.tableJoins,
                                           searchCondition.condition,
                                           orderBy,
+                                          groupBy,
                                           limit);
         case SelectType::Range:
             return formatter->SelectRange(distinct,
@@ -40,7 +41,8 @@ std::string Lightweight::detail::ComposedQuery::ToSql() const
                                           searchCondition.tableName,
                                           searchCondition.tableAlias,
                                           searchCondition.tableJoins,
-                                          searchCondition.condition);
+                                          searchCondition.condition,
+                                          groupBy);
         case SelectType::Undefined:
             break;
     }

--- a/src/Lightweight/SqlQuery/Select.hpp
+++ b/src/Lightweight/SqlQuery/Select.hpp
@@ -198,6 +198,9 @@ class [[nodiscard]] SqlSelectQueryBuilder: public SqlBasicSelectQueryBuilder<Sql
     SqlSelectQueryBuilder& Build(Callable const& callable);
 
     /// Finalizes building the query as SELECT COUNT(*) ... query.
+    ///
+    /// A preceding @c GroupBy is honored: the query then counts the rows of each group and
+    /// yields one row per group, rather than a single total over the whole result set.
     LIGHTWEIGHT_API ComposedQuery Count();
 
     /// @copydoc Count

--- a/src/Lightweight/SqlQueryFormatter.hpp
+++ b/src/Lightweight/SqlQueryFormatter.hpp
@@ -83,6 +83,9 @@ class [[nodiscard]] LIGHTWEIGHT_API SqlQueryFormatter
                                                 std::string_view groupBy) const = 0;
 
     /// Constructs an SQL SELECT query for the first row.
+    ///
+    /// When @p groupBy is non-empty it is emitted between the WHERE and the ORDER BY clause, so
+    /// the row limit given by @p count applies to the grouped result set.
     [[nodiscard]] virtual std::string SelectFirst(bool distinct,
                                                   std::string_view fields,
                                                   std::string_view fromTable,

--- a/src/Lightweight/SqlQueryFormatter.hpp
+++ b/src/Lightweight/SqlQueryFormatter.hpp
@@ -90,6 +90,7 @@ class [[nodiscard]] LIGHTWEIGHT_API SqlQueryFormatter
                                                   std::string_view tableJoins,
                                                   std::string_view whereCondition,
                                                   std::string_view orderBy,
+                                                  std::string_view groupBy,
                                                   size_t count) const = 0;
 
     /// Constructs an SQL SELECT query for a range of rows.
@@ -105,11 +106,15 @@ class [[nodiscard]] LIGHTWEIGHT_API SqlQueryFormatter
                                                   std::size_t limit) const = 0;
 
     /// Constructs an SQL SELECT query retrieve the count of rows matching the given condition.
+    ///
+    /// When @p groupBy is non-empty the query counts the rows of each group, i.e. it yields one
+    /// row per group rather than a single total.
     [[nodiscard]] virtual std::string SelectCount(bool distinct,
                                                   std::string_view fromTable,
                                                   std::string_view fromTableAlias,
                                                   std::string_view tableJoins,
-                                                  std::string_view whereCondition) const = 0;
+                                                  std::string_view whereCondition,
+                                                  std::string_view groupBy) const = 0;
 
     /// Constructs an SQL UPDATE query.
     [[nodiscard]] virtual std::string Update(std::string_view table,

--- a/src/tests/DataMapper/ReadTests.cpp
+++ b/src/tests/DataMapper/ReadTests.cpp
@@ -47,6 +47,14 @@ TEST_CASE_METHOD(SqlTestFixture, "Query", "[DataMapper]")
         CHECK(countAll == 4);
     }
 
+    SECTION("Count() honors GroupBy")
+    {
+        // Two active and two inactive persons, so every group holds exactly two rows and the
+        // expectation is independent of which group the database returns first.
+        auto const groupedCount = dm.Query<Person>().GroupBy(FieldNameOf<Member(Person::is_active)>).Count();
+        CHECK(groupedCount == 2);
+    }
+
     SECTION("Exist()")
     {
         auto const existSome = dm.Query<Person>().Where(FieldNameOf<Member(Person::is_active)>, "=", true).Exist();

--- a/src/tests/MigrationTests.cpp
+++ b/src/tests/MigrationTests.cpp
@@ -2041,6 +2041,14 @@ class CapturingWarningLogger: public Lightweight::SqlLogger::Null
 
 /// @brief Tiny synthetic stand-in for `MigrationBase` used by policy-composition tests.
 /// We only need `GetTimestamp` to be callable from a `CompatPolicy` lambda.
+///
+/// Constructing one auto-registers it with `MigrationManager::GetInstance()` (a
+/// hard-coded side effect of the `MigrationBase` ctor). These stubs have automatic
+/// storage duration, so the destructor below resets the singleton rather than leaving
+/// a dangling pointer behind: `AddMigration` compares timestamps through the stored
+/// pointers, so a later migration allocated at a recycled address is (incorrectly)
+/// reported as a duplicate of itself. PluginIngestionTests.cpp's `FakeMigration`
+/// carries the same reset for the same reason.
 class StubMigration: public Lightweight::SqlMigration::MigrationBase
 {
   public:
@@ -2048,6 +2056,17 @@ class StubMigration: public Lightweight::SqlMigration::MigrationBase
         MigrationBase(Lightweight::SqlMigration::MigrationTimestamp { ts }, "stub")
     {
     }
+
+    ~StubMigration() override
+    {
+        Lightweight::SqlMigration::MigrationManager::GetInstance().RemoveAllMigrations();
+        Lightweight::SqlMigration::MigrationManager::GetInstance().RemoveAllReleases();
+    }
+
+    StubMigration(StubMigration const&) = delete;
+    StubMigration& operator=(StubMigration const&) = delete;
+    StubMigration(StubMigration&&) = delete;
+    StubMigration& operator=(StubMigration&&) = delete;
 
     void Up(Lightweight::SqlMigrationQueryBuilder& /*plan*/) const override {}
 };

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -108,6 +108,43 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.Count", "[SqlQueryBuild
                          QueryExpectations::All("SELECT COUNT(*) FROM \"Table\""));
 }
 
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.Count.GroupBy", "[SqlQueryBuilder]")
+{
+    CheckSqlQueryBuilder([](SqlQueryBuilder& q) { return q.FromTable("Table").Select().GroupBy("a").Count(); },
+                         QueryExpectations::All(R"(SELECT COUNT(*) FROM "Table"
+                                                   GROUP BY "a")"));
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.First.GroupBy", "[SqlQueryBuilder]")
+{
+    CheckSqlQueryBuilder([](SqlQueryBuilder& q) { return q.FromTable("That").Select().Field("a").GroupBy("a").First(); },
+                         QueryExpectations {
+                             .sqlite = R"(SELECT "a" FROM "That"
+                         GROUP BY "a" LIMIT 1)",
+                             .postgres = R"(SELECT "a" FROM "That"
+                           GROUP BY "a" LIMIT 1)",
+                             .sqlServer = R"(SELECT TOP 1 "a" FROM "That"
+                            GROUP BY "a")",
+                         });
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.First.GroupBy.OrderBy", "[SqlQueryBuilder]")
+{
+    CheckSqlQueryBuilder(
+        [](SqlQueryBuilder& q) { return q.FromTable("That").Select().Field("a").GroupBy("a").OrderBy("a").First(3); },
+        QueryExpectations {
+            .sqlite = R"(SELECT "a" FROM "That"
+                         GROUP BY "a"
+                         ORDER BY "a" ASC LIMIT 3)",
+            .postgres = R"(SELECT "a" FROM "That"
+                           GROUP BY "a"
+                           ORDER BY "a" ASC LIMIT 3)",
+            .sqlServer = R"(SELECT TOP 3 "a" FROM "That"
+                            GROUP BY "a"
+                            ORDER BY "a" ASC)",
+        });
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Select.All", "[SqlQueryBuilder]")
 {
     CheckSqlQueryBuilder(


### PR DESCRIPTION
Fixes #559.

## Problem

`SqlQueryFormatter::SelectFirst` and `SelectCount` took no `groupBy` parameter, so a populated `ComposedQuery::groupBy` could never reach them — `.GroupBy(...).First()` and `.GroupBy(...).Count()` silently returned ungrouped results. `SelectAll` and `SelectRange` already took it, which is what marks the omission as accidental.

```cpp
q.FromTable("T").Select().Field("a").GroupBy("a").First().ToSql();
// before: SELECT "a" FROM "T" LIMIT 1        <- GROUP BY dropped
// after:  SELECT "a" FROM "T" GROUP BY "a" LIMIT 1
```

## Change

- Added `std::string_view groupBy` to both virtuals, positioned after `orderBy` to match `SelectRange`.
- Implemented in `SQLiteQueryFormatter` (`SelectCount` + `SelectFirst`, inherited by PostgreSQL) and `SqlServerQueryFormatter` (`SelectFirst`). The clause is emitted between WHERE and ORDER BY, exactly as `SelectAll`/`SelectRange` already do.
- Forwarded from `ComposedQuery::ToSql` in the `First` and `Count` branches.
- The DataMapper query builder calls the formatter directly rather than through `ToSql`, so it had the same bug at 7 further sites — `CountImpl`, `ExistImpl`, the three `FirstImpl` overloads and both `FirstImpl(n)` overloads. All now pass the builder's `groupBy`.
- Documented the grouped-count semantics on both `Count()` surfaces: `SELECT COUNT(*) … GROUP BY x` yields one row per group, and the DataMapper's `Count()` returns the first group's count since it reads a single value.

`HAVING` is still unsupported — noted in the issue as a separate gap, deliberately left out of scope here.

## Tests

Three cases in `QueryBuilderTests.cpp` covering `Count()+GroupBy`, `First()+GroupBy` and `First(3)+GroupBy+OrderBy` across all three dialects. All three fail on master (GROUP BY absent from the generated SQL) and pass with this change.

## Risk

Source/ABI break for any out-of-tree `SqlQueryFormatter` implementation, as the issue anticipated; every in-tree implementor is updated. Behaviour is unchanged wherever `groupBy` is empty — the generated SQL is byte-identical, which is why the rest of the suite is unaffected.

Performance: no measurable impact — one extra `string_view` argument and one stream insertion of an empty view on the unchanged paths.

## Verification

- **SQLite / `clang-debug`** (ASan+UBSan+clang-tidy) on this exact commit in a clean tree: 1405 cases, 13641 assertions, all pass (1 pre-existing skip). Build is warning-free; `clang-format` applied.
- **mssql2022 and postgres (Docker)** were run green on this change earlier in the session — 13618 and 13571 assertions respectively, 0 failures — but in a working tree that also carried unrelated in-flight work, and a re-run against this exact commit was not possible because the containers were being used concurrently by another session (the suite drops all tables at fixture setup, so parallel runs corrupt each other). Worth confirming in CI.
- **Not run locally: `gcc-release`.** No GCC toolchain on this machine, so the compiler CI's database legs actually use is unverified here.