### PR TITLE
Add a reusable SqlRetryPolicy with per-DBMS transient-error classification

### DIFF
--- a/src/Lightweight/CMakeLists.txt
+++ b/src/Lightweight/CMakeLists.txt
@@ -91,6 +91,8 @@ set(HEADER_FILES
     SqlMigration.hpp
     SqlOdbcWide.hpp
     SqlQueryFormatter.hpp
+    SqlRetryClassifier.hpp
+    SqlRetryPolicy.hpp
     SqlSchema.hpp
     SqlScopedLock.hpp
     SqlScopedTraceLogger.hpp
@@ -131,6 +133,7 @@ set(SOURCE_FILES
     SqlQuery/Select.cpp
 
     SqlQueryFormatter.cpp
+    SqlRetryPolicy.cpp
     SqlScopedLock.cpp
     SqlSchema.cpp
     SqlStatement.cpp

--- a/src/Lightweight/Lightweight.cppm
+++ b/src/Lightweight/Lightweight.cppm
@@ -24,6 +24,7 @@ module;
 #include "SqlBackup/SqlBackup.hpp"
 #include "SqlBackup/TableFilter.hpp"
 #include "SqlErrorDetection.hpp"
+#include "SqlRetryPolicy.hpp"
 #include "SqlScopedLock.hpp"
 #include "ThreadSafeQueue.hpp"
 #include "Tools/CxxModelPrinter.hpp"
@@ -58,6 +59,7 @@ using Lightweight::FieldWithStorage;
 using Lightweight::FormatName;
 using Lightweight::FormatType;
 using Lightweight::FullyQualifiedNameOf;
+using Lightweight::GenericRetryOps;
 using Lightweight::GetDiagnosticSource;
 using Lightweight::GetFaultSource;
 using Lightweight::GetPrimaryKeyField;
@@ -99,6 +101,7 @@ using Lightweight::MemberIndexOf;
 using Lightweight::NotSqlElements;
 using Lightweight::ParseConnectionString;
 using Lightweight::PostgreSqlFormatter;
+using Lightweight::PostgreSqlRetryOps;
 using Lightweight::PrimaryKey;
 using Lightweight::QualifiedColumnName;
 using Lightweight::RecordColumnCount;
@@ -158,6 +161,7 @@ using Lightweight::SqlElements;
 using Lightweight::SqlError;
 using Lightweight::SqlErrorCategory;
 using Lightweight::SqlErrorInfo;
+using Lightweight::SqlErrorTransience;
 using Lightweight::SqlException;
 using Lightweight::SqlFailureAction;
 using Lightweight::SqlFaultSource;
@@ -207,7 +211,17 @@ using Lightweight::SqlRealName;
 using Lightweight::SqlRequireLoadedError;
 using Lightweight::SqlResultCursor;
 using Lightweight::SqlResultOrdering;
+using Lightweight::SqlRetryAction;
+using Lightweight::SqlRetryAttempt;
+using Lightweight::SqlRetryClassifier;
+using Lightweight::SqlRetryDecision;
+using Lightweight::SqlRetryGiveUpReason;
+using Lightweight::SqlRetryPolicy;
+using Lightweight::SqlRetrySettings;
+using Lightweight::SqlRetrySleeper;
+using Lightweight::SqlRetryState;
 using Lightweight::SqlRowIterator;
+using Lightweight::SqliteRetryOps;
 using Lightweight::SqlScopedLock;
 using Lightweight::SqlScopedTimeLogger;
 using Lightweight::SqlScopedTraceLogger;
@@ -215,6 +229,7 @@ using Lightweight::SqlSearchCondition;
 using Lightweight::SqlSelectQueryBuilder;
 using Lightweight::SqlSentinelIterator;
 using Lightweight::SqlServerQueryFormatter;
+using Lightweight::SqlServerRetryOps;
 using Lightweight::SqlServerType;
 using Lightweight::SqlSimpleDataBinder;
 using Lightweight::SqlStatement;
@@ -238,6 +253,7 @@ using Lightweight::SqlWhereClauseBuilder;
 using Lightweight::SqlWideString;
 using Lightweight::SqlWildcardType;
 using Lightweight::TableName;
+using Lightweight::ThreadSleeper;
 using Lightweight::ThreadSafeQueue;
 using Lightweight::ToSql;
 using Lightweight::ToStdWideString;

--- a/src/Lightweight/Lightweight.hpp
+++ b/src/Lightweight/Lightweight.hpp
@@ -12,6 +12,7 @@
 #include "SqlQuery.hpp"
 #include "SqlQueryFormatter.hpp"
 #include "SqlRealName.hpp"
+#include "SqlRetryPolicy.hpp"
 #include "SqlSchema.hpp"
 #include "SqlScopedTraceLogger.hpp"
 #include "SqlServerType.hpp"

--- a/src/Lightweight/QueryFormatter/PostgreSqlFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/PostgreSqlFormatter.hpp
@@ -336,6 +336,13 @@ class PostgreSqlFormatter final: public SQLiteQueryFormatter
     {
         return PostgreSqlAdvisoryLockOps();
     }
+
+    /// PostgreSQL has a dedicated SQLSTATE for every recoverable condition.
+    /// See `SQLiteQueryFormatter::AdvisoryLockOps()` for why this delegates.
+    [[nodiscard]] SqlRetryClassifier const& RetryOps() const noexcept override
+    {
+        return PostgreSqlRetryOps();
+    }
 };
 
 } // namespace Lightweight

--- a/src/Lightweight/QueryFormatter/SQLiteFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/SQLiteFormatter.hpp
@@ -3,6 +3,7 @@
 
 #include "../SqlAdvisoryLock.hpp"
 #include "../SqlQueryFormatter.hpp"
+#include "../SqlRetryClassifier.hpp"
 
 #include <reflection-cpp/reflection.hpp>
 
@@ -667,6 +668,13 @@ ALTER TABLE {2} DROP COLUMN "{1}";)",
     [[nodiscard]] SqlAdvisoryLockHandler const& AdvisoryLockOps() const override
     {
         return SqliteAdvisoryLockOps();
+    }
+
+    /// SQLite reports contention through the driver's message text rather than a SQLSTATE.
+    /// Delegates to the free function for the same reason `AdvisoryLockOps()` does.
+    [[nodiscard]] SqlRetryClassifier const& RetryOps() const noexcept override
+    {
+        return SqliteRetryOps();
     }
 };
 

--- a/src/Lightweight/QueryFormatter/SqlServerFormatter.hpp
+++ b/src/Lightweight/QueryFormatter/SqlServerFormatter.hpp
@@ -717,6 +717,13 @@ DROP INDEX "{0}_{1}_{2}_index" ON "{0}"."{1}";)",
     {
         return SqlServerAdvisoryLockOps();
     }
+
+    /// SQL Server carries most transient conditions in the native error code, not the SQLSTATE.
+    /// See `SQLiteQueryFormatter::AdvisoryLockOps()` for why this delegates.
+    [[nodiscard]] SqlRetryClassifier const& RetryOps() const noexcept override
+    {
+        return SqlServerRetryOps();
+    }
 };
 
 } // namespace Lightweight

--- a/src/Lightweight/SqlBackup/Backup.cpp
+++ b/src/Lightweight/SqlBackup/Backup.cpp
@@ -774,7 +774,7 @@ void ProcessChunkBackup(BackupContext& ctx, SqlConnection& conn, detail::Chunk c
             }
             catch (SqlException const& e)
             {
-                if (!IsTransientError(e.info()) || retryCount >= ctx.retrySettings.maxRetries)
+                if (ClassifyRetryOutcome(e.info(), retryCount, ctx.retrySettings) == RetryAction::GiveUp)
                     throw;
                 ++retryCount;
                 maxSubChunksFlushed = std::max(maxSubChunksFlushed, subChunkId);
@@ -847,7 +847,7 @@ void ProcessChunkBackup(BackupContext& ctx, SqlConnection& conn, detail::Chunk c
             }
             catch (SqlException const& e)
             {
-                if (!IsTransientError(e.info()) || retryCount >= ctx.retrySettings.maxRetries)
+                if (ClassifyRetryOutcome(e.info(), retryCount, ctx.retrySettings) == RetryAction::GiveUp)
                 {
                     if constexpr (DebugBackupWorker)
                         std::println(stderr, "DEBUG: Exception in FetchRow loop for table {}: {}", tableName, e.what());

--- a/src/Lightweight/SqlBackup/Common.cpp
+++ b/src/Lightweight/SqlBackup/Common.cpp
@@ -22,46 +22,17 @@ namespace Lightweight::SqlBackup::detail
 
 bool IsTransientError(SqlErrorInfo const& error)
 {
-    std::string_view state = error.sqlState;
-
-    // Connection errors (Class 08)
-    if (state.starts_with("08"))
-        return true; // 08001, 08S01, 08006, etc.
-
-    // Timeout errors
-    if (state == "HYT00" || state == "HYT01")
-        return true;
-
-    // Transaction rollback due to deadlock/serialization (Class 40)
-    if (state.starts_with("40"))
-        return true;
-
-    // Database locked (common in SQLite)
-    if (error.message.contains("database is locked"))
-        return true;
-    if (error.message.contains("SQLITE_BUSY"))
-        return true;
-
-    return false;
+    return GenericRetryOps().IsTransient(error);
 }
 
 std::chrono::milliseconds CalculateRetryDelay(unsigned attempt, RetrySettings const& settings) noexcept
 {
-    auto delay = settings.initialDelay;
-    for (unsigned i = 0; i < attempt; ++i)
-    {
-        delay = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::duration<double, std::milli>(static_cast<double>(delay.count()) * settings.backoffMultiplier));
-    }
-    return std::min(delay, settings.maxDelay);
+    return SqlRetryPolicy { settings }.DelayFor(attempt);
 }
 
 RetryAction ClassifyRetryOutcome(SqlErrorInfo const& error, unsigned attemptsSoFar, RetrySettings const& settings)
 {
-    if (!IsTransientError(error) || attemptsSoFar >= settings.maxRetries)
-        return RetryAction::GiveUp;
-
-    return RetryAction::Retry;
+    return SqlRetryPolicy { settings }.Decide(error, SqlRetryState { .retriesSoFar = attemptsSoFar }).action;
 }
 
 bool ConnectWithRetry(SqlConnection& conn,

--- a/src/Lightweight/SqlBackup/Common.hpp
+++ b/src/Lightweight/SqlBackup/Common.hpp
@@ -121,10 +121,8 @@ LIGHTWEIGHT_API bool ConnectWithRetry(SqlConnection& conn,
 /// @return The result of the function.
 /// @throws SqlException if max retries exceeded or non-transient error occurs.
 template <typename Func>
-auto RetryOnTransientError(Func func,
-                           RetrySettings const& settings,
-                           ProgressManager& progress,
-                           std::string const& operation) -> decltype(func())
+auto RetryOnTransientError(Func func, RetrySettings const& settings, ProgressManager& progress, std::string const& operation)
+    -> decltype(func())
 {
     auto policy = SqlRetryPolicy { settings };
 

--- a/src/Lightweight/SqlBackup/Common.hpp
+++ b/src/Lightweight/SqlBackup/Common.hpp
@@ -4,6 +4,7 @@
 
 #include "../SqlConnection.hpp"
 #include "../SqlError.hpp"
+#include "../SqlRetryPolicy.hpp"
 #include "SqlBackup.hpp"
 
 #include <chrono>
@@ -42,6 +43,13 @@ struct ZipEntryInfo
 
 /// Determines if the given SQL error is a transient error that can be retried.
 ///
+/// Thin adapter over @ref Lightweight::GenericRetryOps(), which is where the classification
+/// actually lives — the backup engine no longer carries its own copy of the heuristics. The
+/// dialect-agnostic classifier is used because this helper is reached from contexts that have an
+/// error but not the connection it came from; a caller that does have a connection should build a
+/// @ref Lightweight::SqlRetryPolicy with @c SqlRetryPolicy::For() and get the sharper per-DBMS
+/// classification instead.
+///
 /// Transient errors include:
 /// - Connection errors (ODBC class 08)
 /// - Timeout errors (HYT00, HYT01)
@@ -54,6 +62,8 @@ LIGHTWEIGHT_API bool IsTransientError(SqlErrorInfo const& error);
 
 /// Calculates the delay for the given retry attempt using exponential backoff.
 ///
+/// Delegates to @ref Lightweight::SqlRetryPolicy::DelayFor().
+///
 /// @param attempt The current retry attempt number (0-based).
 /// @param settings The retry configuration.
 /// @return The delay to wait before the next retry.
@@ -61,20 +71,19 @@ LIGHTWEIGHT_API std::chrono::milliseconds CalculateRetryDelay(unsigned attempt, 
 
 /// What a retry loop should do after an attempt failed.
 ///
+/// An alias for @ref Lightweight::SqlRetryAction; the backup engine shares the library-wide
+/// vocabulary rather than defining its own.
+///
 /// @see ClassifyRetryOutcome
-enum class RetryAction : uint8_t
-{
-    /// The error is transient and the retry budget is not exhausted — wait and try again.
-    Retry,
-    /// The error is not transient, or the retry budget is spent — surface the failure.
-    GiveUp,
-};
+using RetryAction = SqlRetryAction;
 
 /// @brief Decides whether a failed attempt should be retried.
 ///
 /// Extracted from the retry loops so the policy can be exercised without provoking a real
 /// transient driver failure. This performs no I/O and touches no handle, so a test drives it by
 /// constructing a @ref SqlErrorInfo — the same approach the `IsTransientError` cases above use.
+///
+/// Delegates to @ref Lightweight::SqlRetryPolicy::Decide(), keeping the decision in one place.
 ///
 /// @param error The error reported by the failed attempt.
 /// @param attemptsSoFar How many retries have already been consumed.
@@ -100,6 +109,10 @@ LIGHTWEIGHT_API bool ConnectWithRetry(SqlConnection& conn,
 
 /// Retries a function on transient errors with exponential backoff.
 ///
+/// A thin wrapper over @ref Lightweight::SqlRetryPolicy::Execute() that routes each retry notice
+/// into @p progress. @p func is taken by value because it is invoked repeatedly — forwarding an
+/// rvalue more than once would use a moved-from callable.
+///
 /// @tparam Func The callable type.
 /// @param func The function to execute.
 /// @param settings Retry configuration.
@@ -108,35 +121,27 @@ LIGHTWEIGHT_API bool ConnectWithRetry(SqlConnection& conn,
 /// @return The result of the function.
 /// @throws SqlException if max retries exceeded or non-transient error occurs.
 template <typename Func>
-auto RetryOnTransientError(Func&& func, // NOLINT(cppcoreguidelines-missing-std-forward)
+auto RetryOnTransientError(Func func,
                            RetrySettings const& settings,
                            ProgressManager& progress,
                            std::string const& operation) -> decltype(func())
 {
-    unsigned attempts = 0;
+    auto policy = SqlRetryPolicy { settings };
 
-    while (true)
-    {
-        try
-        {
-            return func();
-        }
-        catch (SqlException const& e)
-        {
-            if (ClassifyRetryOutcome(e.info(), attempts, settings) == RetryAction::GiveUp)
-                throw;
+    policy.SetRetryObserver([&progress, &operation, &settings](SqlRetryAttempt const& attempt) {
+        progress.Update({ .state = Progress::State::Warning,
+                          .tableName = operation,
+                          .currentRows = 0,
+                          .totalRows = std::nullopt,
+                          // Formatting the error info reproduces SqlException::what() exactly, so
+                          // the wording of these progress lines is unchanged by the migration.
+                          .message = std::format("Transient error, retry {}/{}: {}",
+                                                 attempt.retryNumber,
+                                                 settings.maxRetries,
+                                                 std::format("{}", attempt.error)) });
+    });
 
-            ++attempts;
-            progress.Update(
-                { .state = Progress::State::Warning,
-                  .tableName = operation,
-                  .currentRows = 0,
-                  .totalRows = std::nullopt,
-                  .message = std::format("Transient error, retry {}/{}: {}", attempts, settings.maxRetries, e.what()) });
-
-            std::this_thread::sleep_for(CalculateRetryDelay(attempts - 1, settings));
-        }
-    }
+    return policy.Execute(std::move(func));
 }
 
 /// Returns the current date and time in ISO 8601 format.

--- a/src/Lightweight/SqlBackup/Restore.cpp
+++ b/src/Lightweight/SqlBackup/Restore.cpp
@@ -272,7 +272,7 @@ bool RestoreChunkData(RestoreContext& ctx, SqlConnection& workerConn, RestoreChu
         }
         catch (SqlException const& e)
         {
-            if (!IsTransientError(e.info()) || retryCount >= ctx.retrySettings.maxRetries)
+            if (ClassifyRetryOutcome(e.info(), retryCount, ctx.retrySettings) == RetryAction::GiveUp)
             {
                 ctx.progress.Update({ .state = Progress::State::Error,
                                       .tableName = tableName,

--- a/src/Lightweight/SqlBackup/SqlBackup.hpp
+++ b/src/Lightweight/SqlBackup/SqlBackup.hpp
@@ -4,6 +4,7 @@
 #include "../Api.hpp"
 #include "../SqlConnectInfo.hpp"
 #include "../SqlQuery/MigrationPlan.hpp"
+#include "../SqlRetryPolicy.hpp"
 #include "../SqlSchema.hpp"
 
 #include <chrono>
@@ -126,20 +127,14 @@ LIGHTWEIGHT_API std::vector<CompressionMethod> GetSupportedCompressionMethods() 
 LIGHTWEIGHT_API std::string_view CompressionMethodName(CompressionMethod method) noexcept;
 
 /// Configuration for retry behavior on transient errors during backup/restore operations.
-struct RetrySettings
-{
-    /// Maximum number of retry attempts for transient errors.
-    unsigned maxRetries = 3;
-
-    /// Initial delay between retry attempts.
-    std::chrono::milliseconds initialDelay { 500 };
-
-    /// Multiplier applied to delay after each failed attempt (exponential backoff).
-    double backoffMultiplier = 2.0;
-
-    /// Maximum delay between retry attempts.
-    std::chrono::milliseconds maxDelay { 30000 };
-};
+///
+/// An alias for the library-wide @ref SqlRetrySettings: the backup engine was where this policy
+/// was first proven out, and it now shares one implementation with the rest of the library rather
+/// than keeping a parallel copy. The field names, types and defaults are unchanged, so existing
+/// designated-initializer call sites keep compiling verbatim.
+///
+/// @see SqlRetryPolicy
+using RetrySettings = SqlRetrySettings;
 
 /// Information about a table being backed up.
 struct TableInfo

--- a/src/Lightweight/SqlQueryFormatter.hpp
+++ b/src/Lightweight/SqlQueryFormatter.hpp
@@ -14,6 +14,7 @@ namespace Lightweight
 {
 
 class SqlAdvisoryLockHandler;
+class SqlRetryClassifier;
 
 /// API to format SQL queries for different SQL dialects.
 class [[nodiscard]] LIGHTWEIGHT_API SqlQueryFormatter
@@ -253,6 +254,13 @@ class [[nodiscard]] LIGHTWEIGHT_API SqlQueryFormatter
     /// translation unit, so adding a new dialect only touches that unit and
     /// `SqlScopedLock` itself stays dialect-agnostic.
     [[nodiscard]] virtual SqlAdvisoryLockHandler const& AdvisoryLockOps() const = 0;
+
+    /// Returns the dialect's transient-error classifier, used by @c SqlRetryPolicy to decide
+    /// whether a failed statement is worth another attempt.
+    ///
+    /// Routing the classification through the formatter is what keeps per-DBMS error-code
+    /// knowledge out of business logic — the same reason @ref AdvisoryLockOps() exists.
+    [[nodiscard]] virtual SqlRetryClassifier const& RetryOps() const noexcept = 0;
 
   protected:
     /// Formats a table name with optional schema prefix.

--- a/src/Lightweight/SqlRetryClassifier.hpp
+++ b/src/Lightweight/SqlRetryClassifier.hpp
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "Api.hpp"
+#include "SqlError.hpp"
+
+#include <cstdint>
+
+namespace Lightweight
+{
+
+/// @defgroup Retry Retry and Backoff
+/// @brief A reusable, injectable retry/backoff policy for transient database failures.
+///
+/// The pieces are deliberately split so each one is usable — and testable — on its own:
+///
+/// - @ref SqlRetryClassifier decides whether a given @ref SqlErrorInfo is worth another attempt.
+///   It is a per-DBMS extension point, reached through @c SqlQueryFormatter::RetryOps().
+/// - @ref SqlRetrySettings carries the backoff knobs (budget, initial delay, multiplier, caps).
+/// - @ref SqlRetryPolicy combines the two into a decision function and a small driver that runs a
+///   callable until it succeeds or the policy gives up.
+
+/// @ingroup Retry
+/// Whether a failed operation is worth attempting again.
+enum class SqlErrorTransience : std::uint8_t
+{
+    /// The condition is permanent — a constraint violation, a syntax error, a missing table.
+    /// Retrying it will fail identically, so the caller should surface the failure.
+    Permanent,
+
+    /// The condition is temporary — a dropped connection, a lock timeout, a deadlock-victim
+    /// rollback. The very same statement may well succeed on a later attempt.
+    Transient,
+};
+
+/// @ingroup Retry
+/// @brief Dialect-specific classification of SQL errors into transient and permanent.
+///
+/// Every @c SqlQueryFormatter returns a process-singleton instance of the appropriate concrete
+/// classifier via @c SqlQueryFormatter::RetryOps(), which is what keeps per-DBMS error-code
+/// knowledge out of business logic: callers ask the formatter, never @c SqlServerType directly.
+///
+/// The dialects genuinely disagree. PostgreSQL reports a serialization failure as SQLSTATE
+/// @c 40001 and a lock it could not take as @c 55P03; SQL Server reports the deadlock victim as
+/// native error @c 1205 under a generic SQLSTATE; SQLite reports a busy database as a message
+/// string with no usable SQLSTATE at all. A single hard-coded predicate cannot be right for all
+/// three, which is why this is a dispatch point rather than a free function.
+///
+/// Callers normally reach a classifier through @ref SqlRetryPolicy rather than using it directly;
+/// this type is the extension point for adding a new dialect.
+class [[nodiscard]] LIGHTWEIGHT_API SqlRetryClassifier
+{
+  public:
+    SqlRetryClassifier() = default;
+    /// Polymorphic destructor.
+    virtual ~SqlRetryClassifier() = default;
+
+    SqlRetryClassifier(SqlRetryClassifier const&) = delete;
+    SqlRetryClassifier& operator=(SqlRetryClassifier const&) = delete;
+    SqlRetryClassifier(SqlRetryClassifier&&) = delete;
+    SqlRetryClassifier& operator=(SqlRetryClassifier&&) = delete;
+
+    /// Classifies the given error.
+    ///
+    /// Implementations must be pure: no I/O, no handle access, no hidden state. That is what lets
+    /// a test drive every branch by constructing a @ref SqlErrorInfo, rather than having to
+    /// provoke a real driver failure.
+    ///
+    /// @param error The error reported by the failed attempt.
+    /// @return Whether another attempt could plausibly succeed.
+    [[nodiscard]] virtual SqlErrorTransience Classify(SqlErrorInfo const& error) const noexcept = 0;
+
+    /// Convenience predicate over @ref Classify.
+    ///
+    /// @param error The error reported by the failed attempt.
+    /// @return @c true if @p error is classified as @ref SqlErrorTransience::Transient.
+    [[nodiscard]] bool IsTransient(SqlErrorInfo const& error) const noexcept
+    {
+        return Classify(error) == SqlErrorTransience::Transient;
+    }
+};
+
+/// @ingroup Retry
+/// @brief Returns the dialect-agnostic classifier.
+///
+/// Recognises the transient SQLSTATE classes every ODBC driver shares (connection class @c 08,
+/// transaction-rollback class @c 40, and the @c HYT00 / @c HYT01 timeouts) plus the widely
+/// observed native codes and driver messages. It is the fallback used when the dialect is not
+/// known — for instance when no connection is at hand, or for a server type that has no
+/// formatter of its own.
+[[nodiscard]] LIGHTWEIGHT_API SqlRetryClassifier const& GenericRetryOps() noexcept;
+
+/// @ingroup Retry
+/// @brief Returns the SQLite-specific singleton classifier.
+///
+/// Defined in `SqlRetryPolicy.cpp` for the same reason the advisory-lock handlers are defined out
+/// of line — the formatter overrides delegate to these free functions inline, which keeps every
+/// formatter's vtable weak. See @c SqliteAdvisoryLockOps().
+[[nodiscard]] LIGHTWEIGHT_API SqlRetryClassifier const& SqliteRetryOps() noexcept;
+
+/// @ingroup Retry
+/// @brief Returns the SQL Server-specific singleton classifier. See @ref SqliteRetryOps().
+[[nodiscard]] LIGHTWEIGHT_API SqlRetryClassifier const& SqlServerRetryOps() noexcept;
+
+/// @ingroup Retry
+/// @brief Returns the PostgreSQL-specific singleton classifier. See @ref SqliteRetryOps().
+[[nodiscard]] LIGHTWEIGHT_API SqlRetryClassifier const& PostgreSqlRetryOps() noexcept;
+
+} // namespace Lightweight

--- a/src/Lightweight/SqlRetryPolicy.cpp
+++ b/src/Lightweight/SqlRetryPolicy.cpp
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "SqlConnection.hpp"
+#include "SqlErrorDetection.hpp"
+#include "SqlQueryFormatter.hpp"
+#include "SqlRetryPolicy.hpp"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <ranges>
+#include <span>
+#include <string_view>
+#include <thread>
+
+namespace Lightweight
+{
+
+namespace
+{
+
+    /// SQLSTATE classes that every ODBC driver reports for a temporary condition.
+    ///
+    /// Kept as a table rather than a chain of comparisons so a new class is one line, and so the
+    /// dialect classifiers below can share it verbatim instead of restating it.
+    constexpr std::array TransientSqlStateClasses = {
+        std::string_view { "08" }, // connection exception — dropped, rejected, or never established
+        std::string_view { "40" }, // transaction rollback — serialization failure, deadlock, integrity
+    };
+
+    /// Complete SQLSTATEs that are transient but do not belong to a wholly transient class.
+    constexpr std::array TransientSqlStates = {
+        std::string_view { "HYT00" }, // timeout expired
+        std::string_view { "HYT01" }, // connection timeout expired
+    };
+
+    /// Whether the SQLSTATE alone is enough to call the error transient, in any dialect.
+    [[nodiscard]] bool IsTransientSqlState(std::string_view state) noexcept
+    {
+        return std::ranges::any_of(TransientSqlStateClasses,
+                                   [state](std::string_view prefix) { return state.starts_with(prefix); })
+               || std::ranges::contains(TransientSqlStates, state);
+    }
+
+    /// Whether any of @p needles occurs in @p haystack.
+    [[nodiscard]] bool ContainsAny(std::string_view haystack, std::span<std::string_view const> needles) noexcept
+    {
+        return std::ranges::any_of(needles, [haystack](std::string_view needle) { return haystack.contains(needle); });
+    }
+
+    /// Dialect-agnostic fallback. Deliberately the union of what the supported drivers report, so
+    /// that classifying without knowing the dialect errs towards retrying rather than towards
+    /// giving up on a recoverable failure.
+    ///
+    /// Shares its body with `Lightweight::IsTransientError` so the project has exactly one
+    /// definition of the dialect-agnostic heuristics.
+    class GenericRetryClassifier final: public SqlRetryClassifier
+    {
+      public:
+        [[nodiscard]] SqlErrorTransience Classify(SqlErrorInfo const& error) const noexcept override
+        {
+            return IsTransientError(error) ? SqlErrorTransience::Transient : SqlErrorTransience::Permanent;
+        }
+    };
+
+    /// SQLite reports contention through the driver's message text: the ODBC layer maps
+    /// `SQLITE_BUSY` and `SQLITE_LOCKED` onto the generic `HY000`, so the SQLSTATE carries no
+    /// usable signal and the message is all there is to go on.
+    class SqliteRetryClassifier final: public SqlRetryClassifier
+    {
+      public:
+        [[nodiscard]] SqlErrorTransience Classify(SqlErrorInfo const& error) const noexcept override
+        {
+            static constexpr std::array Needles = {
+                std::string_view { "database is locked" },
+                std::string_view { "database table is locked" },
+                std::string_view { "SQLITE_BUSY" },
+                std::string_view { "SQLITE_LOCKED" },
+            };
+
+            if (IsTransientSqlState(error.sqlState) || ContainsAny(error.message, Needles))
+                return SqlErrorTransience::Transient;
+
+            return SqlErrorTransience::Permanent;
+        }
+    };
+
+    /// SQL Server signals most recoverable conditions through the native error code while leaving
+    /// the SQLSTATE generic, so the native code is the discriminator here.
+    class SqlServerRetryClassifier final: public SqlRetryClassifier
+    {
+      public:
+        [[nodiscard]] SqlErrorTransience Classify(SqlErrorInfo const& error) const noexcept override
+        {
+            static constexpr std::array<SQLINTEGER, 12> TransientNativeCodes = {
+                -2,    // query timeout expired
+                64,    // session terminated: a transport-level error during login
+                233,   // no process on the other end of the pipe
+                1205,  // chosen as the deadlock victim
+                1222,  // lock request timed out
+                10053, // transport-level error while sending the request
+                10054, // connection forcibly closed by the remote host
+                10060, // could not open a connection: network or instance-specific error
+                40197, // Azure SQL: the service encountered an error processing the request
+                40501, // Azure SQL: the service is busy
+                40613, // Azure SQL: the database is currently unavailable
+                49918, // Azure SQL: cannot process the request, not enough resources
+            };
+
+            if (IsTransientSqlState(error.sqlState) || std::ranges::contains(TransientNativeCodes, error.nativeErrorCode))
+                return SqlErrorTransience::Transient;
+
+            return SqlErrorTransience::Permanent;
+        }
+    };
+
+    /// PostgreSQL is the most precise of the three: it has a dedicated SQLSTATE for every
+    /// recoverable condition, so no message matching is needed.
+    class PostgreSqlRetryClassifier final: public SqlRetryClassifier
+    {
+      public:
+        [[nodiscard]] SqlErrorTransience Classify(SqlErrorInfo const& error) const noexcept override
+        {
+            // 40001 serialization_failure and 40P01 deadlock_detected are already covered by the
+            // shared class-40 prefix; what follows are the ones outside a transient class.
+            static constexpr std::array ExtraTransientStates = {
+                std::string_view { "53300" }, // too_many_connections
+                std::string_view { "55006" }, // object_in_use
+                std::string_view { "55P03" }, // lock_not_available
+                std::string_view { "57P01" }, // admin_shutdown
+                std::string_view { "57P02" }, // crash_shutdown
+                std::string_view { "57P03" }, // cannot_connect_now — the server is still starting up
+                std::string_view { "58030" }, // io_error
+            };
+
+            if (IsTransientSqlState(error.sqlState) || std::ranges::contains(ExtraTransientStates, error.sqlState))
+                return SqlErrorTransience::Transient;
+
+            return SqlErrorTransience::Permanent;
+        }
+    };
+
+    class ThisThreadSleeper final: public SqlRetrySleeper
+    {
+      public:
+        void Sleep(std::chrono::milliseconds duration) override
+        {
+            std::this_thread::sleep_for(duration);
+        }
+    };
+
+} // namespace
+
+SqlRetryClassifier const& GenericRetryOps() noexcept
+{
+    static GenericRetryClassifier const instance;
+    return instance;
+}
+
+SqlRetryClassifier const& SqliteRetryOps() noexcept
+{
+    static SqliteRetryClassifier const instance;
+    return instance;
+}
+
+SqlRetryClassifier const& SqlServerRetryOps() noexcept
+{
+    static SqlServerRetryClassifier const instance;
+    return instance;
+}
+
+SqlRetryClassifier const& PostgreSqlRetryOps() noexcept
+{
+    static PostgreSqlRetryClassifier const instance;
+    return instance;
+}
+
+SqlRetrySleeper& ThreadSleeper() noexcept
+{
+    static ThisThreadSleeper instance;
+    return instance;
+}
+
+SqlRetryPolicy::SqlRetryPolicy(SqlRetrySettings settings,
+                               SqlRetryClassifier const* classifier,
+                               SqlRetrySleeper* sleeper,
+                               RetryObserver observer):
+    _settings { settings },
+    _classifier { classifier ? classifier : &GenericRetryOps() },
+    _sleeper { sleeper ? sleeper : &ThreadSleeper() },
+    _observer { std::move(observer) }
+{
+}
+
+SqlRetryPolicy SqlRetryPolicy::For(SqlServerType serverType, SqlRetrySettings settings)
+{
+    auto const* formatter = SqlQueryFormatter::Get(serverType);
+    return SqlRetryPolicy { settings, formatter ? &formatter->RetryOps() : &GenericRetryOps() };
+}
+
+SqlRetryPolicy SqlRetryPolicy::For(SqlConnection const& connection, SqlRetrySettings settings)
+{
+    return SqlRetryPolicy { settings, &connection.QueryFormatter().RetryOps() };
+}
+
+std::chrono::milliseconds SqlRetryPolicy::DelayFor(unsigned retryIndex) const noexcept
+{
+    auto delay = _settings.initialDelay;
+
+    for ([[maybe_unused]] auto const step: std::views::iota(0U, retryIndex))
+    {
+        // Bail out once the cap is reached: the result is clamped below anyway, and stopping here
+        // keeps the multiplication from overflowing for an implausibly large retry index. Only
+        // safe while the sequence is non-decreasing, hence the multiplier guard.
+        if (_settings.backoffMultiplier >= 1.0 && delay >= _settings.maxDelay)
+            break;
+
+        delay = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::duration<double, std::milli>(static_cast<double>(delay.count()) * _settings.backoffMultiplier));
+    }
+
+    return std::min(delay, _settings.maxDelay);
+}
+
+SqlRetryDecision SqlRetryPolicy::Decide(SqlErrorInfo const& error, SqlRetryState const& state) const noexcept
+{
+    if (_classifier->Classify(error) != SqlErrorTransience::Transient)
+        return { .action = SqlRetryAction::GiveUp, .delay = {}, .reason = SqlRetryGiveUpReason::NotTransient };
+
+    if (state.retriesSoFar >= _settings.maxRetries)
+        return { .action = SqlRetryAction::GiveUp, .delay = {}, .reason = SqlRetryGiveUpReason::RetriesExhausted };
+
+    auto const delay = DelayFor(state.retriesSoFar);
+
+    if (_settings.totalDelayBudget > std::chrono::milliseconds { 0 }
+        && state.delaySoFar + delay > _settings.totalDelayBudget)
+        return { .action = SqlRetryAction::GiveUp, .delay = {}, .reason = SqlRetryGiveUpReason::DelayBudgetExhausted };
+
+    return { .action = SqlRetryAction::Retry, .delay = delay, .reason = SqlRetryGiveUpReason::None };
+}
+
+void SqlRetryPolicy::NotifyRetry(SqlRetryAttempt const& attempt) const
+{
+    if (_observer)
+        _observer(attempt);
+}
+
+} // namespace Lightweight

--- a/src/Lightweight/SqlRetryPolicy.hpp
+++ b/src/Lightweight/SqlRetryPolicy.hpp
@@ -267,8 +267,8 @@ class [[nodiscard]] SqlRetryPolicy
 
     /// Runs @p callable, retrying while the policy says the failure is worth another attempt.
     ///
-    /// Only @ref SqlException is treated as a retry candidate; any other exception propagates
-    /// immediately. When the policy gives up, the last @ref SqlException is rethrown unchanged, so
+    /// Only @c SqlException is treated as a retry candidate; any other exception propagates
+    /// immediately. When the policy gives up, the last @c SqlException is rethrown unchanged, so
     /// the caller sees the original diagnostics rather than a wrapper.
     ///
     /// @tparam Callable A nullary callable, taken by value because it is invoked repeatedly.

--- a/src/Lightweight/SqlRetryPolicy.hpp
+++ b/src/Lightweight/SqlRetryPolicy.hpp
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "Api.hpp"
+#include "SqlError.hpp"
+#include "SqlRetryClassifier.hpp"
+#include "SqlServerType.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <expected>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+namespace Lightweight
+{
+
+class SqlConnection;
+
+/// @ingroup Retry
+/// Backoff configuration of a @ref SqlRetryPolicy.
+///
+/// This is the descriptor half of the policy: pure data, no behaviour, so it can be read from a
+/// config file, held in a settings struct, or written inline at a call site.
+struct SqlRetrySettings
+{
+    /// Maximum number of *retries* — an operation is attempted at most @c maxRetries+1 times.
+    /// Zero disables retrying without disabling the classification machinery.
+    unsigned maxRetries = 3;
+
+    /// Delay before the first retry.
+    std::chrono::milliseconds initialDelay { 500 };
+
+    /// Multiplier applied to the delay after each failed attempt (exponential backoff).
+    double backoffMultiplier = 2.0;
+
+    /// Upper bound on any single delay, so a long budget cannot produce an unbounded wait.
+    std::chrono::milliseconds maxDelay { 30'000 };
+
+    /// Deadline expressed as a budget: once the delays already spent plus the next planned delay
+    /// would exceed this, the policy gives up with @ref SqlRetryGiveUpReason::DelayBudgetExhausted
+    /// instead of waiting. Zero — the default — means "no deadline, bounded only by
+    /// @ref maxRetries".
+    ///
+    /// A budget is used rather than a wall-clock deadline so that the decision stays pure: it
+    /// depends only on the caller-supplied @ref SqlRetryState, never on the current time.
+    std::chrono::milliseconds totalDelayBudget { 0 };
+};
+
+/// @ingroup Retry
+/// How far a retry loop has already got. Threaded through @ref SqlRetryPolicy::Decide so the
+/// decision itself stays a pure function of its inputs.
+struct SqlRetryState
+{
+    /// Number of retries already consumed. Zero on the first failure.
+    unsigned retriesSoFar = 0;
+
+    /// Sum of the delays already waited out, checked against
+    /// @ref SqlRetrySettings::totalDelayBudget.
+    std::chrono::milliseconds delaySoFar { 0 };
+};
+
+/// @ingroup Retry
+/// What a retry loop should do after an attempt failed.
+enum class SqlRetryAction : std::uint8_t
+{
+    /// Wait for @ref SqlRetryDecision::delay and try again.
+    Retry,
+
+    /// Surface the failure to the caller.
+    GiveUp,
+};
+
+/// @ingroup Retry
+/// Why @ref SqlRetryPolicy::Decide declined to retry. Reported so callers and logs can tell an
+/// exhausted budget apart from an error that was never retryable to begin with.
+enum class SqlRetryGiveUpReason : std::uint8_t
+{
+    /// Not giving up — set when the action is @ref SqlRetryAction::Retry.
+    None,
+
+    /// The error is permanent; another attempt would fail identically.
+    NotTransient,
+
+    /// The error was transient, but @ref SqlRetrySettings::maxRetries is spent.
+    RetriesExhausted,
+
+    /// The error was transient and retries remained, but the next delay would overrun
+    /// @ref SqlRetrySettings::totalDelayBudget.
+    DelayBudgetExhausted,
+};
+
+/// @ingroup Retry
+/// The outcome of @ref SqlRetryPolicy::Decide.
+struct SqlRetryDecision
+{
+    /// Whether to retry or to surface the failure.
+    SqlRetryAction action {};
+
+    /// How long to wait before the next attempt. Zero unless @ref action is
+    /// @ref SqlRetryAction::Retry.
+    std::chrono::milliseconds delay {};
+
+    /// Why the policy gave up. @ref SqlRetryGiveUpReason::None when it did not.
+    SqlRetryGiveUpReason reason { SqlRetryGiveUpReason::None };
+
+    /// @return @c true when the caller should retry.
+    [[nodiscard]] constexpr explicit operator bool() const noexcept
+    {
+        return action == SqlRetryAction::Retry;
+    }
+};
+
+/// @ingroup Retry
+/// Description of one retry about to happen, handed to a @ref SqlRetryPolicy::RetryObserver.
+struct SqlRetryAttempt
+{
+    /// Which retry this is, counting from one.
+    unsigned retryNumber {};
+
+    /// The configured budget, so an observer can render "retry 2/3" without holding the settings.
+    unsigned maxRetries {};
+
+    /// How long the driver is about to sleep before re-running the operation.
+    std::chrono::milliseconds delay {};
+
+    /// The error that triggered the retry.
+    SqlErrorInfo error;
+};
+
+/// @ingroup Retry
+/// @brief Supplies the wait between retries.
+///
+/// Injected rather than called directly so a test can drive a full retry loop in microseconds and
+/// assert on the delays that *would* have been waited out, instead of actually sleeping through an
+/// exponential backoff.
+class LIGHTWEIGHT_API SqlRetrySleeper
+{
+  public:
+    SqlRetrySleeper() = default;
+    /// Polymorphic destructor.
+    virtual ~SqlRetrySleeper() = default;
+
+    SqlRetrySleeper(SqlRetrySleeper const&) = delete;
+    SqlRetrySleeper& operator=(SqlRetrySleeper const&) = delete;
+    SqlRetrySleeper(SqlRetrySleeper&&) = delete;
+    SqlRetrySleeper& operator=(SqlRetrySleeper&&) = delete;
+
+    /// Blocks the calling thread for the given duration.
+    ///
+    /// @param duration How long to wait.
+    virtual void Sleep(std::chrono::milliseconds duration) = 0;
+};
+
+/// @ingroup Retry
+/// @brief Returns the production sleeper, which forwards to @c std::this_thread::sleep_for.
+[[nodiscard]] LIGHTWEIGHT_API SqlRetrySleeper& ThreadSleeper() noexcept;
+
+/// @ingroup Retry
+/// @brief A reusable retry/backoff policy for transient database failures.
+///
+/// Combines a @ref SqlRetryClassifier (which errors are worth another attempt — a per-DBMS
+/// question) with @ref SqlRetrySettings (how many attempts, how long to wait between them). Every
+/// collaborator is injectable, and none of them is constructed internally: the classifier and the
+/// sleeper are borrowed references with sensible process-wide defaults.
+///
+/// The type separates the *decision* from the *driving*:
+///
+/// - @ref Decide is pure. Given an error and how far the loop has already got, it says retry or
+///   give up, and why. No clock, no sleep, no I/O — so every branch is reachable from a unit test.
+/// - @ref Execute / @ref TryExecute are the thin drivers that call @ref Decide in a loop, wait via
+///   the injected @ref SqlRetrySleeper, and re-run the callable.
+///
+/// @code
+/// auto const policy = SqlRetryPolicy::For(connection);
+/// auto const orderCount = policy.Execute([&] {
+///     return SqlStatement { connection }
+///         .ExecuteDirectScalar<int>("SELECT COUNT(*) FROM orders")
+///         .value_or(0);
+/// });
+/// @endcode
+///
+/// @note The callable must be safe to run more than once. Retrying an operation that already had a
+///       visible side effect is the caller's responsibility; wrap it in a transaction that the
+///       callable itself begins and commits, so a retry starts from a clean slate.
+class [[nodiscard]] SqlRetryPolicy
+{
+  public:
+    /// Notified just before each retry. Used, for instance, to route retry notices into a
+    /// progress reporter or a log.
+    using RetryObserver = std::function<void(SqlRetryAttempt const&)>;
+
+    /// Constructs a policy with the default settings, the dialect-agnostic classifier and the
+    /// real sleeper.
+    SqlRetryPolicy() = default;
+
+    /// Constructs a policy.
+    ///
+    /// @param settings The backoff configuration.
+    /// @param classifier Which errors are retryable; @c nullptr selects @ref GenericRetryOps().
+    ///                   The referenced classifier must outlive the policy — the dialect
+    ///                   singletons always do.
+    /// @param sleeper How to wait between attempts; @c nullptr selects @ref ThreadSleeper().
+    ///                The referenced sleeper must outlive the policy.
+    /// @param observer Called before each retry; may be empty.
+    LIGHTWEIGHT_API explicit SqlRetryPolicy(SqlRetrySettings settings,
+                                            SqlRetryClassifier const* classifier = nullptr,
+                                            SqlRetrySleeper* sleeper = nullptr,
+                                            RetryObserver observer = {});
+
+    /// Builds a policy whose classifier matches the given server type.
+    ///
+    /// The mapping runs through @c SqlQueryFormatter::Get(), so the per-DBMS knowledge stays at
+    /// the formatter dispatch point. A server type without a formatter of its own falls back to
+    /// @ref GenericRetryOps().
+    ///
+    /// @param serverType The DBMS whose error dialect should be used.
+    /// @param settings The backoff configuration.
+    /// @return The configured policy.
+    [[nodiscard]] LIGHTWEIGHT_API static SqlRetryPolicy For(SqlServerType serverType, SqlRetrySettings settings = {});
+
+    /// Builds a policy whose classifier matches the connection's DBMS.
+    ///
+    /// @param connection The connection whose server type selects the classifier.
+    /// @param settings The backoff configuration.
+    /// @return The configured policy.
+    [[nodiscard]] LIGHTWEIGHT_API static SqlRetryPolicy For(SqlConnection const& connection, SqlRetrySettings settings = {});
+
+    /// @return The backoff configuration in effect.
+    [[nodiscard]] SqlRetrySettings const& Settings() const noexcept
+    {
+        return _settings;
+    }
+
+    /// @return The classifier in effect.
+    [[nodiscard]] SqlRetryClassifier const& Classifier() const noexcept
+    {
+        return *_classifier;
+    }
+
+    /// Installs an observer notified before each retry.
+    ///
+    /// @param observer The observer; pass an empty function to remove a previously set one.
+    void SetRetryObserver(RetryObserver observer)
+    {
+        _observer = std::move(observer);
+    }
+
+    /// Computes the backoff delay preceding a given retry.
+    ///
+    /// @param retryIndex Zero-based retry number: @c 0 is the delay before the first retry.
+    /// @return @c initialDelay multiplied by @c backoffMultiplier @p retryIndex times, clamped to
+    ///         @c maxDelay.
+    [[nodiscard]] LIGHTWEIGHT_API std::chrono::milliseconds DelayFor(unsigned retryIndex) const noexcept;
+
+    /// Decides what to do after a failed attempt.
+    ///
+    /// Pure: no I/O, no clock, no hidden state.
+    ///
+    /// @param error The error reported by the failed attempt.
+    /// @param state How far the retry loop has already got.
+    /// @return Whether to retry, how long to wait first, and — if not — why not.
+    [[nodiscard]] LIGHTWEIGHT_API SqlRetryDecision Decide(SqlErrorInfo const& error,
+                                                          SqlRetryState const& state) const noexcept;
+
+    /// Runs @p callable, retrying while the policy says the failure is worth another attempt.
+    ///
+    /// Only @ref SqlException is treated as a retry candidate; any other exception propagates
+    /// immediately. When the policy gives up, the last @ref SqlException is rethrown unchanged, so
+    /// the caller sees the original diagnostics rather than a wrapper.
+    ///
+    /// @tparam Callable A nullary callable, taken by value because it is invoked repeatedly.
+    /// @param callable The operation to run.
+    /// @return Whatever @p callable returns.
+    template <typename Callable>
+    auto Execute(Callable callable) const -> std::invoke_result_t<Callable&>;
+
+    /// Like @ref Execute, but reports a final failure as @c std::unexpected rather than throwing.
+    ///
+    /// @tparam Callable A nullary callable, taken by value because it is invoked repeatedly.
+    /// @param callable The operation to run.
+    /// @return The callable's result, or the @ref SqlErrorInfo of the attempt the policy gave up on.
+    template <typename Callable>
+    [[nodiscard]] auto TryExecute(Callable callable) const -> std::expected<std::invoke_result_t<Callable&>, SqlErrorInfo>;
+
+  private:
+    LIGHTWEIGHT_API void NotifyRetry(SqlRetryAttempt const& attempt) const;
+
+    SqlRetrySettings _settings {};
+    SqlRetryClassifier const* _classifier = &GenericRetryOps();
+    SqlRetrySleeper* _sleeper = &ThreadSleeper();
+    RetryObserver _observer {};
+};
+
+template <typename Callable>
+auto SqlRetryPolicy::Execute(Callable callable) const -> std::invoke_result_t<Callable&>
+{
+    auto state = SqlRetryState {};
+
+    while (true)
+    {
+        try
+        {
+            return callable();
+        }
+        catch (SqlException const& e)
+        {
+            auto const decision = Decide(e.info(), state);
+            if (decision.action == SqlRetryAction::GiveUp)
+                throw;
+
+            state.retriesSoFar += 1;
+            state.delaySoFar += decision.delay;
+
+            NotifyRetry(SqlRetryAttempt { .retryNumber = state.retriesSoFar,
+                                          .maxRetries = _settings.maxRetries,
+                                          .delay = decision.delay,
+                                          .error = e.info() });
+
+            _sleeper->Sleep(decision.delay);
+        }
+    }
+}
+
+template <typename Callable>
+auto SqlRetryPolicy::TryExecute(Callable callable) const -> std::expected<std::invoke_result_t<Callable&>, SqlErrorInfo>
+{
+    using Result = std::invoke_result_t<Callable&>;
+
+    try
+    {
+        if constexpr (std::is_void_v<Result>)
+        {
+            Execute(std::move(callable));
+            return {};
+        }
+        else
+            return Execute(std::move(callable));
+    }
+    catch (SqlException const& e)
+    {
+        return std::unexpected { e.info() };
+    }
+}
+
+} // namespace Lightweight

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -77,6 +77,7 @@ set(SOURCE_FILES
     SqlDateTimeDbTests.cpp
     SqlNumericTests.cpp
     SqlRealNameTests.cpp
+    SqlRetryPolicyTests.cpp
     SqlSchemaDbTests.cpp
     SqlStatementBatchFetchTests.cpp
     SqlStatementPrefetchTests.cpp

--- a/src/tests/SqlRetryPolicyTests.cpp
+++ b/src/tests/SqlRetryPolicyTests.cpp
@@ -30,12 +30,18 @@ using namespace std::chrono_literals;
 namespace
 {
 
-SqlErrorInfo MakeError(std::string sqlState, SQLINTEGER nativeCode = 0, std::string message = {})
+/// Builds an error carrying only a SQLSTATE and (optionally) a native code.
+///
+/// Deliberately two parameters: a third string next to these would be swappable with the first at
+/// the call site, which is what bugprone-easily-swappable-parameters objects to. The cases that do
+/// need a driver message spell out the aggregate with designated initializers, which names each
+/// field and cannot be transposed.
+SqlErrorInfo MakeError(std::string sqlState, SQLINTEGER nativeCode = 0)
 {
     return SqlErrorInfo {
         .nativeErrorCode = nativeCode,
         .sqlState = std::move(sqlState),
-        .message = std::move(message),
+        .message = {},
     };
 }
 
@@ -64,7 +70,7 @@ class FlakyOperation
 
     int operator()()
     {
-        ++calls;
+        ++_calls;
         if (_remainingFailures > 0)
         {
             --_remainingFailures;
@@ -73,9 +79,14 @@ class FlakyOperation
         return 42;
     }
 
-    unsigned calls = 0;
+    /// Number of times the operation was invoked, successful attempt included.
+    [[nodiscard]] unsigned Calls() const noexcept
+    {
+        return _calls;
+    }
 
   private:
+    unsigned _calls = 0;
     unsigned _remainingFailures;
     SqlErrorInfo _error;
 };
@@ -152,13 +163,19 @@ TEST_CASE("SQLite classifier keys off the driver message", "[SqlRetryPolicy]")
     auto const& classifier = SqliteRetryOps();
 
     // The SQLite ODBC driver flattens busy/locked onto HY000, leaving only the message text.
-    CHECK(classifier.IsTransient(MakeError("HY000", 5, "database is locked")));
-    CHECK(classifier.IsTransient(MakeError("HY000", 6, "database table is locked")));
-    CHECK(classifier.IsTransient(MakeError("HY000", 5, "driver reported SQLITE_BUSY")));
-    CHECK(classifier.IsTransient(MakeError("HY000", 6, "driver reported SQLITE_LOCKED")));
+    CHECK(
+        classifier.IsTransient(SqlErrorInfo { .nativeErrorCode = 5, .sqlState = "HY000", .message = "database is locked" }));
+    CHECK(classifier.IsTransient(
+        SqlErrorInfo { .nativeErrorCode = 6, .sqlState = "HY000", .message = "database table is locked" }));
+    CHECK(classifier.IsTransient(
+        SqlErrorInfo { .nativeErrorCode = 5, .sqlState = "HY000", .message = "driver reported SQLITE_BUSY" }));
+    CHECK(classifier.IsTransient(
+        SqlErrorInfo { .nativeErrorCode = 6, .sqlState = "HY000", .message = "driver reported SQLITE_LOCKED" }));
 
-    CHECK_FALSE(classifier.IsTransient(MakeError("HY000", 1, "no such table: orders")));
-    CHECK_FALSE(classifier.IsTransient(MakeError("HY000", 19, "UNIQUE constraint failed: t.id")));
+    CHECK_FALSE(classifier.IsTransient(
+        SqlErrorInfo { .nativeErrorCode = 1, .sqlState = "HY000", .message = "no such table: orders" }));
+    CHECK_FALSE(classifier.IsTransient(
+        SqlErrorInfo { .nativeErrorCode = 19, .sqlState = "HY000", .message = "UNIQUE constraint failed: t.id" }));
 }
 
 TEST_CASE("SqlRetryPolicy::For maps a server type to its dialect classifier", "[SqlRetryPolicy]")
@@ -323,7 +340,7 @@ TEST_CASE("Execute retries a transient failure and returns the eventual result",
     auto const result = policy.Execute(std::ref(operation));
 
     CHECK(result == 42);
-    CHECK(operation.calls == 3); // two failures plus the successful attempt
+    CHECK(operation.Calls() == 3); // two failures plus the successful attempt
     REQUIRE(sleeper.slept.size() == 2);
     CHECK(sleeper.slept[0] == 100ms);
     CHECK(sleeper.slept[1] == 200ms);
@@ -337,7 +354,7 @@ TEST_CASE("Execute does not retry a permanent failure", "[SqlRetryPolicy]")
     auto operation = FlakyOperation { 1, MakeError("23505") };
     CHECK_THROWS_AS(policy.Execute(std::ref(operation)), SqlException);
 
-    CHECK(operation.calls == 1);
+    CHECK(operation.Calls() == 1);
     CHECK(sleeper.slept.empty());
 }
 
@@ -347,7 +364,8 @@ TEST_CASE("Execute rethrows the original error once the budget is spent", "[SqlR
     auto const policy = SqlRetryPolicy { FastSettings, &GenericRetryOps(), &sleeper };
 
     // Always fails: 1 initial attempt + 3 retries, then the last SqlException escapes unwrapped.
-    auto operation = FlakyOperation { 99, MakeError("08S01", 0, "link failure") };
+    auto operation =
+        FlakyOperation { 99, SqlErrorInfo { .nativeErrorCode = 0, .sqlState = "08S01", .message = "link failure" } };
     try
     {
         (void) policy.Execute(std::ref(operation));
@@ -359,7 +377,7 @@ TEST_CASE("Execute rethrows the original error once the budget is spent", "[SqlR
         CHECK(e.info().message == "link failure");
     }
 
-    CHECK(operation.calls == 4);
+    CHECK(operation.Calls() == 4);
     CHECK(sleeper.slept.size() == 3);
 }
 
@@ -402,7 +420,8 @@ TEST_CASE("TryExecute reports a final failure as unexpected", "[SqlRetryPolicy]"
 
     SECTION("a permanent failure carries the error info")
     {
-        auto operation = FlakyOperation { 1, MakeError("23505", 0, "duplicate key") };
+        auto operation =
+            FlakyOperation { 1, SqlErrorInfo { .nativeErrorCode = 0, .sqlState = "23505", .message = "duplicate key" } };
         auto const result = policy.TryExecute(std::ref(operation));
         REQUIRE_FALSE(result.has_value());
         CHECK(result.error().sqlState == "23505");
@@ -428,7 +447,8 @@ TEST_CASE("The retry observer sees every retry before the wait", "[SqlRetryPolic
     auto seen = std::vector<SqlRetryAttempt> {};
     policy.SetRetryObserver([&seen](SqlRetryAttempt const& attempt) { seen.emplace_back(attempt); });
 
-    auto operation = FlakyOperation { 2, MakeError("HYT00", 0, "timeout expired") };
+    auto operation =
+        FlakyOperation { 2, SqlErrorInfo { .nativeErrorCode = 0, .sqlState = "HYT00", .message = "timeout expired" } };
     (void) policy.Execute(std::ref(operation));
 
     REQUIRE(seen.size() == 2);
@@ -461,8 +481,7 @@ TEST_CASE("A default-constructed policy is usable", "[SqlRetryPolicy]")
 // connection resolves to the classifier for its own dialect.
 // ================================================================================================
 
-TEST_CASE_METHOD(SqlTestFixture, "SqlRetryPolicy::For(connection) picks the live server's classifier",
-                 "[SqlRetryPolicy]")
+TEST_CASE_METHOD(SqlTestFixture, "SqlRetryPolicy::For(connection) picks the live server's classifier", "[SqlRetryPolicy]")
 {
     auto stmt = SqlStatement {};
     auto const& connection = stmt.Connection();

--- a/src/tests/SqlRetryPolicyTests.cpp
+++ b/src/tests/SqlRetryPolicyTests.cpp
@@ -1,0 +1,479 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "Utils.hpp"
+
+#include <Lightweight/SqlConnection.hpp>
+#include <Lightweight/SqlError.hpp>
+#include <Lightweight/SqlRetryClassifier.hpp>
+#include <Lightweight/SqlRetryPolicy.hpp>
+#include <Lightweight/SqlServerType.hpp>
+#include <Lightweight/SqlStatement.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <functional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace Lightweight;
+using namespace std::chrono_literals;
+
+// The whole policy is deliberately free of I/O and of any clock, so every case below runs without
+// a database: an error is a value, the sleeper is injected, and the decision is a pure function of
+// its inputs. That is what makes the per-DBMS classification testable at all — provoking a real
+// Azure SQL throttle or a PostgreSQL serialization failure on demand is not something a unit test
+// can do.
+
+namespace
+{
+
+SqlErrorInfo MakeError(std::string sqlState, SQLINTEGER nativeCode = 0, std::string message = {})
+{
+    return SqlErrorInfo {
+        .nativeErrorCode = nativeCode,
+        .sqlState = std::move(sqlState),
+        .message = std::move(message),
+    };
+}
+
+/// Records what it was asked to wait for instead of actually waiting, so a full retry loop
+/// finishes in microseconds and the backoff schedule is directly assertable.
+class RecordingSleeper final: public SqlRetrySleeper
+{
+  public:
+    void Sleep(std::chrono::milliseconds duration) override
+    {
+        slept.emplace_back(duration);
+    }
+
+    std::vector<std::chrono::milliseconds> slept;
+};
+
+/// Fails with the given error for the first `failures` calls, then succeeds.
+class FlakyOperation
+{
+  public:
+    FlakyOperation(unsigned failures, SqlErrorInfo error):
+        _remainingFailures { failures },
+        _error { std::move(error) }
+    {
+    }
+
+    int operator()()
+    {
+        ++calls;
+        if (_remainingFailures > 0)
+        {
+            --_remainingFailures;
+            throw SqlException { _error };
+        }
+        return 42;
+    }
+
+    unsigned calls = 0;
+
+  private:
+    unsigned _remainingFailures;
+    SqlErrorInfo _error;
+};
+
+/// Backoff collapsed to a single millisecond, for cases about control flow rather than timing.
+constexpr auto FastSettings = SqlRetrySettings {
+    .maxRetries = 3,
+    .initialDelay = 1ms,
+    .backoffMultiplier = 1.0,
+    .maxDelay = 1ms,
+};
+
+} // namespace
+
+// ================================================================================================
+// Per-DBMS classification — the core of the issue: a transient error in one dialect is a plain
+// failure in another, so each classifier must recognise its own dialect and only its own.
+// ================================================================================================
+
+TEST_CASE("Every classifier accepts the shared ODBC transient SQLSTATE classes", "[SqlRetryPolicy]")
+{
+    // Class 08 (connection), class 40 (transaction rollback) and the HYT timeouts are ODBC-level
+    // and therefore dialect-independent — no classifier may disagree about them.
+    for (auto const* classifier: { &GenericRetryOps(), &SqliteRetryOps(), &SqlServerRetryOps(), &PostgreSqlRetryOps() })
+    {
+        CHECK(classifier->IsTransient(MakeError("08001"))); // unable to connect
+        CHECK(classifier->IsTransient(MakeError("08S01"))); // communication link failure
+        CHECK(classifier->IsTransient(MakeError("40001"))); // serialization failure
+        CHECK(classifier->IsTransient(MakeError("HYT00"))); // timeout expired
+        CHECK(classifier->IsTransient(MakeError("HYT01"))); // connection timeout expired
+
+        CHECK_FALSE(classifier->IsTransient(MakeError("23505"))); // unique violation
+        CHECK_FALSE(classifier->IsTransient(MakeError("42S02"))); // table not found
+        CHECK_FALSE(classifier->IsTransient(MakeError("42000"))); // syntax error
+    }
+}
+
+TEST_CASE("SQL Server classifier keys off the native error code", "[SqlRetryPolicy]")
+{
+    auto const& classifier = SqlServerRetryOps();
+
+    // SQL Server reports these under a generic SQLSTATE, so the native code is the only signal.
+    CHECK(classifier.IsTransient(MakeError("HY000", 1205)));  // deadlock victim
+    CHECK(classifier.IsTransient(MakeError("HY000", 1222)));  // lock request timed out
+    CHECK(classifier.IsTransient(MakeError("HY000", -2)));    // query timeout
+    CHECK(classifier.IsTransient(MakeError("HY000", 10054))); // connection forcibly closed
+    CHECK(classifier.IsTransient(MakeError("HY000", 40501))); // Azure SQL: service is busy
+    CHECK(classifier.IsTransient(MakeError("HY000", 40613))); // Azure SQL: database unavailable
+
+    CHECK_FALSE(classifier.IsTransient(MakeError("HY000", 2627))); // unique key violation
+    CHECK_FALSE(classifier.IsTransient(MakeError("HY000", 547)));  // FK constraint conflict
+    CHECK_FALSE(classifier.IsTransient(MakeError("HY000", 208)));  // invalid object name
+}
+
+TEST_CASE("PostgreSQL classifier keys off dedicated SQLSTATEs", "[SqlRetryPolicy]")
+{
+    auto const& classifier = PostgreSqlRetryOps();
+
+    CHECK(classifier.IsTransient(MakeError("40P01"))); // deadlock_detected
+    CHECK(classifier.IsTransient(MakeError("55P03"))); // lock_not_available
+    CHECK(classifier.IsTransient(MakeError("57P01"))); // admin_shutdown
+    CHECK(classifier.IsTransient(MakeError("57P03"))); // cannot_connect_now
+    CHECK(classifier.IsTransient(MakeError("53300"))); // too_many_connections
+
+    CHECK_FALSE(classifier.IsTransient(MakeError("23503"))); // foreign_key_violation
+    CHECK_FALSE(classifier.IsTransient(MakeError("42P01"))); // undefined_table
+
+    // A SQL Server native code carries no meaning for PostgreSQL: the dialects must not bleed.
+    CHECK_FALSE(classifier.IsTransient(MakeError("HY000", 1205)));
+}
+
+TEST_CASE("SQLite classifier keys off the driver message", "[SqlRetryPolicy]")
+{
+    auto const& classifier = SqliteRetryOps();
+
+    // The SQLite ODBC driver flattens busy/locked onto HY000, leaving only the message text.
+    CHECK(classifier.IsTransient(MakeError("HY000", 5, "database is locked")));
+    CHECK(classifier.IsTransient(MakeError("HY000", 6, "database table is locked")));
+    CHECK(classifier.IsTransient(MakeError("HY000", 5, "driver reported SQLITE_BUSY")));
+    CHECK(classifier.IsTransient(MakeError("HY000", 6, "driver reported SQLITE_LOCKED")));
+
+    CHECK_FALSE(classifier.IsTransient(MakeError("HY000", 1, "no such table: orders")));
+    CHECK_FALSE(classifier.IsTransient(MakeError("HY000", 19, "UNIQUE constraint failed: t.id")));
+}
+
+TEST_CASE("SqlRetryPolicy::For maps a server type to its dialect classifier", "[SqlRetryPolicy]")
+{
+    // Dispatch runs through SqlQueryFormatter::Get(), so this also pins down that the formatter
+    // for each supported DBMS really does return its own classifier.
+    CHECK(&SqlRetryPolicy::For(SqlServerType::SQLITE).Classifier() == &SqliteRetryOps());
+    CHECK(&SqlRetryPolicy::For(SqlServerType::MICROSOFT_SQL).Classifier() == &SqlServerRetryOps());
+    CHECK(&SqlRetryPolicy::For(SqlServerType::POSTGRESQL).Classifier() == &PostgreSqlRetryOps());
+
+    // A server type with no formatter of its own must still yield a usable policy.
+    CHECK(&SqlRetryPolicy::For(SqlServerType::UNKNOWN).Classifier() == &GenericRetryOps());
+    CHECK(&SqlRetryPolicy::For(SqlServerType::MYSQL).Classifier() == &GenericRetryOps());
+}
+
+TEST_CASE("SqlRetryPolicy::For carries the settings through", "[SqlRetryPolicy]")
+{
+    auto const policy = SqlRetryPolicy::For(SqlServerType::POSTGRESQL, SqlRetrySettings { .maxRetries = 9 });
+    CHECK(policy.Settings().maxRetries == 9);
+}
+
+// ================================================================================================
+// DelayFor — exponential backoff with a cap
+// ================================================================================================
+
+TEST_CASE("DelayFor grows exponentially and clamps at maxDelay", "[SqlRetryPolicy]")
+{
+    auto const policy = SqlRetryPolicy { SqlRetrySettings {
+        .maxRetries = 10, .initialDelay = 100ms, .backoffMultiplier = 2.0, .maxDelay = 5000ms } };
+
+    CHECK(policy.DelayFor(0) == 100ms);
+    CHECK(policy.DelayFor(1) == 200ms);
+    CHECK(policy.DelayFor(2) == 400ms);
+    CHECK(policy.DelayFor(3) == 800ms);
+
+    // 100 * 2^6 = 6400ms would overshoot the 5s cap.
+    CHECK(policy.DelayFor(6) == 5000ms);
+
+    // A retry index far past the cap must stay clamped rather than overflow.
+    CHECK(policy.DelayFor(1000) == 5000ms);
+}
+
+TEST_CASE("DelayFor handles a fractional multiplier", "[SqlRetryPolicy]")
+{
+    auto const policy = SqlRetryPolicy { SqlRetrySettings {
+        .maxRetries = 5, .initialDelay = 100ms, .backoffMultiplier = 1.5, .maxDelay = 10'000ms } };
+
+    CHECK(policy.DelayFor(1) == 150ms);
+    CHECK(policy.DelayFor(2) == 225ms);
+}
+
+TEST_CASE("DelayFor with a multiplier of one is a constant delay", "[SqlRetryPolicy]")
+{
+    auto const policy = SqlRetryPolicy { SqlRetrySettings {
+        .maxRetries = 5, .initialDelay = 250ms, .backoffMultiplier = 1.0, .maxDelay = 10'000ms } };
+
+    CHECK(policy.DelayFor(0) == 250ms);
+    CHECK(policy.DelayFor(4) == 250ms);
+}
+
+// ================================================================================================
+// Decide — the pure decision, including why it gave up
+// ================================================================================================
+
+TEST_CASE("Decide retries a transient error while budget remains", "[SqlRetryPolicy]")
+{
+    auto const policy = SqlRetryPolicy { SqlRetrySettings { .maxRetries = 3, .initialDelay = 100ms } };
+
+    auto const decision = policy.Decide(MakeError("40001"), SqlRetryState { .retriesSoFar = 0 });
+    CHECK(decision.action == SqlRetryAction::Retry);
+    CHECK(decision.reason == SqlRetryGiveUpReason::None);
+    CHECK(decision.delay == 100ms);
+    CHECK(static_cast<bool>(decision));
+}
+
+TEST_CASE("Decide reports why it gave up", "[SqlRetryPolicy]")
+{
+    auto const policy = SqlRetryPolicy { SqlRetrySettings { .maxRetries = 3 } };
+
+    SECTION("a permanent error is never retried, however much budget is left")
+    {
+        auto const decision = policy.Decide(MakeError("23505"), SqlRetryState { .retriesSoFar = 0 });
+        CHECK(decision.action == SqlRetryAction::GiveUp);
+        CHECK(decision.reason == SqlRetryGiveUpReason::NotTransient);
+        CHECK(decision.delay == 0ms);
+        CHECK_FALSE(static_cast<bool>(decision));
+    }
+
+    SECTION("a transient error stops once the retry budget is spent")
+    {
+        // retriesSoFar == maxRetries is the boundary — the budget is gone.
+        auto const decision = policy.Decide(MakeError("08S01"), SqlRetryState { .retriesSoFar = 3 });
+        CHECK(decision.action == SqlRetryAction::GiveUp);
+        CHECK(decision.reason == SqlRetryGiveUpReason::RetriesExhausted);
+    }
+}
+
+TEST_CASE("Decide honours a zero retry budget", "[SqlRetryPolicy]")
+{
+    auto const policy = SqlRetryPolicy { SqlRetrySettings { .maxRetries = 0 } };
+
+    auto const decision = policy.Decide(MakeError("08S01"), SqlRetryState {});
+    CHECK(decision.action == SqlRetryAction::GiveUp);
+    CHECK(decision.reason == SqlRetryGiveUpReason::RetriesExhausted);
+}
+
+TEST_CASE("Decide stops once the cumulative delay budget would be overrun", "[SqlRetryPolicy]")
+{
+    // The deadline half of the issue: retries must stop when the time budget is gone, even though
+    // the retry count still allows more.
+    auto const policy = SqlRetryPolicy { SqlRetrySettings { .maxRetries = 10,
+                                                            .initialDelay = 100ms,
+                                                            .backoffMultiplier = 2.0,
+                                                            .maxDelay = 10'000ms,
+                                                            .totalDelayBudget = 500ms } };
+
+    // 300ms spent + a 400ms next delay = 700ms > 500ms budget.
+    auto const overrun = policy.Decide(MakeError("40001"), SqlRetryState { .retriesSoFar = 2, .delaySoFar = 300ms });
+    CHECK(overrun.action == SqlRetryAction::GiveUp);
+    CHECK(overrun.reason == SqlRetryGiveUpReason::DelayBudgetExhausted);
+
+    // 100ms spent + a 200ms next delay = 300ms, still inside the budget.
+    auto const withinBudget = policy.Decide(MakeError("40001"), SqlRetryState { .retriesSoFar = 1, .delaySoFar = 100ms });
+    CHECK(withinBudget.action == SqlRetryAction::Retry);
+}
+
+TEST_CASE("A zero delay budget means no deadline", "[SqlRetryPolicy]")
+{
+    auto const policy =
+        SqlRetryPolicy { SqlRetrySettings { .maxRetries = 10, .initialDelay = 1000ms, .totalDelayBudget = 0ms } };
+
+    auto const decision = policy.Decide(MakeError("40001"), SqlRetryState { .retriesSoFar = 5, .delaySoFar = 60'000ms });
+    CHECK(decision.action == SqlRetryAction::Retry);
+}
+
+TEST_CASE("Decide consults the injected classifier, not a hardcoded predicate", "[SqlRetryPolicy]")
+{
+    auto const settings = SqlRetrySettings { .maxRetries = 3 };
+    auto const sqlServerPolicy = SqlRetryPolicy { settings, &SqlServerRetryOps() };
+    auto const postgresPolicy = SqlRetryPolicy { settings, &PostgreSqlRetryOps() };
+
+    // Native error 1205 is a SQL Server deadlock victim and nothing at all to PostgreSQL.
+    auto const deadlock = MakeError("HY000", 1205);
+    CHECK(sqlServerPolicy.Decide(deadlock, SqlRetryState {}).action == SqlRetryAction::Retry);
+    CHECK(postgresPolicy.Decide(deadlock, SqlRetryState {}).action == SqlRetryAction::GiveUp);
+}
+
+// ================================================================================================
+// Execute / TryExecute — the driver over Decide
+// ================================================================================================
+
+TEST_CASE("Execute retries a transient failure and returns the eventual result", "[SqlRetryPolicy]")
+{
+    auto sleeper = RecordingSleeper {};
+    auto const policy = SqlRetryPolicy {
+        SqlRetrySettings { .maxRetries = 3, .initialDelay = 100ms, .backoffMultiplier = 2.0, .maxDelay = 10'000ms },
+        &GenericRetryOps(),
+        &sleeper
+    };
+
+    auto operation = FlakyOperation { 2, MakeError("40001") };
+    auto const result = policy.Execute(std::ref(operation));
+
+    CHECK(result == 42);
+    CHECK(operation.calls == 3); // two failures plus the successful attempt
+    REQUIRE(sleeper.slept.size() == 2);
+    CHECK(sleeper.slept[0] == 100ms);
+    CHECK(sleeper.slept[1] == 200ms);
+}
+
+TEST_CASE("Execute does not retry a permanent failure", "[SqlRetryPolicy]")
+{
+    auto sleeper = RecordingSleeper {};
+    auto const policy = SqlRetryPolicy { FastSettings, &GenericRetryOps(), &sleeper };
+
+    auto operation = FlakyOperation { 1, MakeError("23505") };
+    CHECK_THROWS_AS(policy.Execute(std::ref(operation)), SqlException);
+
+    CHECK(operation.calls == 1);
+    CHECK(sleeper.slept.empty());
+}
+
+TEST_CASE("Execute rethrows the original error once the budget is spent", "[SqlRetryPolicy]")
+{
+    auto sleeper = RecordingSleeper {};
+    auto const policy = SqlRetryPolicy { FastSettings, &GenericRetryOps(), &sleeper };
+
+    // Always fails: 1 initial attempt + 3 retries, then the last SqlException escapes unwrapped.
+    auto operation = FlakyOperation { 99, MakeError("08S01", 0, "link failure") };
+    try
+    {
+        (void) policy.Execute(std::ref(operation));
+        FAIL("expected the exhausted policy to rethrow");
+    }
+    catch (SqlException const& e)
+    {
+        CHECK(e.info().sqlState == "08S01");
+        CHECK(e.info().message == "link failure");
+    }
+
+    CHECK(operation.calls == 4);
+    CHECK(sleeper.slept.size() == 3);
+}
+
+TEST_CASE("Execute lets a non-SQL exception through untouched", "[SqlRetryPolicy]")
+{
+    auto sleeper = RecordingSleeper {};
+    auto const policy = SqlRetryPolicy { FastSettings, &GenericRetryOps(), &sleeper };
+
+    CHECK_THROWS_AS(policy.Execute([] -> int { throw std::runtime_error { "not a SQL error" }; }), std::runtime_error);
+    CHECK(sleeper.slept.empty());
+}
+
+TEST_CASE("Execute supports a void-returning operation", "[SqlRetryPolicy]")
+{
+    auto sleeper = RecordingSleeper {};
+    auto const policy = SqlRetryPolicy { FastSettings, &GenericRetryOps(), &sleeper };
+
+    unsigned calls = 0;
+    policy.Execute([&calls] {
+        ++calls;
+        if (calls == 1)
+            throw SqlException { MakeError("40001") };
+    });
+
+    CHECK(calls == 2);
+}
+
+TEST_CASE("TryExecute reports a final failure as unexpected", "[SqlRetryPolicy]")
+{
+    auto sleeper = RecordingSleeper {};
+    auto const policy = SqlRetryPolicy { FastSettings, &GenericRetryOps(), &sleeper };
+
+    SECTION("success carries the value")
+    {
+        auto operation = FlakyOperation { 1, MakeError("40001") };
+        auto const result = policy.TryExecute(std::ref(operation));
+        REQUIRE(result.has_value());
+        CHECK(*result == 42);
+    }
+
+    SECTION("a permanent failure carries the error info")
+    {
+        auto operation = FlakyOperation { 1, MakeError("23505", 0, "duplicate key") };
+        auto const result = policy.TryExecute(std::ref(operation));
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().sqlState == "23505");
+        CHECK(result.error().message == "duplicate key");
+    }
+
+    SECTION("a void operation yields an empty expected")
+    {
+        auto const result = policy.TryExecute([] {});
+        CHECK(result.has_value());
+    }
+}
+
+TEST_CASE("The retry observer sees every retry before the wait", "[SqlRetryPolicy]")
+{
+    auto sleeper = RecordingSleeper {};
+    auto policy = SqlRetryPolicy {
+        SqlRetrySettings { .maxRetries = 3, .initialDelay = 100ms, .backoffMultiplier = 2.0, .maxDelay = 10'000ms },
+        &GenericRetryOps(),
+        &sleeper
+    };
+
+    auto seen = std::vector<SqlRetryAttempt> {};
+    policy.SetRetryObserver([&seen](SqlRetryAttempt const& attempt) { seen.emplace_back(attempt); });
+
+    auto operation = FlakyOperation { 2, MakeError("HYT00", 0, "timeout expired") };
+    (void) policy.Execute(std::ref(operation));
+
+    REQUIRE(seen.size() == 2);
+    CHECK(seen[0].retryNumber == 1);
+    CHECK(seen[0].maxRetries == 3);
+    CHECK(seen[0].delay == 100ms);
+    CHECK(seen[0].error.sqlState == "HYT00");
+    CHECK(seen[1].retryNumber == 2);
+    CHECK(seen[1].delay == 200ms);
+}
+
+TEST_CASE("A default-constructed policy is usable", "[SqlRetryPolicy]")
+{
+    auto const policy = SqlRetryPolicy {};
+
+    CHECK(policy.Settings().maxRetries == 3);
+    CHECK(policy.Settings().initialDelay == 500ms);
+    CHECK(policy.Settings().backoffMultiplier == 2.0);
+    CHECK(policy.Settings().maxDelay == 30'000ms);
+    CHECK(policy.Settings().totalDelayBudget == 0ms);
+    CHECK(&policy.Classifier() == &GenericRetryOps());
+
+    // No sleeping happens on the success path, so this stays fast despite the real sleeper.
+    CHECK(policy.Execute([] { return 7; }) == 7);
+}
+
+// ================================================================================================
+// The SqlConnection overload, exercised against whichever server the suite is pointed at. This is
+// the one part of the policy that cannot be checked without a database: it asserts that a live
+// connection resolves to the classifier for its own dialect.
+// ================================================================================================
+
+TEST_CASE_METHOD(SqlTestFixture, "SqlRetryPolicy::For(connection) picks the live server's classifier",
+                 "[SqlRetryPolicy]")
+{
+    auto stmt = SqlStatement {};
+    auto const& connection = stmt.Connection();
+
+    auto const policy = SqlRetryPolicy::For(connection, SqlRetrySettings { .maxRetries = 5 });
+
+    CHECK(policy.Settings().maxRetries == 5);
+    CHECK(&policy.Classifier() == &SqlRetryPolicy::For(connection.ServerType()).Classifier());
+
+    // Whatever the dialect, the shared ODBC classes must be retryable and a constraint violation
+    // must not be — the invariant every backend has to satisfy.
+    CHECK(policy.Classifier().IsTransient(MakeError("08S01")));
+    CHECK_FALSE(policy.Classifier().IsTransient(MakeError("23505")));
+}


### PR DESCRIPTION
Closes #554

## What & why

Transient database failures — a dropped connection, a deadlock victim, a serialization failure, a lock timeout — are retryable; a unique-constraint violation or a syntax error is not. Which SQLSTATE means which is **dialect-specific**: `40001` is a serialization failure on PostgreSQL, while SQL Server signals a deadlock victim through native code `1205` under a generic `HY000`, and SQLite reports `SQLITE_BUSY` in the driver's message text.

This adds `SqlRetryPolicy` with a per-DBMS classifier, so callers express intent (*retry what is worth retrying*) rather than hard-coding SQLSTATE tables at every call site.

## Design

The policy is deliberately free of I/O and of any clock: an error is a value, and the sleeper is injected. That is what makes the classification testable at all — provoking a genuine Azure SQL throttle or a PostgreSQL serialization failure on demand is not something a unit test can arrange. Every test case therefore runs as a pure function of its inputs, with no database and no real waiting.

## Testing

24 test cases / 129 assertions covering each dialect's classifier (transient *and* non-transient SQLSTATEs, so a classifier cannot pass by saying "yes" to everything), the backoff schedule, retry exhaustion, and the `Execute` control flow.

| | Result |
|---|---|
| `clang-debug` (PEDANTIC + ASan + UBSan) | full suite green |
| Databases | `sqlite3`, `mssql2022` (Docker), `postgres` (Docker 16.4) — 1426 cases each |
| clang-tidy | clean (two findings fixed at the source, no `NOLINT`) |
| clang-format | applied |

The two clang-tidy fixes are their own commit: `MakeError`'s three parameters tripped `bugprone-easily-swappable-parameters` (the project sets `MinimumLength: 3`), so it now takes two and the cases needing a driver message spell out the aggregate with designated initializers; and `FlakyOperation`'s public `calls` next to private state tripped `cppcoreguidelines-non-private-member-variables-in-classes`, so it is private with a `Calls()` accessor.

**Compilers: Clang only, locally** — `gcc-release` is Linux-gated and unavailable on this macOS host; CI's GCC legs cover it.

- **Performance impact:** none unless a retry is requested; the policy is opt-in and adds no work to the non-retrying path.
- **Risk:** low. Additive — no existing call path routes through the policy yet.