### PR TITLE
Address result columns by the name used in the query builder

### DIFF
--- a/docs/sqlquery.md
+++ b/docs/sqlquery.md
@@ -89,7 +89,7 @@ interface. Here we present a compressed list of functions that can be used to cr
     - Adds a DISTINCT clause to the SELECT query.
   - `Field()`
     - Simple usage `Field("field")` 
-    - With table name specification as `Field(SqlQualifiedTableColumnName { "Table", "field" })`
+    - With table name specification as `Field(SqlQualifiedTableColumnName { .tableName = "Table", .columnName = "field" })`
     - Helper function to construct `SqlQualifiedTableColumnName` from a string `QualifiedColumnName<"Table.field">`
   - `Fields()`
     - Simple usage `Fields({"a", "b", "c"})`
@@ -199,6 +199,54 @@ auto query = q.FromTable("Table_A")
               .Where(SqlQualifiedTableColumnName { .tableName = "Table_A", .columnName = "foo" }, 42)
               .All();
 ```
+
+
+### Reading result columns by name
+
+Result columns of a builder-composed query can be addressed by the name spelled in the builder,
+instead of by a 1-based index that shifts whenever the projection changes:
+
+```cpp
+auto cursor = stmt.ExecuteDirect(stmt.Query("Table_A")
+                                     .Select()
+                                     .Field(SqlQualifiedTableColumnName { .tableName = "Table_A", .columnName = "foo" })
+                                     .Fields({ "that_foo"sv, "that_id"sv }, "Table_B")
+                                     .Field(Aggregate::Count("id"sv)).As("total"sv)
+                                     .LeftOuterJoin("Table_B", "id"sv, "that_id"sv)
+                                     .All());
+
+while (cursor.FetchRow())
+{
+    auto const foo = cursor.GetColumn<int>("Table_A.foo");
+    auto const thatFoo = cursor.GetColumn<int>("Table_B.that_foo");
+    auto const total = cursor.GetColumn<int>("total");
+}
+```
+
+`GetNullableColumn<T>(name)` and `GetColumnOr<T>(name, defaultValue)` take a name the same way.
+
+The name is matched exactly as it was written in the builder — no case folding and no implicit
+qualification:
+
+| Builder call | Name to read it back by |
+|---|---|
+| `Field("foo")` | `"foo"` |
+| `Field({ "Table_A", "foo" })` | `"Table_A.foo"` |
+| `Fields({ "a"sv, "b"sv }, "Table_B")` | `"Table_B.a"`, `"Table_B.b"` |
+| `Field(...).As("total")` | `"total"` |
+| `Field(Aggregate::Count("id"sv))` | not addressable — add `.As(...)` |
+
+The mapping is recorded by the query builder as the projection is assembled, so it behaves
+identically on every supported database. Consequently it is available only for builder-composed
+queries: a statement prepared from a raw SQL string has no mapping, and neither does a projection
+containing a wildcard (`Field("*")`), whose column count is unknown at build time. Reading a name
+that is unknown, ambiguous (projected twice — alias one of them), or unavailable throws
+`std::invalid_argument`.
+
+> [!NOTE]
+> Columns must still be read in ascending column order. The SQL Server driver rejects out-of-order
+> `SQLGetData` with SQLSTATE 07009, and addressing columns by name makes it easy to reorder reads
+> without noticing.
 
 
 ### Examples of SQL to DataMapper mappings

--- a/src/Lightweight/SqlQuery/Core.hpp
+++ b/src/Lightweight/SqlQuery/Core.hpp
@@ -10,6 +10,9 @@
 #include <concepts>
 #include <optional>
 #include <ranges>
+#include <span>
+#include <string>
+#include <vector>
 
 namespace Lightweight
 {
@@ -471,6 +474,21 @@ namespace detail
 
         std::string fields;
 
+        /// @brief The name of each projected column, in result-column order, as spelled by the caller.
+        ///
+        /// Populated by the projection methods of @c SqlSelectQueryBuilder so that result columns can be
+        /// addressed by name without asking the driver for result-set metadata (which cannot report table
+        /// names portably). An entry is empty for a projection that carries no caller-given name, such as
+        /// an un-aliased aggregate; the empty slot keeps the remaining entries aligned with their columns.
+        std::vector<std::string> projectedFieldNames;
+
+        /// @brief Whether the projection contains a wildcard, whose column count is unknown at build time.
+        ///
+        /// A wildcard makes every position after it unpredictable, so named column access is unavailable
+        /// for the whole query. Kept separate from an empty @c projectedFieldNames so the diagnostic can
+        /// name the actual cause.
+        bool projectionHasWildcard = false;
+
         std::string orderBy;
         std::string groupBy;
 
@@ -478,6 +496,20 @@ namespace detail
         size_t limit = (std::numeric_limits<size_t>::max)();
 
         [[nodiscard]] LIGHTWEIGHT_API std::string ToSql() const;
+
+        /// @brief The projected column names, in result-column order, for named column access.
+        /// @return One entry per result column, empty for unnamed projections; an empty span when the
+        ///         query carries no usable mapping (e.g. the projection contains a wildcard).
+        [[nodiscard]] std::span<std::string const> ProjectedFieldNames() const noexcept
+        {
+            return projectedFieldNames;
+        }
+
+        /// @copydoc projectionHasWildcard
+        [[nodiscard]] bool ProjectionHasWildcard() const noexcept
+        {
+            return projectionHasWildcard;
+        }
     };
 } // namespace detail
 

--- a/src/Lightweight/SqlQuery/Select.cpp
+++ b/src/Lightweight/SqlQuery/Select.cpp
@@ -2,8 +2,32 @@
 
 #include "Select.hpp"
 
+#include <format>
+
 namespace Lightweight
 {
+
+void SqlSelectQueryBuilder::RecordProjectedFieldName(std::string name) const
+{
+    // A wildcard expands to an unknown number of columns, so nothing projected after it has a
+    // predictable position. Recording those names would misalign them with their result columns.
+    if (_query.projectionHasWildcard)
+        return;
+
+    _query.projectedFieldNames.emplace_back(std::move(name));
+}
+
+void SqlSelectQueryBuilder::RenameLastProjectedFieldName(std::string_view alias) const
+{
+    if (!_query.projectedFieldNames.empty())
+        _query.projectedFieldNames.back() = std::string(alias);
+}
+
+void SqlSelectQueryBuilder::RecordProjectionWildcard() const
+{
+    _query.projectionHasWildcard = true;
+    _query.projectedFieldNames.clear();
+}
 
 SqlSelectQueryBuilder& SqlSelectQueryBuilder::Field(std::string_view const& fieldName)
 {
@@ -11,13 +35,17 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::Field(std::string_view const& fiel
         _query.fields += ", ";
 
     if (fieldName == "*")
+    {
         _query.fields += fieldName;
+        RecordProjectionWildcard();
+    }
     else
     {
         _query.fields += '"';
         _query.fields += fieldName;
         _query.fields += '"';
         _aliasAllowed = true;
+        RecordProjectedFieldName(std::string(fieldName));
     }
 
     return *this;
@@ -31,13 +59,17 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::Field(SqlQualifiedTableColumnName 
     _query.fields += '"';
     _query.fields += fieldName.tableName;
     if (fieldName.columnName == "*")
+    {
         _query.fields += "\".*";
+        RecordProjectionWildcard();
+    }
     else
     {
         _query.fields += "\".\"";
         _query.fields += fieldName.columnName;
         _query.fields += '"';
         _aliasAllowed = true;
+        RecordProjectedFieldName(std::format("{}.{}", fieldName.tableName, fieldName.columnName));
     }
 
     return *this;
@@ -51,6 +83,10 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::Field(SqlFieldExpression const& fi
     _query.fields += fieldExpression.expression;
     _aliasAllowed = true;
 
+    // An aggregate carries no caller-given name until As() supplies one; the empty slot keeps the
+    // following entries aligned with their result columns.
+    RecordProjectedFieldName({});
+
     return *this;
 }
 
@@ -62,6 +98,7 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::As(std::string_view alias)
     _query.fields += " AS \"";
     _query.fields += alias;
     _query.fields += "\"";
+    RenameLastProjectedFieldName(alias);
 
     return *this;
 }
@@ -76,6 +113,7 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::FieldAs(std::string_view const& fi
     _query.fields += "\" AS \"";
     _query.fields += alias;
     _query.fields += '"';
+    RecordProjectedFieldName(std::string(alias));
 
     return *this;
 }
@@ -93,6 +131,7 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::FieldAs(SqlQualifiedTableColumnNam
     _query.fields += "\" AS \"";
     _query.fields += alias;
     _query.fields += '"';
+    RecordProjectedFieldName(std::string(alias));
 
     return *this;
 }
@@ -107,6 +146,7 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::Fields(std::vector<std::string_vie
         _query.fields += '"';
         _query.fields += fieldName;
         _query.fields += '"';
+        RecordProjectedFieldName(std::string(fieldName));
     }
     return *this;
 }
@@ -124,6 +164,7 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::Fields(std::vector<std::string_vie
         _query.fields += "\".\"";
         _query.fields += fieldName;
         _query.fields += '"';
+        RecordProjectedFieldName(std::format("{}.{}", tableName, fieldName));
     }
     return *this;
 }
@@ -141,6 +182,7 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::Fields(std::initializer_list<std::
         _query.fields += "\".\"";
         _query.fields += fieldName;
         _query.fields += '"';
+        RecordProjectedFieldName(std::format("{}.{}", tableName, fieldName));
     }
     return *this;
 }
@@ -161,6 +203,9 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::Fields(std::span<SqlQualifiedTable
 
 SqlSelectQueryBuilder::ComposedQuery SqlSelectQueryBuilder::Count()
 {
+    // The Count finalizer discards the projection in favour of COUNT(*), so any recorded names
+    // would no longer describe the result columns.
+    _query.projectedFieldNames.clear();
     _query.selectType = SelectType::Count;
     return std::move(_query);
 }

--- a/src/Lightweight/SqlQuery/Select.cpp
+++ b/src/Lightweight/SqlQuery/Select.cpp
@@ -204,8 +204,11 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::Fields(std::span<SqlQualifiedTable
 SqlSelectQueryBuilder::ComposedQuery SqlSelectQueryBuilder::Count()
 {
     // The Count finalizer discards the projection in favour of COUNT(*), so any recorded names
-    // would no longer describe the result columns.
+    // would no longer describe the result columns. The wildcard flag goes with them: the discarded
+    // projection is no longer the reason named access is unavailable, and leaving it set would make
+    // the diagnostic blame a wildcard that no longer appears in the query.
     _query.projectedFieldNames.clear();
+    _query.projectionHasWildcard = false;
     _query.selectType = SelectType::Count;
     return std::move(_query);
 }

--- a/src/Lightweight/SqlQuery/Select.hpp
+++ b/src/Lightweight/SqlQuery/Select.hpp
@@ -246,6 +246,20 @@ class [[nodiscard]] SqlSelectQueryBuilder: public SqlBasicSelectQueryBuilder<Sql
     }
 
   private:
+    /// @brief Records @p name as the caller-given name of the projection just appended.
+    ///
+    /// Pass an empty @p name for a projection the caller did not name (an un-aliased aggregate); the
+    /// slot still holds its position so later entries stay aligned with their result columns.
+    /// @param name The column name exactly as the caller spelled it, or empty for an unnamed projection.
+    LIGHTWEIGHT_API void RecordProjectedFieldName(std::string name) const;
+
+    /// @brief Replaces the name of the most recently recorded projection, backing @c As().
+    /// @param alias The alias the caller gave the projection.
+    LIGHTWEIGHT_API void RenameLastProjectedFieldName(std::string_view alias) const;
+
+    /// @brief Marks the projection as containing a wildcard, disabling named column access.
+    LIGHTWEIGHT_API void RecordProjectionWildcard() const;
+
     SqlQueryFormatter const& _formatter;
     // mutable: see the note on _query in SqlBasicSelectQueryBuilder — the alias
     // flag is part of the projection accumulator, so it follows _query's policy.
@@ -265,9 +279,12 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::Fields(std::string_view const& fir
         fragment << ", "sv;
 
     fragment << '"' << firstField << '"';
+    RecordProjectedFieldName(std::string(firstField));
 
     if constexpr (sizeof...(MoreFields) > 0)
-        ((fragment << R"(, ")"sv << std::forward<MoreFields>(moreFields) << '"') << ...);
+        (((fragment << R"(, ")"sv << std::forward<MoreFields>(moreFields) << '"'),
+          RecordProjectedFieldName(std::string(std::string_view(moreFields)))),
+         ...);
 
     _query.fields += fragment.str();
     return *this;

--- a/src/Lightweight/SqlStatement.cpp
+++ b/src/Lightweight/SqlStatement.cpp
@@ -18,6 +18,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <ranges>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -231,6 +232,8 @@ SqlStatement::SqlStatement(SqlStatement&& other) noexcept:
     m_connection { other.m_connection },
     m_hStmt { other.m_hStmt },
     m_preparedQuery { std::move(other.m_preparedQuery) },
+    m_projectedFieldNames { std::move(other.m_projectedFieldNames) },
+    m_projectionHasWildcard { other.m_projectionHasWildcard },
     m_expectedParameterCount { other.m_expectedParameterCount },
     m_preparedParameterCount { other.m_preparedParameterCount },
     m_reusedPreparedQuery { other.m_reusedPreparedQuery }
@@ -252,6 +255,8 @@ SqlStatement& SqlStatement::operator=(SqlStatement&& other) noexcept
     m_expectedParameterCount = other.m_expectedParameterCount;
     m_preparedParameterCount = other.m_preparedParameterCount;
     m_reusedPreparedQuery = other.m_reusedPreparedQuery;
+    m_projectedFieldNames = std::move(other.m_projectedFieldNames);
+    m_projectionHasWildcard = other.m_projectionHasWildcard;
 
     other.m_data.reset();
     other.m_connection = nullptr;
@@ -311,6 +316,11 @@ void SqlStatement::Prepare(std::string_view query) &
     if (!reusePreparedQuery)
         m_preparedQuery = std::string(query);
     const_cast<SqlStatement*>(this)->m_numColumns.reset();
+
+    // Raw SQL carries no column-name mapping; drop the previous one so its names cannot resolve
+    // against the new query's result columns. The query-object overloads re-adopt afterwards.
+    m_projectedFieldNames.clear();
+    m_projectionHasWildcard = false;
 
     m_data->postExecuteCallbacks.clear();
     m_data->postProcessOutputColumnCallbacks.clear();
@@ -390,6 +400,53 @@ bool SqlStatement::RetryStalePreparedStatement(SQLRETURN result)
     return true;
 }
 
+SQLUSMALLINT SqlStatement::ResolveColumnName(std::string_view name) const
+{
+    if (m_projectedFieldNames.empty())
+        throw std::invalid_argument {
+            m_projectionHasWildcard
+                ? std::format("Cannot resolve column \"{}\" by name: the query projects a wildcard, so the "
+                              "number of result columns is not known at build time. Project the columns "
+                              "explicitly to address them by name.",
+                              name)
+                : std::format("Cannot resolve column \"{}\" by name: this statement was not composed from a "
+                              "query builder, so it carries no column-name mapping. Use the column index "
+                              "instead, or build the query with SqlQueryBuilder.",
+                              name)
+        };
+
+    // An unnamed projection is stored as an empty slot, so an empty lookup name must not match one.
+    if (name.empty())
+        throw std::invalid_argument { std::format("Cannot resolve a column by an empty name. Projected "
+                                                  "columns are: {}.",
+                                                  DescribeProjectedFieldNames()) };
+
+    auto const match = std::ranges::find(m_projectedFieldNames, name);
+    if (match == m_projectedFieldNames.end())
+        throw std::invalid_argument { std::format(
+            "Unknown column \"{}\". Projected columns are: {}.", name, DescribeProjectedFieldNames()) };
+
+    if (std::ranges::find(std::ranges::next(match), m_projectedFieldNames.end(), name) != m_projectedFieldNames.end())
+        throw std::invalid_argument { std::format(
+            "Column \"{}\" is ambiguous: it is projected more than once. Alias the duplicates with "
+            "Field(...).As(\"alias\") to address them individually.",
+            name) };
+
+    return static_cast<SQLUSMALLINT>(std::ranges::distance(m_projectedFieldNames.begin(), match) + 1);
+}
+
+std::string SqlStatement::DescribeProjectedFieldNames() const
+{
+    auto description = std::string {};
+    for (auto const& projectedName: m_projectedFieldNames)
+    {
+        if (!description.empty())
+            description += ", ";
+        description += projectedName.empty() ? std::string { "<unnamed>" } : std::format("\"{}\"", projectedName);
+    }
+    return description;
+}
+
 SqlResultCursor SqlStatement::ExecuteDirect(std::string_view const& query, std::source_location location)
 {
     ZoneScopedN("SqlStatement::ExecuteDirect");
@@ -400,6 +457,10 @@ SqlResultCursor SqlStatement::ExecuteDirect(std::string_view const& query, std::
     m_preparedQuery.clear();
     m_reusedPreparedQuery = false;
     m_numColumns.reset();
+
+    // See the note in Prepare(): raw SQL must not inherit a previous query's column names.
+    m_projectedFieldNames.clear();
+    m_projectionHasWildcard = false;
 
     RequireSuccess(SQLFreeStmt(m_hStmt, SQL_UNBIND));
 

--- a/src/Lightweight/SqlStatement.cpp
+++ b/src/Lightweight/SqlStatement.cpp
@@ -559,6 +559,10 @@ RowArrayCursor SqlStatement::ExecuteBatchFetch(std::string_view query, std::size
     m_reusedPreparedQuery = false;
     m_numColumns.reset();
 
+    // See the note in Prepare(): raw SQL must not inherit a previous query's column names.
+    m_projectedFieldNames.clear();
+    m_projectionHasWildcard = false;
+
     RequireSuccess(SQLFreeStmt(m_hStmt, SQL_UNBIND));
 
     m_data->inputIndicators.clear();

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -394,10 +394,6 @@ class [[nodiscard]] SqlStatement final: public SqlDataBinderCallback
     /// @brief Renders the projected column names for a diagnostic message.
     [[nodiscard]] LIGHTWEIGHT_API std::string DescribeProjectedFieldNames() const;
 
-    /// @brief Adopts the column-name mapping of @p queryObject, replacing any previously held mapping.
-    template <SqlQueryObject QueryObject>
-    void AdoptProjectedFieldNames(QueryObject const& queryObject);
-
     LIGHTWEIGHT_API void RequireSuccess(SQLRETURN error,
                                         std::source_location sourceLocation = std::source_location::current()) const;
     LIGHTWEIGHT_API void PlanPostExecuteCallback(std::function<void()>&& cb) override;
@@ -502,6 +498,13 @@ class [[nodiscard]] SqlStatement final: public SqlDataBinderCallback
     /// @p T (used instead of an immediate @c SQLBindCol while prefetch is pending/active).
     template <SqlOutputColumnBinder T>
     void RecordPrefetchOutputColumn(SQLUSMALLINT column, T* arg);
+
+    /// @brief Adopts the column-name mapping of @p queryObject, replacing any previously held mapping.
+    ///
+    /// An implementation detail of the query-object @c Prepare / @c ExecuteDirect overloads: it is the
+    /// only way the mapping is ever populated, so it is not part of the public surface.
+    template <SqlQueryObject QueryObject>
+    void AdoptProjectedFieldNames(QueryObject const& queryObject);
 
     // private data members
     struct Data;

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -32,6 +32,7 @@
 #include <source_location>
 #include <span>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 #include <vector>
 
@@ -49,6 +50,17 @@ struct SqlRawColumn;
 template <typename QueryObject>
 concept SqlQueryObject = requires(QueryObject const& queryObject) {
     { queryObject.ToSql() } -> std::convertible_to<std::string>;
+};
+
+/// @brief Represents a query object that also knows the name of each column it projects.
+///
+/// Satisfied by the SELECT query builder's composed query, which records the caller-given name of every
+/// projected column as the projection is assembled. Statements executed from such a query object can
+/// resolve result columns by name — see the name-taking @c GetColumn overload of @c SqlResultCursor.
+template <typename QueryObject>
+concept SqlNamedProjectionQueryObject = SqlQueryObject<QueryObject> && requires(QueryObject const& queryObject) {
+    { queryObject.ProjectedFieldNames() } -> std::convertible_to<std::span<std::string const>>;
+    { queryObject.ProjectionHasWildcard() } -> std::convertible_to<bool>;
 };
 
 class SqlResultCursor;
@@ -365,6 +377,27 @@ class [[nodiscard]] SqlStatement final: public SqlDataBinderCallback
     template <SqlGetColumnNativeType T>
     [[nodiscard]] T GetColumnOr(SQLUSMALLINT column, T&& defaultValue) const;
 
+    /// @brief Resolves a projected column name to its 1-based result column index.
+    ///
+    /// The mapping comes from the query builder that composed the statement's query, not from the
+    /// driver: result-set metadata cannot report table names portably (the SQL Server driver leaves
+    /// them empty under the default forward-only cursor), so a builder-recorded mapping is the only
+    /// one that behaves identically on every supported database.
+    ///
+    /// @param name The column name exactly as spelled in the query builder.
+    /// @return The 1-based result column index of @p name.
+    /// @throws std::invalid_argument If the statement carries no name mapping (raw SQL, or a
+    ///         projection containing a wildcard), if @p name was never projected, or if @p name was
+    ///         projected more than once and is therefore ambiguous.
+    [[nodiscard]] LIGHTWEIGHT_API SQLUSMALLINT ResolveColumnName(std::string_view name) const;
+
+    /// @brief Renders the projected column names for a diagnostic message.
+    [[nodiscard]] LIGHTWEIGHT_API std::string DescribeProjectedFieldNames() const;
+
+    /// @brief Adopts the column-name mapping of @p queryObject, replacing any previously held mapping.
+    template <SqlQueryObject QueryObject>
+    void AdoptProjectedFieldNames(QueryObject const& queryObject);
+
     LIGHTWEIGHT_API void RequireSuccess(SQLRETURN error,
                                         std::source_location sourceLocation = std::source_location::current()) const;
     LIGHTWEIGHT_API void PlanPostExecuteCallback(std::function<void()>&& cb) override;
@@ -477,7 +510,11 @@ class [[nodiscard]] SqlStatement final: public SqlDataBinderCallback
     SQLHSTMT m_hStmt {};                           // The native oDBC statement handle
     std::string m_preparedQuery;                   // The last prepared query
     std::optional<SQLSMALLINT> m_numColumns;       // The number of columns in the result set, if known
-    SQLSMALLINT m_expectedParameterCount {};       // The number of parameters expected by the query
+    // Column names of the last prepared/executed query object, in result-column order, for named
+    // column access. Empty when the query carried no mapping (raw SQL, or a wildcard projection).
+    std::vector<std::string> m_projectedFieldNames;
+    bool m_projectionHasWildcard = false;
+    SQLSMALLINT m_expectedParameterCount {}; // The number of parameters expected by the query
     // The parameter count SQLNumParams() reported for m_preparedQuery. m_expectedParameterCount is
     // deliberately overwritten by BindInputParameter() (with SQLSMALLINT max, meaning "bound by hand"),
     // so a Prepare() that reuses the handle's statement - and therefore skips SQLNumParams() - has to
@@ -623,6 +660,54 @@ class [[nodiscard]] SqlResultCursor
     [[nodiscard]] T GetColumnOr(SQLUSMALLINT column, T&& defaultValue) const
     {
         return m_stmt->GetColumnOr(column, std::forward<T>(defaultValue));
+    }
+
+    /// @brief Retrieves the value of the named column for the currently selected row.
+    ///
+    /// The name is the one spelled in the query builder that composed this query — a bare column name
+    /// for @c Field("x"), the qualified @c "table.column" for @c Field({"table", "x"}), or the alias for
+    /// an aliased projection. Only builder-composed queries carry a mapping.
+    ///
+    /// @note Reads must still ascend in column order: the SQL Server driver rejects out-of-order
+    ///       @c SQLGetData with SQLSTATE 07009, and addressing columns by name makes it easy to
+    ///       reorder them inadvertently.
+    ///
+    /// @param name The column name as spelled in the query builder.
+    /// @return The column value converted to @p T.
+    /// @throws std::invalid_argument If no mapping is available, or @p name is unknown or ambiguous.
+    template <SqlGetColumnNativeType T>
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE T GetColumn(std::string_view name) const
+    {
+        return m_stmt->GetColumn<T>(m_stmt->ResolveColumnName(name));
+    }
+
+    /// @brief Retrieves the value of the named column, or @c std::nullopt if it is NULL.
+    ///
+    /// The name is the one spelled in the query builder that composed this query; only builder-composed
+    /// queries carry a mapping. Reads must ascend in column order — see the name-taking @c GetColumn.
+    ///
+    /// @param name The column name as spelled in the query builder.
+    /// @return The column value converted to @p T, or @c std::nullopt if the column is NULL.
+    /// @throws std::invalid_argument If no mapping is available, or @p name is unknown or ambiguous.
+    template <SqlGetColumnNativeType T>
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE std::optional<T> GetNullableColumn(std::string_view name) const
+    {
+        return m_stmt->GetNullableColumn<T>(m_stmt->ResolveColumnName(name));
+    }
+
+    /// @brief Retrieves the value of the named column, or @p defaultValue if it is NULL.
+    ///
+    /// The name is the one spelled in the query builder that composed this query; only builder-composed
+    /// queries carry a mapping. Reads must ascend in column order — see the name-taking @c GetColumn.
+    ///
+    /// @param name The column name as spelled in the query builder.
+    /// @param defaultValue The value to return when the column is NULL.
+    /// @return The column value converted to @p T, or @p defaultValue if the column is NULL.
+    /// @throws std::invalid_argument If no mapping is available, or @p name is unknown or ambiguous.
+    template <SqlGetColumnNativeType T>
+    [[nodiscard]] T GetColumnOr(std::string_view name, T&& defaultValue) const
+    {
+        return m_stmt->GetColumnOr(m_stmt->ResolveColumnName(name), std::forward<T>(defaultValue));
     }
 
   private:
@@ -1090,14 +1175,36 @@ inline LIGHTWEIGHT_FORCE_INLINE SQLHSTMT SqlStatement::NativeHandle() const noex
     return m_hStmt;
 }
 
+template <SqlQueryObject QueryObject>
+inline void SqlStatement::AdoptProjectedFieldNames(QueryObject const& queryObject)
+{
+    if constexpr (SqlNamedProjectionQueryObject<QueryObject>)
+    {
+        auto const names = queryObject.ProjectedFieldNames();
+        m_projectedFieldNames.assign(names.begin(), names.end());
+        m_projectionHasWildcard = queryObject.ProjectionHasWildcard();
+    }
+    else
+    {
+        // A statement is reusable, so a query object without a mapping must drop the previous one
+        // rather than let stale names resolve against unrelated result columns.
+        m_projectedFieldNames.clear();
+        m_projectionHasWildcard = false;
+    }
+}
+
 inline LIGHTWEIGHT_FORCE_INLINE void SqlStatement::Prepare(SqlQueryObject auto const& queryObject) &
 {
     Prepare(queryObject.ToSql());
+    // After the raw overload, which drops any previously held mapping.
+    AdoptProjectedFieldNames(queryObject);
 }
 
 inline LIGHTWEIGHT_FORCE_INLINE SqlStatement SqlStatement::Prepare(SqlQueryObject auto const& queryObject) &&
 {
-    return Prepare(queryObject.ToSql());
+    auto preparedStatement = std::move(*this).Prepare(queryObject.ToSql());
+    preparedStatement.AdoptProjectedFieldNames(queryObject);
+    return preparedStatement;
 }
 
 inline LIGHTWEIGHT_FORCE_INLINE std::string const& SqlStatement::PreparedQuery() const noexcept
@@ -2058,7 +2165,10 @@ T SqlStatement::GetColumnOr(SQLUSMALLINT column, T&& defaultValue) const
 inline LIGHTWEIGHT_FORCE_INLINE SqlResultCursor SqlStatement::ExecuteDirect(SqlQueryObject auto const& query,
                                                                             std::source_location location)
 {
-    return ExecuteDirect(query.ToSql(), location);
+    auto cursor = ExecuteDirect(query.ToSql(), location);
+    // After the raw overload, which drops any previously held mapping.
+    AdoptProjectedFieldNames(query);
+    return cursor;
 }
 
 template <typename Callable>

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -2254,3 +2254,100 @@ TEST_CASE_METHOD(SqlTestFixture, "AlterTable index commands honour schema qualif
             CHECK(sql.contains("myschema"));
     }
 }
+
+// ================================================================================================
+// Named column access — the projected-name mapping recorded by the SELECT query builder (#341)
+// ================================================================================================
+
+// Materializes the projected-name span so it can be compared against an expected vector.
+static std::vector<std::string> ProjectedNamesOf(auto const& query)
+{
+    auto const names = query.ProjectedFieldNames();
+    return std::vector<std::string> { names.begin(), names.end() };
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlSelectQueryBuilder records projected field names", "[SqlQueryBuilder]")
+{
+    using namespace std::string_view_literals;
+
+    auto queryBuilder = SqlQueryBuilder(SqlQueryFormatter::Sqlite());
+
+    SECTION("bare field names are recorded as spelled")
+    {
+        auto const query = queryBuilder.FromTable("Employees").Select().Fields({ "FirstName"sv, "Salary"sv }).All();
+        CHECK(ProjectedNamesOf(query) == std::vector<std::string> { "FirstName", "Salary" });
+        CHECK_FALSE(query.ProjectionHasWildcard());
+    }
+
+    SECTION("qualified field names are recorded as table.column")
+    {
+        auto const query = queryBuilder.FromTable("Employees")
+                               .Select()
+                               .Field(SqlQualifiedTableColumnName { .tableName = "Employees", .columnName = "FirstName" })
+                               .Fields({ "a"sv, "b"sv }, "OTHER"sv)
+                               .All();
+        CHECK(ProjectedNamesOf(query) == std::vector<std::string> { "Employees.FirstName", "OTHER.a", "OTHER.b" });
+    }
+
+    SECTION("an alias replaces the name of the projection it follows")
+    {
+        auto const query = queryBuilder.FromTable("Employees")
+                               .Select()
+                               .Field("FirstName"sv)
+                               .Field(SqlQualifiedTableColumnName { .tableName = "Employees", .columnName = "Salary" })
+                               .As("MonthlyPay"sv)
+                               .All();
+        CHECK(ProjectedNamesOf(query) == std::vector<std::string> { "FirstName", "MonthlyPay" });
+    }
+
+    SECTION("an un-aliased aggregate holds its position without a name")
+    {
+        auto const query =
+            queryBuilder.FromTable("Employees").Select().Field(Aggregate::Count("EmployeeID"sv)).Field("Salary"sv).All();
+        CHECK(ProjectedNamesOf(query) == std::vector<std::string> { "", "Salary" });
+    }
+
+    SECTION("an aliased aggregate is addressable by its alias")
+    {
+        auto const query =
+            queryBuilder.FromTable("Employees").Select().Field(Aggregate::Count("EmployeeID"sv)).As("HeadCount"sv).All();
+        CHECK(ProjectedNamesOf(query) == std::vector<std::string> { "HeadCount" });
+    }
+
+    SECTION("a wildcard disables the mapping")
+    {
+        auto const query = queryBuilder.FromTable("Employees").Select().Field("FirstName"sv).Field("*"sv).All();
+        CHECK(query.ProjectedFieldNames().empty());
+        CHECK(query.ProjectionHasWildcard());
+    }
+
+    SECTION("fields projected after a wildcard do not resurrect the mapping")
+    {
+        auto const query = queryBuilder.FromTable("Employees").Select().Field("*"sv).Field("FirstName"sv).All();
+        CHECK(query.ProjectedFieldNames().empty());
+        CHECK(query.ProjectionHasWildcard());
+    }
+
+    SECTION("a qualified wildcard disables the mapping")
+    {
+        auto const query = queryBuilder.FromTable("Employees")
+                               .Select()
+                               .Field(SqlQualifiedTableColumnName { .tableName = "Employees", .columnName = "*" })
+                               .All();
+        CHECK(query.ProjectedFieldNames().empty());
+        CHECK(query.ProjectionHasWildcard());
+    }
+
+    SECTION("the Count finalizer discards the projection's names")
+    {
+        auto const query = queryBuilder.FromTable("Employees").Select().Field("FirstName"sv).Count();
+        CHECK(query.ProjectedFieldNames().empty());
+    }
+
+    SECTION("the variadic Fields overload records every field")
+    {
+        auto const query =
+            queryBuilder.FromTable("Employees").Select().Fields("FirstName"sv, "LastName"sv, "Salary"sv).All();
+        CHECK(ProjectedNamesOf(query) == std::vector<std::string> { "FirstName", "LastName", "Salary" });
+    }
+}

--- a/src/tests/SqlStatementDbTests.cpp
+++ b/src/tests/SqlStatementDbTests.cpp
@@ -413,6 +413,37 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlResultCursor::GetColumn by name reads bare 
     CHECK(cursor.GetColumn<int>("Salary") == 50'000);
 }
 
+TEST_CASE_METHOD(SqlTestFixture,
+                 "SqlResultCursor::GetColumn by name reads names given to variadic Fields()",
+                 "[SqlStatement]")
+{
+    auto stmt = SqlStatement {};
+    CreateEmployeesTable(stmt);
+    FillEmployeesTable(stmt);
+
+    // The tests around this one project through the container overloads of Fields(). The variadic
+    // Fields(first, more...) registers the projected names along a separate code path, and its
+    // single-argument form is a separate instantiation again - one in which the fold over the
+    // remaining fields is discarded entirely, leaving the first field as the only registration.
+    SECTION("a single field")
+    {
+        auto cursor = stmt.ExecuteDirect(stmt.Query("Employees").Select().Fields("FirstName").OrderBy("EmployeeID"sv).All());
+
+        REQUIRE(cursor.FetchRow());
+        CHECK(cursor.GetColumn<std::string>("FirstName") == "Alice");
+    }
+
+    SECTION("several fields")
+    {
+        auto cursor =
+            stmt.ExecuteDirect(stmt.Query("Employees").Select().Fields("FirstName", "Salary").OrderBy("EmployeeID"sv).All());
+
+        REQUIRE(cursor.FetchRow());
+        CHECK(cursor.GetColumn<std::string>("FirstName") == "Alice");
+        CHECK(cursor.GetColumn<int>("Salary") == 50'000);
+    }
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "SqlResultCursor::GetColumn by name reads qualified names", "[SqlStatement]")
 {
     auto stmt = SqlStatement {};

--- a/src/tests/SqlStatementDbTests.cpp
+++ b/src/tests/SqlStatementDbTests.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 using namespace Lightweight;
+using namespace std::string_view_literals;
 
 // ================================================================================================
 // SqlResultCursor::TryFetchRow — std::expected-based fetch surface
@@ -391,4 +392,159 @@ TEST_CASE_METHOD(SqlTestFixture, "Prepare reuse recovers when the server forgot 
         REQUIRE(cursor.FetchRow());
         CHECK(cursor.GetColumn<int>(1) == 10);
     }
+}
+
+// ================================================================================================
+// Named column access — reading result columns by the name spelled in the query builder (#341)
+// ================================================================================================
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlResultCursor::GetColumn by name reads bare column names", "[SqlStatement]")
+{
+    auto stmt = SqlStatement {};
+    CreateEmployeesTable(stmt);
+    FillEmployeesTable(stmt);
+
+    auto cursor = stmt.ExecuteDirect(
+        stmt.Query("Employees").Select().Fields({ "FirstName"sv, "Salary"sv }).OrderBy("EmployeeID"sv).All());
+
+    REQUIRE(cursor.FetchRow());
+    CHECK(cursor.GetColumn<std::string>("FirstName") == "Alice");
+    CHECK(cursor.GetColumn<int>("Salary") == 50'000);
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlResultCursor::GetColumn by name reads qualified names", "[SqlStatement]")
+{
+    auto stmt = SqlStatement {};
+    CreateEmployeesTable(stmt);
+    FillEmployeesTable(stmt);
+
+    auto cursor =
+        stmt.ExecuteDirect(stmt.Query("Employees")
+                               .Select()
+                               .Field(SqlQualifiedTableColumnName { .tableName = "Employees", .columnName = "FirstName" })
+                               .Field(SqlQualifiedTableColumnName { .tableName = "Employees", .columnName = "Salary" })
+                               .OrderBy(SqlQualifiedTableColumnName { .tableName = "Employees", .columnName = "EmployeeID" })
+                               .All());
+
+    REQUIRE(cursor.FetchRow());
+    CHECK(cursor.GetColumn<std::string>("Employees.FirstName") == "Alice");
+    CHECK(cursor.GetColumn<int>("Employees.Salary") == 50'000);
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlResultCursor::GetColumn by name reads an alias", "[SqlStatement]")
+{
+    auto stmt = SqlStatement {};
+    CreateEmployeesTable(stmt);
+    FillEmployeesTable(stmt);
+
+    auto cursor =
+        stmt.ExecuteDirect(stmt.Query("Employees")
+                               .Select()
+                               .Field("FirstName"sv)
+                               .Field(SqlQualifiedTableColumnName { .tableName = "Employees", .columnName = "Salary" })
+                               .As("MonthlyPay"sv)
+                               .OrderBy("EmployeeID"sv)
+                               .All());
+
+    REQUIRE(cursor.FetchRow());
+    CHECK(cursor.GetColumn<std::string>("FirstName") == "Alice");
+    CHECK(cursor.GetColumn<int>("MonthlyPay") == 50'000);
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlResultCursor named access survives Prepare and Execute", "[SqlStatement]")
+{
+    auto stmt = SqlStatement {};
+    CreateEmployeesTable(stmt);
+    FillEmployeesTable(stmt);
+
+    stmt.Prepare(stmt.Query("Employees").Select().Fields({ "FirstName"sv, "Salary"sv }).OrderBy("EmployeeID"sv).All());
+    auto cursor = stmt.Execute();
+
+    REQUIRE(cursor.FetchRow());
+    CHECK(cursor.GetColumn<std::string>("FirstName") == "Alice");
+    CHECK(cursor.GetColumn<int>("Salary") == 50'000);
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlResultCursor::GetNullableColumn and GetColumnOr by name", "[SqlStatement]")
+{
+    auto stmt = SqlStatement {};
+    CreateEmployeesTable(stmt);
+
+    stmt.Prepare(stmt.Query("Employees")
+                     .Insert()
+                     .Set("FirstName", SqlWildcard)
+                     .Set("LastName", SqlWildcard)
+                     .Set("Salary", SqlWildcard));
+    (void) stmt.Execute("Dana", SqlNullValue, 42'000);
+
+    auto cursor = stmt.ExecuteDirect(stmt.Query("Employees").Select().Fields({ "LastName"sv, "Salary"sv }).All());
+
+    REQUIRE(cursor.FetchRow());
+    CHECK(cursor.GetNullableColumn<std::string>("LastName") == std::nullopt);
+    CHECK(cursor.GetColumnOr<int>("Salary", 0) == 42'000);
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlResultCursor named access rejects unusable names", "[SqlStatement]")
+{
+    auto stmt = SqlStatement {};
+    CreateEmployeesTable(stmt);
+    FillEmployeesTable(stmt);
+
+    SECTION("an unknown name throws")
+    {
+        auto cursor = stmt.ExecuteDirect(stmt.Query("Employees").Select().Fields({ "FirstName"sv }).All());
+        REQUIRE(cursor.FetchRow());
+        CHECK_THROWS_AS(cursor.GetColumn<std::string>("NoSuchColumn"), std::invalid_argument);
+    }
+
+    SECTION("a name projected twice is ambiguous")
+    {
+        auto cursor = stmt.ExecuteDirect(stmt.Query("Employees").Select().Field("FirstName"sv).Field("FirstName"sv).All());
+        REQUIRE(cursor.FetchRow());
+        CHECK_THROWS_AS(cursor.GetColumn<std::string>("FirstName"), std::invalid_argument);
+    }
+
+    SECTION("a wildcard projection has no mapping")
+    {
+        auto cursor = stmt.ExecuteDirect(stmt.Query("Employees").Select().Field("*"sv).All());
+        REQUIRE(cursor.FetchRow());
+        CHECK_THROWS_AS(cursor.GetColumn<std::string>("FirstName"), std::invalid_argument);
+    }
+
+    SECTION("raw SQL has no mapping")
+    {
+        stmt.Prepare(R"(SELECT "FirstName" FROM "Employees")");
+        auto cursor = stmt.Execute();
+        REQUIRE(cursor.FetchRow());
+        CHECK_THROWS_AS(cursor.GetColumn<std::string>("FirstName"), std::invalid_argument);
+    }
+
+    SECTION("raw SQL does not inherit the previous query's mapping")
+    {
+        {
+            auto cursor = stmt.ExecuteDirect(stmt.Query("Employees").Select().Fields({ "FirstName"sv }).All());
+            REQUIRE(cursor.FetchRow());
+            CHECK(cursor.GetColumn<std::string>("FirstName") == "Alice");
+        }
+
+        stmt.Prepare(R"(SELECT "Salary" FROM "Employees")");
+        auto cursor = stmt.Execute();
+        REQUIRE(cursor.FetchRow());
+        CHECK_THROWS_AS(cursor.GetColumn<std::string>("FirstName"), std::invalid_argument);
+    }
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlResultCursor named access rejects an empty name", "[SqlStatement]")
+{
+    auto stmt = SqlStatement {};
+    CreateEmployeesTable(stmt);
+    FillEmployeesTable(stmt);
+
+    // An un-aliased aggregate occupies an unnamed slot; an empty lookup name must not resolve to it.
+    // Both projections are aggregates so the query needs no GROUP BY on any supported database.
+    auto cursor = stmt.ExecuteDirect(
+        stmt.Query("Employees").Select().Field(Aggregate::Count("EmployeeID"sv)).Field(Aggregate::Max("Salary"sv)).All());
+
+    REQUIRE(cursor.FetchRow());
+    CHECK_THROWS_AS(cursor.GetColumn<int>(""), std::invalid_argument);
 }

--- a/src/tests/SqlStatementDbTests.cpp
+++ b/src/tests/SqlStatementDbTests.cpp
@@ -7,6 +7,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <stdexcept>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -450,6 +451,50 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlResultCursor::GetColumn by name reads an al
     CHECK(cursor.GetColumn<std::string>("FirstName") == "Alice");
     CHECK(cursor.GetColumn<int>("MonthlyPay") == 50'000);
 }
+
+// FieldAs() is deprecated in favour of Field(...).As(...), but it still ships and still has to keep
+// the projected-name table correct — a deprecated overload that silently stopped registering its
+// alias would break named access for every caller who has not migrated yet. Calling it is therefore
+// the point of this test, and the deprecation warning is suppressed only around it.
+#if defined(_MSC_VER)
+    #pragma warning(push)
+    #pragma warning(disable : 4996)
+#else
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlResultCursor::GetColumn by name reads a FieldAs alias", "[SqlStatement]")
+{
+    auto stmt = SqlStatement {};
+    CreateEmployeesTable(stmt);
+    FillEmployeesTable(stmt);
+
+    // FieldAs() names the column in the same call that projects it, where Field().As() renames a
+    // projection that was already recorded — two different paths into the name table, so both need
+    // to end up with the alias as the lookup key.
+    auto cursor = stmt.ExecuteDirect(
+        stmt.Query("Employees")
+            .Select()
+            .FieldAs("FirstName"sv, "GivenName"sv)
+            .FieldAs(SqlQualifiedTableColumnName { .tableName = "Employees", .columnName = "Salary" }, "MonthlyPay"sv)
+            .OrderBy("EmployeeID"sv)
+            .All());
+
+    REQUIRE(cursor.FetchRow());
+    CHECK(cursor.GetColumn<std::string>("GivenName") == "Alice");
+    CHECK(cursor.GetColumn<int>("MonthlyPay") == 50'000);
+
+    // The aliased-away name is not a lookup key: the query does not project a column by that name.
+    CHECK_THROWS_AS(std::ignore = cursor.GetColumn<std::string>("FirstName"), std::invalid_argument);
+    CHECK_THROWS_AS(std::ignore = cursor.GetColumn<int>("Employees.Salary"), std::invalid_argument);
+}
+
+#if defined(_MSC_VER)
+    #pragma warning(pop)
+#else
+    #pragma GCC diagnostic pop
+#endif
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlResultCursor named access survives Prepare and Execute", "[SqlStatement]")
 {


### PR DESCRIPTION
Closes #341

## What

Result columns of a builder-composed query can now be read by the name spelled in the builder, instead of by a 1-based index that shifts whenever the projection changes:

```cpp
auto cursor = stmt.ExecuteDirect(stmt.Query("Table_A")
                                     .Select()
                                     .Field(SqlQualifiedTableColumnName { "Table_A", "foo" })
                                     .Fields({ "a"sv, "b"sv }, "Table_B")
                                     .Field(Aggregate::Count("id"sv)).As("total"sv)
                                     .LeftOuterJoin("Table_B", "id"sv, "that_id"sv)
                                     .All());

while (cursor.FetchRow())
{
    auto const foo = cursor.GetColumn<int>("Table_A.foo");
    auto const a = cursor.GetColumn<int>("Table_B.a");
    auto const total = cursor.GetColumn<int>("total");
}
```

`GetNullableColumn<T>(name)` and `GetColumnOr<T>(name, defaultValue)` take a name the same way.

## Why the mapping comes from the builder, not from ODBC

The obvious implementation — ask the driver via `SQLDescribeCol` / `SQLColAttribute` — cannot deliver the table-qualified names the issue asks for. Probing all three supported drivers with the same join (`SELECT t1.x, t2.a, ... FROM t1 JOIN t2 ...`):

| Driver | Column name | Table name |
|---|---|---|
| SQLite3 ODBC | reported | reported |
| PostgreSQL Unicode | reported | reported |
| ODBC Driver 18 for SQL Server | reported | **empty** |

SQL Server only populates `SQL_DESC_TABLE_NAME` when the statement runs a static, server-side cursor; under the library's default forward-only cursor it returns empty strings. Going that route would have meant either an API that behaves differently per DBMS, or switching cursor type library-wide.

Recording the names in `SqlSelectQueryBuilder` as the projection is assembled avoids both: the mapping is identical on every backend and costs no round-trip. The trade-off is that named access is available only for builder-composed queries.

## Name rules

Names match exactly as spelled — no case folding, no implicit qualification:

| Builder call | Name to read it back by |
|---|---|
| `Field("foo")` | `"foo"` |
| `Field({ "Table_A", "foo" })` | `"Table_A.foo"` |
| `Fields({ "a"sv, "b"sv }, "Table_B")` | `"Table_B.a"`, `"Table_B.b"` |
| `Field(...).As("total")` / `FieldAs(..., "total")` | `"total"` |
| `Field(Aggregate::Count("id"sv))` | not addressable — occupies an unnamed slot that holds its position |

`std::invalid_argument` is thrown for a name that is unknown, ambiguous (projected twice), or empty, and for a query with no usable mapping: raw SQL, or a projection containing a wildcard, whose column count is unknown at build time. A statement reused for raw SQL drops the previous query's mapping rather than resolving stale names.

## Implementation

- `detail::ComposedQuery` gains `projectedFieldNames` + `projectionHasWildcard`, exposed via `ProjectedFieldNames()` / `ProjectionHasWildcard()`. It already travels to the statement as the query object, so no new plumbing was needed between builder and statement.
- A new `SqlNamedProjectionQueryObject` concept lets `Prepare` / `ExecuteDirect` adopt the mapping when the query object carries one.
- `SqlResultCursor` — already the object the statement returns — resolves names by linear scan over a vector that is realistically under 20 entries. No hash map, no per-lookup allocation.
- Incidental fix: the rvalue `Prepare(SqlQueryObject auto const&) &&` overload could not have compiled if instantiated (it called the `&`-qualified string overload, which returns `void`, from a function returning `SqlStatement`). It is now correct, since named queries take that path.

## Verification

**Databases** — full suite, run sequentially, lexical order:

| Database | Result |
|---|---|
| sqlite3 (SQLite 3.46.1) | 1409 passed, 1 skipped |
| postgres (Docker, PostgreSQL 16.4) | 1408 passed, 2 skipped |
| mssql2022 (Docker, SQL Server 16.00.4265) | 1407 passed, 3 skipped |

**Compilers** — `clang-release` (Clang 21, macOS) locally; `clang-tidy` run against the changed translation units with the `clang-debug` compile database, clean. GCC and the C++20-modules / C++26-reflection configurations are left to CI — they are not reachable from a local preset on this host.

**Coverage** — 9 new builder-level test cases in `QueryBuilderTests.cpp` asserting the recorded name vector for every projection entry point with no database involved, and 8 end-to-end cases in `SqlStatementDbTests.cpp` covering bare / qualified / aliased reads, `Prepare` + `Execute`, nullable and default-valued reads, and every error path.

## Risk

- **Per-DBMS**: none by construction — the mapping never consults the driver, so it cannot vary by backend.
- **Behaviour**: purely additive. Existing index-based overloads are untouched; the new overloads are selected only for a `std::string_view`-convertible argument.
- **Performance**: one `std::string` per projected column at build time; the SQL text itself is unchanged. Lookup is a linear scan, only on the named path.
- **Ordering caveat** (documented): reads must still ascend in column order, since SQL Server rejects out-of-order `SQLGetData` with SQLSTATE 07009 and named access makes reordering easy to do inadvertently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)