### PR TITLE
SqlRowIterator: iterate a filtered subset via a query-customizer callable

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -148,9 +148,13 @@ void CRUD(DataMapper& dm)
     // Query all persons
     auto const persons = dm.Query<Person>(); 
 
-    // Iterate over all persons 
-    auto stmt = SqlStatement { dm.Connection() };
-    for(const auto& person: SqlRowIterator<Person>(stmt))
+    // Iterate over all persons
+    for (auto const& person: SqlRowIterator<Person>(dm.Connection()))
+        std::println("|{}|{}|", person.name, person.age);
+
+    // Iterate over a subset of the persons
+    for (auto const& person: SqlRowIterator<Person>(dm.Connection(),
+                                                    [](auto& query) { return query.Where("age", ">=", 18); }))
         std::println("|{}|{}|", person.name, person.age);
 
     // Delete the person
@@ -212,3 +216,32 @@ void SimpleStructExample(DataMapper& dm)
         std::println("{}", DataMapper::Inspect(obj));
 }
 ```
+
+## Streaming a table with `SqlRowIterator`
+
+`SqlRowIterator<T>` streams a table row by row, materializing one record at a time instead of
+loading the whole result set into a `std::vector` as `DataMapper::Query<T>()` does. That makes it
+the tool of choice for tables too large to hold in memory.
+
+```cpp
+for (auto const& person: SqlRowIterator<Person>(dm.Connection()))
+    std::println("{}", DataMapper::Inspect(person));
+```
+
+Pass a callable as second argument to iterate over a **subset** of the rows. It receives the
+underlying `SqlSelectQueryBuilder` with the projection for `T` already applied, so the full
+`Where` / `OrWhere` / `OrderBy` / `Limit` surface of the [query builder](sqlquery.md) is available.
+Whatever the callable returns is ignored, so the builder's chaining methods can be returned
+directly:
+
+```cpp
+for (auto const& person: SqlRowIterator<Person>(dm.Connection(), [](auto& query) {
+         return query.Where("age", ">=", 18).OrWhere([](auto& query) {
+             return query.Where("age", 10).Where("name", "John");
+         });
+     }))
+    std::println("{}", DataMapper::Inspect(person));
+```
+
+Both plain column names and `FieldNameOf<Member(Person::age)>` work as column arguments; the latter
+keeps the condition in sync when a field is renamed.

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -892,19 +892,50 @@ class [[nodiscard]] SqlVariantRowCursor
 ///    Field<double> field3;
 /// };
 ///
-/// for (auto const& row : SqlRowIterator<MyRecord>(stmt))
+/// for (auto const& row : SqlRowIterator<MyRecord>(conn))
 /// {
 ///    // row is of type MyRecord
 ///    // row.field1, row.field2, row.field3 are accessible
+/// }
+/// @endcode
+///
+/// Pass a second argument to iterate over a subset of the table only. The callable receives the
+/// underlying @ref SqlSelectQueryBuilder with the projection for @c T already applied, so the full
+/// WHERE / ORDER BY / LIMIT surface of the query builder is available:
+/// @code
+///
+/// for (auto const& row : SqlRowIterator<MyRecord>(conn, [](auto& query) {
+///          return query.Where("field2", 10).OrWhere([](auto& query) {
+///              return query.Where("field2", 20).Where("field3", 3.14);
+///          });
+///      }))
+/// {
+///    // only the rows matching the condition above are fetched
 /// }
 /// @endcode
 template <typename T>
 class SqlRowIterator
 {
   public:
-    /// Constructs a row iterator using the given SQL connection.
+    /// Callable refining the SELECT query before it is executed.
+    ///
+    /// It is invoked with the query builder that already carries the projection for @c T. Any value
+    /// the callable returns is ignored, so the builder's chaining methods can be returned directly.
+    using QueryCustomizer = std::function<void(SqlSelectQueryBuilder&)>;
+
+    /// Constructs a row iterator over all rows of the record's table, using the given SQL connection.
     explicit SqlRowIterator(SqlConnection& conn):
         _connection { &conn }
+    {
+    }
+
+    /// Constructs a row iterator over the subset of rows selected by @p queryCustomizer.
+    ///
+    /// @param conn The SQL connection to run the query on.
+    /// @param queryCustomizer Callable refining the SELECT query, e.g. by adding WHERE conditions.
+    SqlRowIterator(SqlConnection& conn, QueryCustomizer queryCustomizer):
+        _connection { &conn },
+        _queryCustomizer { std::move(queryCustomizer) }
     {
     }
 
@@ -986,7 +1017,7 @@ class SqlRowIterator
     {
         auto it = iterator { *_connection };
         auto& stmt = it.Statement();
-        stmt.Prepare(it.Statement().Query(RecordTableName<T>).Select().template Fields<T>().All());
+        stmt.Prepare(it.Statement().Query(RecordTableName<T>).Select().template Fields<T>().Build(_queryCustomizer).All());
         it.SetCursor(stmt.Execute());
         ++it;
         return it;
@@ -1000,6 +1031,8 @@ class SqlRowIterator
 
   private:
     SqlConnection* _connection;
+    QueryCustomizer _queryCustomizer = [](SqlSelectQueryBuilder& /*query*/) {
+    };
 };
 
 // {{{ inline implementation

--- a/src/tests/DataMapper/ReadTests.cpp
+++ b/src/tests/DataMapper/ReadTests.cpp
@@ -15,7 +15,11 @@
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include <algorithm>
+#include <iterator>
+#include <string>
 #include <string_view>
+#include <vector>
 
 using namespace std::string_view_literals;
 using namespace std::string_literals;
@@ -295,6 +299,76 @@ TEST_CASE_METHOD(SqlTestFixture, "iterate over database", "[SqlRowIterator]")
     }
 
     CHECK(count == 11);
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "iterate over subset of database", "[SqlRowIterator]")
+{
+    auto dm = DataMapper();
+    dm.CreateTable<Person>();
+
+    for (int i = 40; i <= 50; ++i)
+    {
+        auto person = Person {};
+        person.name = std::format("John-{}", i);
+        person.age = i;
+        dm.Create(person);
+    }
+
+    auto const agesOf = [](std::vector<Person> const& records) -> std::vector<int> {
+        auto ages = std::vector<int> {};
+        ages.reserve(records.size());
+        std::ranges::transform(
+            records, std::back_inserter(ages), [](Person const& person) { return person.age.Value().value(); });
+        std::ranges::sort(ages);
+        return ages;
+    };
+
+    SECTION("single condition")
+    {
+        auto retrievedPersons = std::vector<Person> {};
+        for (auto&& person: SqlRowIterator<Person>(
+                 dm.Connection(), [](auto& query) { return query.Where(FieldNameOf<Member(Person::age)>, ">=", 48); }))
+            retrievedPersons.emplace_back(person);
+
+        CHECK(agesOf(retrievedPersons) == std::vector { 48, 49, 50 });
+    }
+
+    SECTION("nested conditions")
+    {
+        auto retrievedPersons = std::vector<Person> {};
+        for (auto&& person: SqlRowIterator<Person>(dm.Connection(), [](auto& query) {
+                 return query.Where(FieldNameOf<Member(Person::age)>, 41).OrWhere([](auto& query) {
+                     return query.Where(FieldNameOf<Member(Person::age)>, ">=", 49)
+                         .Where(FieldNameOf<Member(Person::name)>, "!=", "John-50");
+                 });
+             }))
+            retrievedPersons.emplace_back(person);
+
+        CHECK(agesOf(retrievedPersons) == std::vector { 41, 49 });
+    }
+
+    SECTION("no match yields an empty range")
+    {
+        auto count = size_t { 0 };
+        for ([[maybe_unused]] auto&& person: SqlRowIterator<Person>(
+                 dm.Connection(), [](auto& query) { return query.Where(FieldNameOf<Member(Person::age)>, 1); }))
+            ++count;
+
+        CHECK(count == 0);
+    }
+
+    SECTION("ordering")
+    {
+        auto retrievedNames = std::vector<std::string> {};
+        for (auto&& person: SqlRowIterator<Person>(dm.Connection(), [](auto& query) {
+                 return query.OrderBy(FieldNameOf<Member(Person::age)>, SqlResultOrdering::DESCENDING);
+             }))
+            retrievedNames.emplace_back(person.name.Value());
+
+        REQUIRE(retrievedNames.size() == 11);
+        CHECK(retrievedNames.front() == "John-50");
+        CHECK(retrievedNames.back() == "John-40");
+    }
 }
 
 // Simple struct, used for testing SELECT'ing into it


### PR DESCRIPTION
Closes #195

## What & why

`SqlRowIterator` could only walk an entire table: it built its SELECT with the projection for `T` and executed it unconditionally, so narrowing the result meant dropping to `SqlStatement` and giving up typed row iteration entirely.

This adds a second constructor taking a `QueryCustomizer` — a callable handed the `SqlSelectQueryBuilder` with `T`'s projection already applied, so the full `WHERE` / `ORDER BY` / `LIMIT` surface of the query builder is available:

```cpp
for (auto const& row: SqlRowIterator<MyRecord>(conn, [](auto& query) {
         return query.Where("field2", 10).OrWhere([](auto& query) {
             return query.Where("field2", 20).Where("field3", 3.14);
         });
     }))
{
    // only the matching rows are fetched
}
```

Any value the callable returns is ignored, which is what lets the builder's chaining methods be returned directly from the lambda. The default customizer is a no-op, so the existing single-argument constructor behaves exactly as before.

The class documentation gains the worked example above, and the doc comment on the original constructor is corrected — it takes a connection, not a statement.

## Testing

New case `iterate over subset of database` with sections for a single condition, nested conditions, an empty result set, and ordering.

| | Result |
|---|---|
| `clang-debug` (PEDANTIC + ASan + UBSan) | full suite green |
| Databases | `sqlite3`, `mssql2022` (Docker), `postgres` (Docker 16.4) — 1403 cases each |
| clang-tidy / clang-format | no new findings on the changed lines |

**Compilers: Clang only, locally** — the `gcc-release` preset is Linux-gated and CMake refuses it on this macOS host, so CI's GCC legs are the GCC check for this branch.

- **Performance impact:** none for the existing constructor; the customizer is a `std::function` invoked once per iteration setup, not per row.
- **Risk:** low. Additive — the existing constructor and its generated SQL are unchanged.