### PR TITLE
SqlMigration: diff registered migrations against the live schema, and generate migrations from it

### DIFF
--- a/src/Lightweight/CMakeLists.txt
+++ b/src/Lightweight/CMakeLists.txt
@@ -197,6 +197,8 @@ target_compile_features(LightweightTools PUBLIC cxx_std_23)
 target_sources(LightweightTools PRIVATE
     Tools/CxxModelPrinter.cpp
     Tools/CxxModelPrinter.hpp
+    Tools/MigrationSourcePrinter.cpp
+    Tools/MigrationSourcePrinter.hpp
 )
 target_link_libraries(LightweightTools PUBLIC Lightweight)
 

--- a/src/Lightweight/Lightweight.cppm
+++ b/src/Lightweight/Lightweight.cppm
@@ -27,6 +27,7 @@ module;
 #include "SqlScopedLock.hpp"
 #include "ThreadSafeQueue.hpp"
 #include "Tools/CxxModelPrinter.hpp"
+#include "Tools/MigrationSourcePrinter.hpp"
 #include "Zip/ZipArchive.hpp"
 #include "Zip/ZipError.hpp"
 

--- a/src/Lightweight/SqlMigration.cpp
+++ b/src/Lightweight/SqlMigration.cpp
@@ -3056,8 +3056,12 @@ namespace
     /// `nvarchar (50)` must compare equal.
     [[nodiscard]] bool RenderedTypesEqual(std::string_view lhs, std::string_view rhs) noexcept
     {
-        auto const significant = [](char c) { return !std::isspace(static_cast<unsigned char>(c)); };
-        auto const fold = [](char c) { return static_cast<char>(std::toupper(static_cast<unsigned char>(c))); };
+        auto const significant = [](char c) {
+            return !std::isspace(static_cast<unsigned char>(c));
+        };
+        auto const fold = [](char c) {
+            return static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+        };
         return std::ranges::equal(lhs | std::views::filter(significant) | std::views::transform(fold),
                                   rhs | std::views::filter(significant) | std::views::transform(fold));
     }

--- a/src/Lightweight/SqlMigration.cpp
+++ b/src/Lightweight/SqlMigration.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <chrono>
 #include <format>
 #include <limits>
@@ -3044,6 +3045,204 @@ MigrationManager::UnicodeUpgradeResult MigrationManager::UnicodeUpgradeTables(bo
         ExecuteGenericUpgrade(stmt, formatter, pendingPerTable);
     transaction.Commit();
     return result;
+}
+
+namespace
+{
+    /// @brief Whitespace- and case-insensitive comparison of two rendered column types.
+    ///
+    /// The two sides come from different producers — the formatter renders the intended
+    /// type, the introspection layer round-trips the live one — so `NVARCHAR(50)` and
+    /// `nvarchar (50)` must compare equal.
+    [[nodiscard]] bool RenderedTypesEqual(std::string_view lhs, std::string_view rhs) noexcept
+    {
+        auto const significant = [](char c) { return !std::isspace(static_cast<unsigned char>(c)); };
+        auto const fold = [](char c) { return static_cast<char>(std::toupper(static_cast<unsigned char>(c))); };
+        return std::ranges::equal(lhs | std::views::filter(significant) | std::views::transform(fold),
+                                  rhs | std::views::filter(significant) | std::views::transform(fold));
+    }
+
+    /// @brief Whether a folded column declaration implies NOT NULL.
+    ///
+    /// A primary key is NOT NULL whether or not the declaration says `required`, so
+    /// treating the two independently would report phantom nullability drift on every
+    /// primary key.
+    [[nodiscard]] bool DeclaredNotNull(SqlColumnDeclaration const& column) noexcept
+    {
+        return column.required || column.primaryKey != SqlPrimaryKeyType::NONE;
+    }
+
+    /// @brief Computes the column-level delta for one table present on both sides.
+    ///
+    /// @param key Fully-qualified name of the table being compared.
+    /// @param folded The table as the registered migrations declare it.
+    /// @param live The table as the database currently has it.
+    /// @param formatter Formatter used to render both sides' types for comparison.
+    /// @return The delta, or `nullopt` when the table matches.
+    [[nodiscard]] std::optional<MigrationManager::SchemaDiffTable> ComputeTableDiff(
+        SqlSchema::FullyQualifiedTableName const& key,
+        MigrationManager::PlanFoldingResult::TableState const& folded,
+        SqlSchema::Table const& live,
+        SqlQueryFormatter const& formatter)
+    {
+        std::map<std::string, SqlSchema::Column const*> liveColumns;
+        for (auto const& c: live.columns)
+            liveColumns.emplace(c.name, &c);
+
+        MigrationManager::SchemaDiffTable diff;
+        diff.schemaName = key.schema;
+        diff.tableName = key.table;
+
+        std::set<std::string> intendedNames;
+        for (auto const& intended: folded.columns)
+        {
+            intendedNames.insert(intended.name);
+            auto const liveIt = liveColumns.find(intended.name);
+            if (liveIt == liveColumns.end())
+            {
+                diff.addedColumns.push_back(intended);
+                continue;
+            }
+
+            auto const& liveColumn = *liveIt->second;
+            bool const typeDrifted =
+                !RenderedTypesEqual(formatter.ColumnType(intended.type), formatter.ColumnType(liveColumn.type));
+            // Primary keys are NOT NULL by construction on every supported backend, so a
+            // nullability comparison there only ever produces noise.
+            bool const nullabilityDrifted = intended.primaryKey == SqlPrimaryKeyType::NONE && !liveColumn.isPrimaryKey
+                                            && DeclaredNotNull(intended) == liveColumn.isNullable;
+            if (!typeDrifted && !nullabilityDrifted)
+                continue;
+
+            diff.changedColumns.push_back(MigrationManager::SchemaDiffColumnChange {
+                .column = intended.name,
+                .intendedType = intended.type,
+                .liveType = liveColumn.type,
+                .intendedNullable = !DeclaredNotNull(intended),
+                .liveNullable = liveColumn.isNullable,
+            });
+        }
+
+        for (auto const& liveColumn: live.columns)
+            if (!intendedNames.contains(liveColumn.name))
+                diff.droppedColumns.push_back(liveColumn.name);
+
+        if (diff.addedColumns.empty() && diff.droppedColumns.empty() && diff.changedColumns.empty())
+            return std::nullopt;
+        return diff;
+    }
+} // namespace
+
+MigrationManager::SchemaDiffResult MigrationManager::DiffAgainstLiveSchema(
+    std::optional<MigrationTimestamp> upToInclusive) const
+{
+    SchemaDiffResult result;
+
+    auto& dm = GetDataMapper();
+    auto const& formatter = dm.Connection().QueryFormatter();
+    auto const fold = FoldRegisteredMigrations(formatter, upToInclusive);
+
+    auto stmt = SqlStatement { dm.Connection() };
+    auto const liveTables = SqlSchema::ReadAllTables(stmt, std::string {}, std::string {});
+
+    std::map<std::string, SqlSchema::Table const*> liveByName;
+    for (auto const& t: liveTables)
+        liveByName.emplace(t.name, &t);
+
+    // Tables Lightweight owns itself are neither migration-declared nor user-owned, so
+    // they must not surface as "unmanaged". Mirrors the exclusion `HardReset` applies.
+    auto const bookkeepingTableNames = formatter.AdvisoryLockOps().BookkeepingTableNames();
+    std::set<std::string_view> infrastructureNames { bookkeepingTableNames.begin(), bookkeepingTableNames.end() };
+    infrastructureNames.insert(SchemaMigration::TableName);
+
+    // Walk in creation order so a generated plan replays CREATE TABLE in an order where
+    // foreign keys already have their target.
+    for (auto const& key: fold.creationOrder)
+    {
+        auto const& state = fold.tables.at(key);
+        auto const liveIt = liveByName.find(key.table);
+        if (liveIt == liveByName.end())
+        {
+            result.missingTables.push_back(SqlCreateTablePlan {
+                .schemaName = key.schema,
+                .tableName = key.table,
+                .columns = state.columns,
+                .foreignKeys = state.compositeForeignKeys,
+                .ifNotExists = state.ifNotExists,
+            });
+            continue;
+        }
+
+        if (auto tableDiff = ComputeTableDiff(key, state, *liveIt->second, formatter))
+            result.alteredTables.push_back(std::move(*tableDiff));
+    }
+
+    std::set<std::string> intendedNames;
+    for (auto const& key: fold.creationOrder)
+        intendedNames.insert(key.table);
+
+    for (auto const& live: liveTables)
+        if (!intendedNames.contains(live.name) && !infrastructureNames.contains(live.name))
+            result.unmanagedTables.push_back(SqlSchema::FullyQualifiedTableName {
+                .catalog = {},
+                .schema = live.schema,
+                .table = live.name,
+            });
+
+    // An index is missing when the table that carries it has no index of that name. A
+    // table the diff is about to create carries its indexes with it, so those are skipped.
+    for (auto const& index: fold.indexes)
+    {
+        auto const liveIt = liveByName.find(index.tableName);
+        if (liveIt == liveByName.end())
+            continue;
+        auto const& liveIndexes = liveIt->second->indexes;
+        if (std::ranges::none_of(liveIndexes, [&](auto const& live) { return live.name == index.indexName; }))
+            result.missingIndexes.push_back(index);
+    }
+
+    return result;
+}
+
+std::vector<SqlMigrationPlanElement> MakeSchemaDiffPlan(MigrationManager::SchemaDiffResult const& diff)
+{
+    std::vector<SqlMigrationPlanElement> plan;
+    plan.reserve(diff.missingTables.size() + diff.alteredTables.size() + diff.missingIndexes.size());
+
+    for (auto const& table: diff.missingTables)
+        plan.emplace_back(table);
+
+    for (auto const& table: diff.alteredTables)
+    {
+        SqlAlterTablePlan alter {
+            .schemaName = table.schemaName,
+            .tableName = table.tableName,
+            .commands = {},
+        };
+        // Add before alter before drop: a column the same migration both adds and then
+        // reshapes cannot exist, and dropping last keeps the table readable for as long
+        // as possible if an operator stops the migration part-way.
+        for (auto const& column: table.addedColumns)
+            alter.commands.emplace_back(SqlAlterTableCommands::AddColumn {
+                .columnName = column.name,
+                .columnType = column.type,
+                .nullable = DeclaredNotNull(column) ? SqlNullable::NotNull : SqlNullable::Null,
+            });
+        for (auto const& change: table.changedColumns)
+            alter.commands.emplace_back(SqlAlterTableCommands::AlterColumn {
+                .columnName = change.column,
+                .columnType = change.intendedType,
+                .nullable = change.intendedNullable ? SqlNullable::Null : SqlNullable::NotNull,
+            });
+        for (auto const& column: table.droppedColumns)
+            alter.commands.emplace_back(SqlAlterTableCommands::DropColumn { .columnName = column });
+        plan.emplace_back(std::move(alter));
+    }
+
+    for (auto const& index: diff.missingIndexes)
+        plan.emplace_back(index);
+
+    return plan;
 }
 
 MigrationStatus MigrationManager::GetMigrationStatus() const

--- a/src/Lightweight/SqlMigration.hpp
+++ b/src/Lightweight/SqlMigration.hpp
@@ -611,6 +611,97 @@ namespace SqlMigration
         /// @param dryRun When true, returns the would-be diff without writing anything.
         [[nodiscard]] LIGHTWEIGHT_API UnicodeUpgradeResult UnicodeUpgradeTables(bool dryRun = false);
 
+        /// @brief One column whose live definition drifted from what the migrations declare.
+        struct SchemaDiffColumnChange
+        {
+            /// Name of the drifted column.
+            std::string column;
+            /// Type the folded migrations declare for this column.
+            SqlColumnTypeDefinition intendedType;
+            /// Type the column currently has in the live database.
+            SqlColumnTypeDefinition liveType;
+            /// Whether the folded migrations declare the column nullable.
+            bool intendedNullable = true;
+            /// Whether the live column is nullable.
+            bool liveNullable = true;
+        };
+
+        /// @brief Per-table delta for a table present both in the folded plan and live.
+        struct SchemaDiffTable
+        {
+            /// Schema the table lives in (empty for engines without schemas, e.g. SQLite).
+            std::string schemaName;
+            /// Name of the table the delta applies to.
+            std::string tableName;
+            /// Columns the migrations declare that the live table does not have.
+            std::vector<SqlColumnDeclaration> addedColumns;
+            /// Columns the live table has that the migrations no longer declare.
+            std::vector<std::string> droppedColumns;
+            /// Columns present on both sides whose rendered type or nullability drifted.
+            std::vector<SchemaDiffColumnChange> changedColumns;
+        };
+
+        /// @brief Result of a `DiffAgainstLiveSchema` call — what separates the schema the
+        /// registered migrations *intend* from the schema the database actually *has*.
+        ///
+        /// Every member owns its strings, so the result is freely copyable. To obtain the
+        /// same delta as replayable migration plan elements, pass it to
+        /// `MakeSchemaDiffPlan` — the plan element types hold `string_view`s, so they are
+        /// built on demand rather than stored here.
+        struct SchemaDiffResult
+        {
+            /// Tables the migrations declare that are absent from the live database, as
+            /// ready-to-replay CREATE TABLE plans in creation order (so foreign keys
+            /// resolve when the plan is replayed front to back).
+            std::vector<SqlCreateTablePlan> missingTables;
+
+            /// Tables the live database has that no registered migration declares. Reported
+            /// for visibility only — never dropped and never part of the generated plan,
+            /// because they are typically user-owned. Same stance `HardReset` takes with
+            /// `HardResetResult::preservedTables`.
+            std::vector<SqlSchema::FullyQualifiedTableName> unmanagedTables;
+
+            /// Per-table column-level deltas for tables present on both sides.
+            std::vector<SchemaDiffTable> alteredTables;
+
+            /// Indexes the migrations declare that the live database does not have.
+            std::vector<SqlCreateIndexPlan> missingIndexes;
+
+            /// @brief True when the live schema already matches what the migrations intend.
+            /// @return Whether there is anything to generate. `unmanagedTables` alone does
+            ///         not make a diff non-empty — nothing is generated for them.
+            [[nodiscard]] bool Empty() const noexcept
+            {
+                return missingTables.empty() && alteredTables.empty() && missingIndexes.empty();
+            }
+        };
+
+        /// @brief Diffs the schema the registered migrations intend against the live database.
+        ///
+        /// Folds every registered migration via `FoldRegisteredMigrations` (a pure plan-walk)
+        /// and compares the result against `SqlSchema::ReadAllTables`. This is the
+        /// autogenerate primitive: `dbtool diff` prints the result, `dbtool generate` emits
+        /// it as a timestamped migration source file.
+        ///
+        /// Read-only — issues only schema-introspection queries and never writes.
+        ///
+        /// Column types are compared *as the active dialect renders them*
+        /// (`SqlQueryFormatter::ColumnType`), not as raw variant alternatives. Two
+        /// alternatives a backend spells identically are therefore not reported as drift,
+        /// which is what keeps the diff quiet across backends whose introspection cannot
+        /// distinguish them (`DateTime` vs `Timestamp` on SQLite, say).
+        ///
+        /// Bookkeeping tables Lightweight owns itself (`schema_migrations` and the SQLite
+        /// advisory-lock table) are excluded from `unmanagedTables`: they belong to no
+        /// registered migration but are not user-owned either.
+        ///
+        /// @param upToInclusive If set, fold only migrations with `timestamp <= upToInclusive`,
+        ///                      so the diff answers "what does the live DB still need to
+        ///                      reach that point" rather than "to reach HEAD".
+        /// @return The delta. Empty when the live schema already matches the intent.
+        [[nodiscard]] LIGHTWEIGHT_API SchemaDiffResult DiffAgainstLiveSchema(
+            std::optional<MigrationTimestamp> upToInclusive = std::nullopt) const;
+
         /// @brief Re-stamps `schema_migrations.checksum` rows that have drifted.
         ///
         /// Applied migrations whose stored checksum no longer matches the current
@@ -777,6 +868,23 @@ namespace SqlMigration
 
         LogSink _logSink; ///< Optional status-message sink. Empty by default.
     };
+
+    /// @brief Renders a schema diff as replayable migration plan elements.
+    ///
+    /// Emission order matches replay order: `CREATE TABLE` for every missing table (in the
+    /// creation order the fold established, so foreign keys resolve), then one `ALTER TABLE`
+    /// per altered table carrying its add/alter/drop column commands, then `CREATE INDEX`
+    /// for every missing index. `SchemaDiffResult::unmanagedTables` contributes nothing —
+    /// tables the migrations do not own are never dropped by an autogenerated migration.
+    ///
+    /// @warning The plan element types hold `std::string_view`s. The returned elements
+    ///          borrow from @p diff, which must outlive them and must not be modified
+    ///          while they are in use.
+    ///
+    /// @param diff The diff to render, typically from `MigrationManager::DiffAgainstLiveSchema`.
+    /// @return The plan elements, borrowing their names from @p diff.
+    [[nodiscard]] LIGHTWEIGHT_API std::vector<SqlMigrationPlanElement> MakeSchemaDiffPlan(
+        MigrationManager::SchemaDiffResult const& diff);
 
 /// Requires the user to call LIGHTWEIGHT_MIGRATION_PLUGIN() in exactly one CPP file of the migration plugin.
 ///

--- a/src/Lightweight/SqlMigration.hpp
+++ b/src/Lightweight/SqlMigration.hpp
@@ -699,8 +699,8 @@ namespace SqlMigration
         ///                      so the diff answers "what does the live DB still need to
         ///                      reach that point" rather than "to reach HEAD".
         /// @return The delta. Empty when the live schema already matches the intent.
-        [[nodiscard]] LIGHTWEIGHT_API SchemaDiffResult DiffAgainstLiveSchema(
-            std::optional<MigrationTimestamp> upToInclusive = std::nullopt) const;
+        [[nodiscard]] LIGHTWEIGHT_API SchemaDiffResult
+        DiffAgainstLiveSchema(std::optional<MigrationTimestamp> upToInclusive = std::nullopt) const;
 
         /// @brief Re-stamps `schema_migrations.checksum` rows that have drifted.
         ///

--- a/src/Lightweight/Tools/MigrationSourcePrinter.cpp
+++ b/src/Lightweight/Tools/MigrationSourcePrinter.cpp
@@ -322,11 +322,18 @@ namespace
                 else if constexpr (std::same_as<T, SqlAlterTablePlan>)
                     return PrintAlterTable(e);
                 else if constexpr (std::same_as<T, SqlDropTablePlan>)
-                    return std::format("    plan.{}({});\n",
-                                       e.cascade    ? "DropTableCascade"
-                                       : e.ifExists ? "DropTableIfExists"
-                                                    : "DropTable",
-                                       QuoteCppString(e.tableName));
+                {
+                    // An if-chain rather than nested conditionals, which clang-tidy rejects as
+                    // readability-avoid-nested-conditional-operator.
+                    auto const* const method = [&e] {
+                        if (e.cascade)
+                            return "DropTableCascade";
+                        if (e.ifExists)
+                            return "DropTableIfExists";
+                        return "DropTable";
+                    }();
+                    return std::format("    plan.{}({});\n", method, QuoteCppString(e.tableName));
+                }
                 else if constexpr (std::same_as<T, SqlCreateIndexPlan>)
                     return std::format("    plan.{}({}, {}, {});\n",
                                        e.unique ? "CreateUniqueIndex" : "CreateIndex",

--- a/src/Lightweight/Tools/MigrationSourcePrinter.cpp
+++ b/src/Lightweight/Tools/MigrationSourcePrinter.cpp
@@ -23,12 +23,24 @@ namespace
         {
             switch (c)
             {
-                case '"': out.append(R"(\")"); break;
-                case '\\': out.append(R"(\\)"); break;
-                case '\n': out.append(R"(\n)"); break;
-                case '\r': out.append(R"(\r)"); break;
-                case '\t': out.append(R"(\t)"); break;
-                default: out.push_back(c); break;
+                case '"':
+                    out.append(R"(\")");
+                    break;
+                case '\\':
+                    out.append(R"(\\)");
+                    break;
+                case '\n':
+                    out.append(R"(\n)");
+                    break;
+                case '\r':
+                    out.append(R"(\r)");
+                    break;
+                case '\t':
+                    out.append(R"(\t)");
+                    break;
+                default:
+                    out.push_back(c);
+                    break;
             }
         }
         out.push_back('"');
@@ -98,9 +110,8 @@ namespace
                               || std::same_as<T, Varchar>)
                     return std::format("SqlColumnTypeDefinitions::{} {{ {} }}", ColumnTypeName<T>(), t.size);
                 else if constexpr (std::same_as<T, Decimal>)
-                    return std::format("SqlColumnTypeDefinitions::Decimal {{ .precision = {}, .scale = {} }}",
-                                       t.precision,
-                                       t.scale);
+                    return std::format(
+                        "SqlColumnTypeDefinitions::Decimal {{ .precision = {}, .scale = {} }}", t.precision, t.scale);
                 else if constexpr (std::same_as<T, Real>)
                     return std::format("SqlColumnTypeDefinitions::Real {{ .precision = {} }}", t.precision);
                 else
@@ -133,8 +144,7 @@ namespace
     /// everything the shorthands have no parameter for does.
     [[nodiscard]] bool IsExpressibleAsShorthand(SqlColumnDeclaration const& column) noexcept
     {
-        return column.defaultValue.empty() && column.primaryKeyIndex == 0
-               && column.primaryKey != SqlPrimaryKeyType::GUID;
+        return column.defaultValue.empty() && column.primaryKeyIndex == 0 && column.primaryKey != SqlPrimaryKeyType::GUID;
     }
 
     /// @brief Renders a foreign-key reference as its aggregate initializer.
@@ -150,10 +160,14 @@ namespace
     {
         switch (type)
         {
-            case SqlPrimaryKeyType::NONE: return "SqlPrimaryKeyType::NONE";
-            case SqlPrimaryKeyType::MANUAL: return "SqlPrimaryKeyType::MANUAL";
-            case SqlPrimaryKeyType::AUTO_INCREMENT: return "SqlPrimaryKeyType::AUTO_INCREMENT";
-            case SqlPrimaryKeyType::GUID: return "SqlPrimaryKeyType::GUID";
+            case SqlPrimaryKeyType::NONE:
+                return "SqlPrimaryKeyType::NONE";
+            case SqlPrimaryKeyType::MANUAL:
+                return "SqlPrimaryKeyType::MANUAL";
+            case SqlPrimaryKeyType::AUTO_INCREMENT:
+                return "SqlPrimaryKeyType::AUTO_INCREMENT";
+            case SqlPrimaryKeyType::GUID:
+                return "SqlPrimaryKeyType::GUID";
         }
         return "SqlPrimaryKeyType::NONE";
     }
@@ -274,8 +288,9 @@ namespace
                 else if constexpr (std::same_as<T, Cmd::DropIndexIfExists>)
                     return std::format(".DropIndexIfExists({})", QuoteCppString(c.columnName));
                 else if constexpr (std::same_as<T, Cmd::AddForeignKey>)
-                    return std::format(
-                        ".AddForeignKey({}, {})", QuoteCppString(c.columnName), PrintForeignKeyReference(c.referencedColumn));
+                    return std::format(".AddForeignKey({}, {})",
+                                       QuoteCppString(c.columnName),
+                                       PrintForeignKeyReference(c.referencedColumn));
                 else if constexpr (std::same_as<T, Cmd::AddCompositeForeignKey>)
                     return std::format(".AddCompositeForeignKey({}, {}, {})",
                                        PrintStringList(c.columns),
@@ -308,9 +323,9 @@ namespace
                     return PrintAlterTable(e);
                 else if constexpr (std::same_as<T, SqlDropTablePlan>)
                     return std::format("    plan.{}({});\n",
-                                       e.cascade      ? "DropTableCascade"
-                                       : e.ifExists   ? "DropTableIfExists"
-                                                      : "DropTable",
+                                       e.cascade    ? "DropTableCascade"
+                                       : e.ifExists ? "DropTableIfExists"
+                                                    : "DropTable",
                                        QuoteCppString(e.tableName));
                 else if constexpr (std::same_as<T, SqlCreateIndexPlan>)
                     return std::format("    plan.{}({}, {}, {});\n",

--- a/src/Lightweight/Tools/MigrationSourcePrinter.cpp
+++ b/src/Lightweight/Tools/MigrationSourcePrinter.cpp
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "MigrationSourcePrinter.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <format>
+#include <ranges>
+#include <variant>
+
+namespace Lightweight::Tools
+{
+
+namespace
+{
+    /// @brief Renders @p value as a C++ string literal, escaping what a literal cannot carry raw.
+    [[nodiscard]] std::string QuoteCppString(std::string_view value)
+    {
+        std::string out;
+        out.reserve(value.size() + 2);
+        out.push_back('"');
+        for (char const c: value)
+        {
+            switch (c)
+            {
+                case '"': out.append(R"(\")"); break;
+                case '\\': out.append(R"(\\)"); break;
+                case '\n': out.append(R"(\n)"); break;
+                case '\r': out.append(R"(\r)"); break;
+                case '\t': out.append(R"(\t)"); break;
+                default: out.push_back(c); break;
+            }
+        }
+        out.push_back('"');
+        return out;
+    }
+
+    /// @brief The `SqlColumnTypeDefinitions` alternative name that spells @p T in source.
+    ///
+    /// Kept as one explicit mapping rather than derived from `typeid`, whose spelling is
+    /// compiler-dependent and would make the emitted source differ between toolchains.
+    ///
+    /// @tparam T One alternative of `SqlColumnTypeDefinition`.
+    /// @return The unqualified type name.
+    template <typename T>
+    [[nodiscard]] consteval std::string_view ColumnTypeName()
+    {
+        using namespace SqlColumnTypeDefinitions;
+        if constexpr (std::same_as<T, Bigint>)
+            return "Bigint";
+        else if constexpr (std::same_as<T, Binary>)
+            return "Binary";
+        else if constexpr (std::same_as<T, Bool>)
+            return "Bool";
+        else if constexpr (std::same_as<T, Char>)
+            return "Char";
+        else if constexpr (std::same_as<T, Date>)
+            return "Date";
+        else if constexpr (std::same_as<T, DateTime>)
+            return "DateTime";
+        else if constexpr (std::same_as<T, Decimal>)
+            return "Decimal";
+        else if constexpr (std::same_as<T, Guid>)
+            return "Guid";
+        else if constexpr (std::same_as<T, Integer>)
+            return "Integer";
+        else if constexpr (std::same_as<T, NChar>)
+            return "NChar";
+        else if constexpr (std::same_as<T, NVarchar>)
+            return "NVarchar";
+        else if constexpr (std::same_as<T, Real>)
+            return "Real";
+        else if constexpr (std::same_as<T, Smallint>)
+            return "Smallint";
+        else if constexpr (std::same_as<T, Text>)
+            return "Text";
+        else if constexpr (std::same_as<T, Time>)
+            return "Time";
+        else if constexpr (std::same_as<T, Timestamp>)
+            return "Timestamp";
+        else if constexpr (std::same_as<T, Tinyint>)
+            return "Tinyint";
+        else if constexpr (std::same_as<T, VarBinary>)
+            return "VarBinary";
+        else
+            return "Varchar";
+    }
+
+    /// @brief Renders a column type as the `SqlColumnTypeDefinitions::X { ... }` expression
+    /// that reconstructs it.
+    [[nodiscard]] std::string PrintColumnType(SqlColumnTypeDefinition const& type)
+    {
+        using namespace SqlColumnTypeDefinitions;
+        return std::visit(
+            []<typename T>(T const& t) -> std::string {
+                if constexpr (std::same_as<T, Binary> || std::same_as<T, Char> || std::same_as<T, NChar>
+                              || std::same_as<T, NVarchar> || std::same_as<T, Text> || std::same_as<T, VarBinary>
+                              || std::same_as<T, Varchar>)
+                    return std::format("SqlColumnTypeDefinitions::{} {{ {} }}", ColumnTypeName<T>(), t.size);
+                else if constexpr (std::same_as<T, Decimal>)
+                    return std::format("SqlColumnTypeDefinitions::Decimal {{ .precision = {}, .scale = {} }}",
+                                       t.precision,
+                                       t.scale);
+                else if constexpr (std::same_as<T, Real>)
+                    return std::format("SqlColumnTypeDefinitions::Real {{ .precision = {} }}", t.precision);
+                else
+                    return std::format("SqlColumnTypeDefinitions::{} {{}}", ColumnTypeName<T>());
+            },
+            type);
+    }
+
+    /// @brief Renders a nullability flag as its enumerator spelling.
+    [[nodiscard]] std::string_view PrintNullable(SqlNullable nullable) noexcept
+    {
+        return nullable == SqlNullable::NotNull ? "SqlNullable::NotNull" : "SqlNullable::Null";
+    }
+
+    /// @brief Renders a `std::vector<std::string>` as a braced initializer list of literals.
+    [[nodiscard]] std::string PrintStringList(std::span<std::string const> values)
+    {
+        // Index loop rather than `std::views::enumerate`: the latter does not compile over
+        // `std::span` on every libc++ version this project builds against (see PluginDiscovery.cpp).
+        std::string out = "{ ";
+        for (auto const index: std::views::iota(std::size_t { 0 }, values.size()))
+            out += std::format("{}{}", index == 0 ? "" : ", ", QuoteCppString(values[index]));
+        out += " }";
+        return out;
+    }
+
+    /// @brief Whether the fluent `CreateTable` shorthands can express @p column losslessly.
+    ///
+    /// `Unique()` / `Index()` are trailing modifiers and so do not disqualify a column;
+    /// everything the shorthands have no parameter for does.
+    [[nodiscard]] bool IsExpressibleAsShorthand(SqlColumnDeclaration const& column) noexcept
+    {
+        return column.defaultValue.empty() && column.primaryKeyIndex == 0
+               && column.primaryKey != SqlPrimaryKeyType::GUID;
+    }
+
+    /// @brief Renders a foreign-key reference as its aggregate initializer.
+    [[nodiscard]] std::string PrintForeignKeyReference(SqlForeignKeyReferenceDefinition const& reference)
+    {
+        return std::format("SqlForeignKeyReferenceDefinition {{ .tableName = {}, .columnName = {} }}",
+                           QuoteCppString(reference.tableName),
+                           QuoteCppString(reference.columnName));
+    }
+
+    /// @brief Renders the primary-key kind as its enumerator spelling.
+    [[nodiscard]] std::string_view PrintPrimaryKeyType(SqlPrimaryKeyType type) noexcept
+    {
+        switch (type)
+        {
+            case SqlPrimaryKeyType::NONE: return "SqlPrimaryKeyType::NONE";
+            case SqlPrimaryKeyType::MANUAL: return "SqlPrimaryKeyType::MANUAL";
+            case SqlPrimaryKeyType::AUTO_INCREMENT: return "SqlPrimaryKeyType::AUTO_INCREMENT";
+            case SqlPrimaryKeyType::GUID: return "SqlPrimaryKeyType::GUID";
+        }
+        return "SqlPrimaryKeyType::NONE";
+    }
+
+    /// @brief Renders one column as the full `SqlColumnDeclaration` aggregate.
+    ///
+    /// The lossless fallback for columns the fluent shorthands cannot spell.
+    [[nodiscard]] std::string PrintColumnDeclaration(SqlColumnDeclaration const& column)
+    {
+        std::string out = std::format("SqlColumnDeclaration {{ .name = {}, .type = {}, .primaryKey = {}",
+                                      QuoteCppString(column.name),
+                                      PrintColumnType(column.type),
+                                      PrintPrimaryKeyType(column.primaryKey));
+        if (column.foreignKey)
+            out += std::format(", .foreignKey = {}", PrintForeignKeyReference(*column.foreignKey));
+        out += std::format(", .required = {}, .unique = {}", column.required, column.unique);
+        if (!column.defaultValue.empty())
+            out += std::format(", .defaultValue = {}", QuoteCppString(column.defaultValue));
+        out += std::format(", .index = {}", column.index);
+        if (column.primaryKeyIndex != 0)
+            out += std::format(", .primaryKeyIndex = {}", column.primaryKeyIndex);
+        out += " }";
+        return out;
+    }
+
+    /// @brief Renders the fluent call that declares @p column, without the trailing
+    /// `Unique()` / `Index()` modifiers.
+    [[nodiscard]] std::string PrintColumnCall(SqlColumnDeclaration const& column)
+    {
+        if (!IsExpressibleAsShorthand(column))
+            return std::format(".Column({})", PrintColumnDeclaration(column));
+
+        auto const name = QuoteCppString(column.name);
+        auto const type = PrintColumnType(column.type);
+
+        if (column.primaryKey == SqlPrimaryKeyType::AUTO_INCREMENT)
+            return std::format(".PrimaryKeyWithAutoIncrement({}, {})", name, type);
+        if (column.primaryKey == SqlPrimaryKeyType::MANUAL)
+            return std::format(".PrimaryKey({}, {})", name, type);
+        if (column.foreignKey)
+            return std::format(".{}({}, {}, {})",
+                               column.required ? "RequiredForeignKey" : "ForeignKey",
+                               name,
+                               type,
+                               PrintForeignKeyReference(*column.foreignKey));
+        return std::format(".{}({}, {})", column.required ? "RequiredColumn" : "Column", name, type);
+    }
+
+    /// @brief Renders the trailing `Unique()` / `Index()` / `UniqueIndex()` modifier, if any.
+    ///
+    /// A primary key already carries both, and re-stating them would be noise.
+    [[nodiscard]] std::string_view PrintColumnModifier(SqlColumnDeclaration const& column) noexcept
+    {
+        if (column.primaryKey != SqlPrimaryKeyType::NONE || !IsExpressibleAsShorthand(column))
+            return {};
+        if (column.unique && column.index)
+            return ".UniqueIndex()";
+        if (column.unique)
+            return ".Unique()";
+        if (column.index)
+            return ".Index()";
+        return {};
+    }
+
+    /// @brief Renders a `CREATE TABLE` element as a chained `plan.CreateTable(...)` statement.
+    [[nodiscard]] std::string PrintCreateTable(SqlCreateTablePlan const& create)
+    {
+        auto out = std::format("    plan.{}({})",
+                               create.ifNotExists ? "CreateTableIfNotExists" : "CreateTable",
+                               QuoteCppString(create.tableName));
+        for (auto const& column: create.columns)
+            out += std::format("\n        {}{}", PrintColumnCall(column), PrintColumnModifier(column));
+        for (auto const& fk: create.foreignKeys)
+            out += std::format("\n        .ForeignKey({}, {}, {})",
+                               PrintStringList(fk.columns),
+                               QuoteCppString(fk.referencedTableName),
+                               PrintStringList(fk.referencedColumns));
+        out += ";\n";
+        return out;
+    }
+
+    /// @brief Renders one `ALTER TABLE` command as its fluent call.
+    [[nodiscard]] std::string PrintAlterCommand(SqlAlterTableCommand const& command)
+    {
+        namespace Cmd = SqlAlterTableCommands;
+        return std::visit(
+            [](auto const& c) -> std::string {
+                using T = std::decay_t<decltype(c)>;
+                if constexpr (std::same_as<T, Cmd::RenameTable>)
+                    return std::format(".RenameTo({})", QuoteCppString(c.newTableName));
+                else if constexpr (std::same_as<T, Cmd::AddColumn>)
+                    return std::format(".{}({}, {})",
+                                       c.nullable == SqlNullable::NotNull ? "AddColumn" : "AddNotRequiredColumn",
+                                       QuoteCppString(c.columnName),
+                                       PrintColumnType(c.columnType));
+                else if constexpr (std::same_as<T, Cmd::AddColumnIfNotExists>)
+                    return std::format(".{}({}, {})",
+                                       c.nullable == SqlNullable::NotNull ? "AddColumnIfNotExists"
+                                                                          : "AddNotRequiredColumnIfNotExists",
+                                       QuoteCppString(c.columnName),
+                                       PrintColumnType(c.columnType));
+                else if constexpr (std::same_as<T, Cmd::AlterColumn>)
+                    return std::format(".AlterColumn({}, {}, {})",
+                                       QuoteCppString(c.columnName),
+                                       PrintColumnType(c.columnType),
+                                       PrintNullable(c.nullable));
+                else if constexpr (std::same_as<T, Cmd::AddIndex>)
+                    return std::format(".{}({})", c.unique ? "AddUniqueIndex" : "AddIndex", QuoteCppString(c.columnName));
+                else if constexpr (std::same_as<T, Cmd::RenameColumn>)
+                    return std::format(
+                        ".RenameColumn({}, {})", QuoteCppString(c.oldColumnName), QuoteCppString(c.newColumnName));
+                else if constexpr (std::same_as<T, Cmd::DropColumn>)
+                    return std::format(".DropColumn({})", QuoteCppString(c.columnName));
+                else if constexpr (std::same_as<T, Cmd::DropColumnIfExists>)
+                    return std::format(".DropColumnIfExists({})", QuoteCppString(c.columnName));
+                else if constexpr (std::same_as<T, Cmd::DropIndex>)
+                    return std::format(".DropIndex({})", QuoteCppString(c.columnName));
+                else if constexpr (std::same_as<T, Cmd::DropIndexIfExists>)
+                    return std::format(".DropIndexIfExists({})", QuoteCppString(c.columnName));
+                else if constexpr (std::same_as<T, Cmd::AddForeignKey>)
+                    return std::format(
+                        ".AddForeignKey({}, {})", QuoteCppString(c.columnName), PrintForeignKeyReference(c.referencedColumn));
+                else if constexpr (std::same_as<T, Cmd::AddCompositeForeignKey>)
+                    return std::format(".AddCompositeForeignKey({}, {}, {})",
+                                       PrintStringList(c.columns),
+                                       QuoteCppString(c.referencedTableName),
+                                       PrintStringList(c.referencedColumns));
+                else
+                    return std::format(".DropForeignKey({})", QuoteCppString(c.columnName));
+            },
+            command);
+    }
+
+    /// @brief Renders an `ALTER TABLE` element as a chained `plan.AlterTable(...)` statement.
+    [[nodiscard]] std::string PrintAlterTable(SqlAlterTablePlan const& alter)
+    {
+        auto out = std::format("    plan.AlterTable({})", QuoteCppString(alter.tableName));
+        for (auto const& command: alter.commands)
+            out += std::format("\n        {}", PrintAlterCommand(command));
+        out += ";\n";
+        return out;
+    }
+
+    /// @brief Renders one plan element as the migration-DSL statement that rebuilds it.
+    [[nodiscard]] std::string PrintPlanElement(SqlMigrationPlanElement const& element)
+    {
+        return std::visit(
+            []<typename T>(T const& e) -> std::string {
+                if constexpr (std::same_as<T, SqlCreateTablePlan>)
+                    return PrintCreateTable(e);
+                else if constexpr (std::same_as<T, SqlAlterTablePlan>)
+                    return PrintAlterTable(e);
+                else if constexpr (std::same_as<T, SqlDropTablePlan>)
+                    return std::format("    plan.{}({});\n",
+                                       e.cascade      ? "DropTableCascade"
+                                       : e.ifExists   ? "DropTableIfExists"
+                                                      : "DropTable",
+                                       QuoteCppString(e.tableName));
+                else if constexpr (std::same_as<T, SqlCreateIndexPlan>)
+                    return std::format("    plan.{}({}, {}, {});\n",
+                                       e.unique ? "CreateUniqueIndex" : "CreateIndex",
+                                       QuoteCppString(e.indexName),
+                                       QuoteCppString(e.tableName),
+                                       PrintStringList(e.columns));
+                else if constexpr (std::same_as<T, SqlRawSqlPlan>)
+                    return std::format("    plan.RawSql({});\n", QuoteCppString(e.sql));
+                else
+                    return "    // NOTE: a data step (INSERT/UPDATE/DELETE) was skipped — "
+                           "autogenerate emits DDL only.\n";
+            },
+            element);
+    }
+} // namespace
+
+std::string PrintMigrationSource(MigrationSourceOptions const& options, std::span<SqlMigrationPlanElement const> plan)
+{
+    std::string out = "// SPDX-License-Identifier: Apache-2.0\n"
+                      "\n"
+                      "#include <Lightweight/SqlMigration.hpp>\n"
+                      "#include <Lightweight/SqlQuery/Migrate.hpp>\n"
+                      "\n"
+                      "using namespace Lightweight;\n"
+                      "\n";
+
+    if (options.includePluginEntryPoint)
+        out += "// Define the plugin entry point (exactly one translation unit per plugin may do this).\n"
+               "LIGHTWEIGHT_MIGRATION_PLUGIN()\n"
+               "\n";
+
+    if (!options.provenance.empty())
+        out += std::format("// {}\n", options.provenance);
+
+    out += std::format("LIGHTWEIGHT_SQL_MIGRATION({}, {})\n{{\n", options.timestamp, QuoteCppString(options.title));
+
+    if (plan.empty())
+        out += "    // TODO: describe the schema change here, e.g.\n"
+               "    //   plan.CreateTable(\"MyTable\")\n"
+               "    //       .PrimaryKeyWithAutoIncrement(\"id\", SqlColumnTypeDefinitions::Bigint {})\n"
+               "    //       .RequiredColumn(\"name\", SqlColumnTypeDefinitions::Varchar { 128 });\n"
+               "    (void) plan;\n";
+    else
+        for (auto const index: std::views::iota(std::size_t { 0 }, plan.size()))
+            out += std::format("{}{}", index == 0 ? "" : "\n", PrintPlanElement(plan[index]));
+
+    out += "}\n";
+    return out;
+}
+
+std::string FormatMigrationTimestamp(std::chrono::system_clock::time_point when)
+{
+    return std::format("{:%Y%m%d%H%M%S}", std::chrono::floor<std::chrono::seconds>(when));
+}
+
+std::string SlugifyMigrationTitle(std::string_view title)
+{
+    std::string slug;
+    slug.reserve(title.size());
+    for (char const c: title)
+    {
+        if (std::isalnum(static_cast<unsigned char>(c)))
+            slug.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+        else if (!slug.empty() && slug.back() != '_')
+            slug.push_back('_');
+    }
+    while (!slug.empty() && slug.back() == '_')
+        slug.pop_back();
+    return slug.empty() ? std::string { "migration" } : slug;
+}
+
+} // namespace Lightweight::Tools

--- a/src/Lightweight/Tools/MigrationSourcePrinter.hpp
+++ b/src/Lightweight/Tools/MigrationSourcePrinter.hpp
@@ -56,7 +56,7 @@ struct MigrationSourceOptions
 /// @param plan The plan elements to spell out, in replay order.
 /// @return The full contents of the `.cpp` file, newline-terminated.
 [[nodiscard]] std::string PrintMigrationSource(MigrationSourceOptions const& options,
-                                                               std::span<SqlMigrationPlanElement const> plan);
+                                               std::span<SqlMigrationPlanElement const> plan);
 
 /// @brief Formats a time point as a `YYYYMMDDHHMMSS` migration timestamp in UTC.
 ///

--- a/src/Lightweight/Tools/MigrationSourcePrinter.hpp
+++ b/src/Lightweight/Tools/MigrationSourcePrinter.hpp
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <Lightweight/SqlQuery/MigrationPlan.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <string_view>
+
+namespace Lightweight::Tools
+{
+
+/// @brief Knobs controlling how a migration source file is emitted.
+///
+/// @ingroup SqlMigration
+struct MigrationSourceOptions
+{
+    /// The `YYYYMMDDHHMMSS` timestamp that identifies the migration. Emitted verbatim as
+    /// the first argument of `LIGHTWEIGHT_SQL_MIGRATION`, so the caller owns the format;
+    /// `FormatMigrationTimestamp` produces the canonical shape.
+    std::string timestamp;
+
+    /// Human-readable migration title, emitted as the macro's second argument.
+    std::string title;
+
+    /// When true, the file also carries `LIGHTWEIGHT_MIGRATION_PLUGIN()`. Exactly one
+    /// translation unit per migration plugin may define it, so this defaults to off:
+    /// a generated migration usually joins an existing plugin that already has one.
+    bool includePluginEntryPoint = false;
+
+    /// Optional provenance banner emitted as a comment above the migration, e.g. the
+    /// connection the diff was taken against. Empty means no banner.
+    std::string provenance;
+};
+
+/// @brief Emits a compilable `.cpp` migration source file for @p plan.
+///
+/// The body is the migration DSL spelling of @p plan: `CreateTable`, `AlterTable`,
+/// `CreateIndex`, `DropTable` and `RawSql` elements each render as the fluent call that
+/// would rebuild them. A column declaration that the fluent shorthands cannot express
+/// losslessly (a default value, a composite primary-key position, a GUID primary key)
+/// falls back to the `Column(SqlColumnDeclaration { ... })` overload rather than silently
+/// dropping the attribute.
+///
+/// Data plan elements (INSERT / UPDATE / DELETE) are not schema changes and are emitted as
+/// a visible `// NOTE:` comment instead of code — autogenerate produces DDL only, and a
+/// silently missing data step would be worse than an obvious one.
+///
+/// An empty @p plan yields a valid migration with an empty body, which is the scaffolding
+/// mode: a correctly-timestamped file for the author to fill in.
+///
+/// @param options Timestamp, title and emission knobs.
+/// @param plan The plan elements to spell out, in replay order.
+/// @return The full contents of the `.cpp` file, newline-terminated.
+[[nodiscard]] std::string PrintMigrationSource(MigrationSourceOptions const& options,
+                                                               std::span<SqlMigrationPlanElement const> plan);
+
+/// @brief Formats a time point as a `YYYYMMDDHHMMSS` migration timestamp in UTC.
+///
+/// UTC rather than local time so that two authors in different zones cannot produce
+/// timestamps that order differently from the wall-clock order in which they wrote them.
+///
+/// @param when The instant to format.
+/// @return The 14-digit timestamp.
+[[nodiscard]] std::string FormatMigrationTimestamp(std::chrono::system_clock::time_point when);
+
+/// @brief Turns a free-form migration title into a filename-safe `lower_snake` slug.
+///
+/// Alphanumerics are lower-cased and kept, every other run of characters collapses to a
+/// single underscore, and leading/trailing underscores are trimmed. A title with no usable
+/// characters yields `"migration"` so the caller always has a filename.
+///
+/// @param title The human-readable title.
+/// @return The slug.
+[[nodiscard]] std::string SlugifyMigrationTitle(std::string_view title);
+
+} // namespace Lightweight::Tools

--- a/src/tools/dbtool/CMakeLists.txt
+++ b/src/tools/dbtool/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(dbtool_lib STATIC
 # dbtool executable and the test target (which links dbtool_lib) resolve the dependency. The `zip`
 # target itself is resolved once in the root CMakeLists.txt for every platform (find_package first,
 # CPM fallback if not found — #543); re-resolving libzip here would hard-fail a CPM-fallback build.
-target_link_libraries(dbtool_lib PUBLIC Lightweight tools_shared zip)
+target_link_libraries(dbtool_lib PUBLIC Lightweight Lightweight::Tools tools_shared zip)
 
 add_executable(dbtool main.cpp)
 target_link_libraries(dbtool PRIVATE dbtool_lib)

--- a/src/tools/dbtool/main.cpp
+++ b/src/tools/dbtool/main.cpp
@@ -11,6 +11,7 @@
 #include <Lightweight/SqlMigration.hpp>
 #include <Lightweight/SqlSchema.hpp>
 #include <Lightweight/SqlScopedLock.hpp>
+#include <Lightweight/Tools/MigrationSourcePrinter.hpp>
 #include <Lightweight/Utils.hpp>
 
 #include <algorithm>
@@ -19,6 +20,7 @@
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
+#include <charconv>
 #include <expected>
 #include <filesystem>
 #include <fstream>
@@ -174,6 +176,13 @@ void PrintUsage()
     std::println("  {}unicode-upgrade-tables{}    Rewrites legacy VARCHAR/CHAR columns to NVARCHAR/NCHAR",
                  c.command, c.reset);
     std::println("                            where the registered migrations now declare wide types");
+    std::println("  {}diff{}                     Reports how the live schema differs from what the registered",
+                 c.command, c.reset);
+    std::println("                            migrations declare (read-only; honours --up-to)");
+    std::println("  {}generate{} {}<TITLE>{}         Writes that same diff as a timestamped migration source file",
+                 c.command, c.reset, c.param, c.reset);
+    std::println("                            (--empty scaffolds a blank one without touching the database,");
+    std::println("                            --dry-run prints to stdout, --output pins the path)");
     std::println("  {}exec{} {}<QUERY>{}             Executes the given SQL query and prints any result set.",
                  c.command, c.reset, c.param, c.reset);
     std::println("                            Pass `-` (or omit the argument) to read the query from stdin.");
@@ -245,6 +254,10 @@ void PrintUsage()
                  c.option, c.reset);
     std::println("  {}--schema-only{}             Backup/restore schema only, skip data",
                  c.option, c.reset);
+    std::println("  {}--empty{}                   generate: scaffold a blank migration without reading the database",
+                 c.option, c.reset);
+    std::println("  {}--up-to{} {}<TIMESTAMP>{}       diff/generate: fold only migrations up to and including this one",
+                 c.option, c.reset, c.param, c.reset);
     std::println("  {}--quiet{}                   Suppress progress output", c.option, c.reset);
     std::println("  {}--verbose{}, {}-v{}             Emit extra informational output (e.g. shadowed plugins)",
                  c.option, c.reset, c.option, c.reset);
@@ -372,6 +385,7 @@ struct Options
     bool schemaOnly = false; ///< If true, backup/restore schema only (no data)
     bool yes = false;        ///< If true, confirm destructive actions (e.g. rewrite-checksums)
     bool verbose = false;    ///< If true, emit extra informational output (e.g. shadowed plugins)
+    bool emptyMigration = false; ///< `generate --empty`: scaffold a blank migration, no DB needed
 
     /// @brief `--up-to <X>` for migration commands. Empty = no bound.
     std::string upTo;
@@ -742,6 +756,10 @@ std::expected<Options, std::string> ParseArguments(int argc, char** argv)
         else if (arg == "--yes" || arg == "-y")
         {
             options.yes = true;
+        }
+        else if (arg == "--empty")
+        {
+            options.emptyMigration = true;
         }
         else if (arg == "--up-to")
         {
@@ -1365,6 +1383,224 @@ int UnicodeUpgradeTables(MigrationManager& manager, bool dryRun, bool yes)
                 tables.insert(c.table.table);
             std::println("Upgraded {} column(s) across {} table(s).", r.columns.size(), tables.size());
         });
+}
+
+/// @brief Parses `--up-to <TIMESTAMP>` into a fold cut-off.
+///
+/// @param upTo The raw option value; empty means "no bound".
+/// @return The parsed bound, `nullopt` when unbounded, or an error message when the
+///         value is not a migration timestamp.
+std::expected<std::optional<MigrationTimestamp>, std::string> ParseUpToBound(std::string_view upTo)
+{
+    if (upTo.empty())
+        return std::optional<MigrationTimestamp> {};
+
+    auto value = uint64_t {};
+    auto const parsed = std::from_chars(upTo.data(), upTo.data() + upTo.size(), value);
+    if (parsed.ec != std::errc {} || parsed.ptr != upTo.data() + upTo.size())
+        return std::unexpected { std::format("Error: --up-to expects a migration timestamp, got '{}'.", upTo) };
+    return std::optional { MigrationTimestamp { value } };
+}
+
+/// @brief Prints one altered table's column-level delta.
+void PrintTableDelta(MigrationManager::SchemaDiffTable const& table, SqlQueryFormatter const& formatter)
+{
+    std::println("  {}", table.tableName);
+    for (auto const& column: table.addedColumns)
+        std::println("    + {:<24} {}", column.name, formatter.ColumnType(column.type));
+    for (auto const& change: table.changedColumns)
+        std::println("    ~ {:<24} {} (live: {})",
+                     change.column,
+                     formatter.ColumnType(change.intendedType),
+                     formatter.ColumnType(change.liveType));
+    for (auto const& column: table.droppedColumns)
+        std::println("    - {:<24} (not declared by any migration)", column);
+}
+
+/// @brief Renders the whole diff report to stdout.
+///
+/// Shared by `diff` and by `generate`, so the operator sees the same summary whether or
+/// not a file is written.
+void PrintSchemaDiff(MigrationManager::SchemaDiffResult const& diff, SqlQueryFormatter const& formatter)
+{
+    if (!diff.missingTables.empty())
+    {
+        std::println("Tables to create ({}):", diff.missingTables.size());
+        for (auto const& table: diff.missingTables)
+            std::println("  {} ({} column(s))", table.tableName, table.columns.size());
+        std::println("");
+    }
+
+    if (!diff.alteredTables.empty())
+    {
+        std::println("Tables to alter ({}):", diff.alteredTables.size());
+        for (auto const& table: diff.alteredTables)
+            PrintTableDelta(table, formatter);
+        std::println("");
+    }
+
+    if (!diff.missingIndexes.empty())
+    {
+        std::println("Indexes to create ({}):", diff.missingIndexes.size());
+        for (auto const& index: diff.missingIndexes)
+            std::println("  {} on {} ({})",
+                         index.indexName,
+                         index.tableName,
+                         index.columns | std::views::join_with(std::string_view { ", " }) | std::ranges::to<std::string>());
+        std::println("");
+    }
+
+    if (!diff.unmanagedTables.empty())
+    {
+        std::println("Unmanaged tables — in the database, declared by no migration ({}):", diff.unmanagedTables.size());
+        for (auto const& table: diff.unmanagedTables)
+            std::println("  {}", table.table);
+        std::println("  (reported only; autogenerate never drops them)");
+        std::println("");
+    }
+}
+
+/// @brief `diff` — reports how the live schema differs from what the migrations intend.
+///
+/// Read-only. Always exits successfully: a drifted schema is a finding to act on, not a
+/// dbtool failure.
+int SchemaDiff(MigrationManager& manager, Options const& options)
+{
+    auto const bound = ParseUpToBound(options.upTo);
+    if (!bound)
+    {
+        std::println(std::cerr, "{}", bound.error());
+        return EXIT_FAILURE;
+    }
+
+    auto const& formatter = manager.GetDataMapper().Connection().QueryFormatter();
+    auto const diff = manager.DiffAgainstLiveSchema(*bound);
+
+    if (diff.Empty() && diff.unmanagedTables.empty())
+    {
+        std::println("The live schema matches what the registered migrations declare. Nothing to generate.");
+        return EXIT_SUCCESS;
+    }
+
+    std::println("Schema diff: registered migrations → live database");
+    std::println("");
+    PrintSchemaDiff(diff, formatter);
+
+    if (diff.Empty())
+        return EXIT_SUCCESS;
+
+    auto const plan = SqlMigration::MakeSchemaDiffPlan(diff);
+    std::println("Migration plan ({} step(s)):", plan.size());
+    for (auto const& element: plan)
+        for (auto const& sql: ToSql(formatter, element))
+            std::println("  {}", sql);
+    std::println("");
+    std::println("Run `dbtool generate \"<title>\"` to emit this as a migration source file.");
+    return EXIT_SUCCESS;
+}
+
+/// @brief Resolves where `generate` should write, and refuses to clobber silently.
+///
+/// @param options Parsed CLI options; `--output` pins an exact path, otherwise the file
+///                lands in the current directory under `<timestamp>_<slug>.cpp`.
+/// @param timestamp The migration timestamp.
+/// @param title The migration title, used for the filename slug.
+/// @return The destination path, or an error message.
+std::expected<std::filesystem::path, std::string> ResolveGenerateTarget(Options const& options,
+                                                                        std::string_view timestamp,
+                                                                        std::string_view title)
+{
+    auto const target =
+        options.outputFile.empty()
+            ? std::filesystem::path { std::format("{}_{}.cpp", timestamp, Tools::SlugifyMigrationTitle(title)) }
+            : options.outputFile;
+
+    if (std::filesystem::exists(target) && !options.yes)
+        return std::unexpected { std::format(
+            "Error: {} already exists. Pass --yes to overwrite, or --output to write elsewhere.", target.string()) };
+    return target;
+}
+
+/// @brief `generate <TITLE>` — emits the diff as a timestamped migration source file.
+///
+/// With `--empty` no database is consulted and a scaffold is written instead, which is the
+/// answer to the one piece of friction that exists even when there is nothing to diff:
+/// hand-typing a `YYYYMMDDHHMMSS` timestamp.
+int GenerateMigration(MigrationManager* manager, Options const& options)
+{
+    if (options.argument.empty())
+    {
+        std::println(std::cerr, "Error: generate requires a <TITLE> argument, e.g. dbtool generate \"Add orders table\".");
+        return EXIT_FAILURE;
+    }
+
+    auto const timestamp = Tools::FormatMigrationTimestamp(std::chrono::system_clock::now());
+    auto sourceOptions = Tools::MigrationSourceOptions {
+        .timestamp = timestamp,
+        .title = options.argument,
+        .includePluginEntryPoint = false,
+        .provenance = {},
+    };
+
+    // Holds the diff for as long as the plan borrows names from it.
+    auto diff = MigrationManager::SchemaDiffResult {};
+    auto plan = std::vector<SqlMigrationPlanElement> {};
+
+    if (manager != nullptr)
+    {
+        auto const bound = ParseUpToBound(options.upTo);
+        if (!bound)
+        {
+            std::println(std::cerr, "{}", bound.error());
+            return EXIT_FAILURE;
+        }
+
+        diff = manager->DiffAgainstLiveSchema(*bound);
+        if (diff.Empty())
+        {
+            std::println("The live schema matches what the registered migrations declare. Nothing to generate.");
+            std::println("Pass --empty to scaffold a blank migration anyway.");
+            return EXIT_SUCCESS;
+        }
+
+        PrintSchemaDiff(diff, manager->GetDataMapper().Connection().QueryFormatter());
+        plan = SqlMigration::MakeSchemaDiffPlan(diff);
+        sourceOptions.provenance = "Autogenerated by `dbtool generate` from the diff between the registered "
+                                   "migrations and the live schema. Review before committing.";
+    }
+
+    auto const source = Tools::PrintMigrationSource(sourceOptions, plan);
+
+    if (options.dryRun)
+    {
+        std::print("{}", source);
+        return EXIT_SUCCESS;
+    }
+
+    auto const target = ResolveGenerateTarget(options, timestamp, options.argument);
+    if (!target)
+    {
+        std::println(std::cerr, "{}", target.error());
+        return EXIT_FAILURE;
+    }
+
+    auto out = std::ofstream { *target, std::ios::binary | std::ios::trunc };
+    if (!out)
+    {
+        std::println(std::cerr, "Error: cannot write to {}.", target->string());
+        return EXIT_FAILURE;
+    }
+    out << source;
+    out.close();
+    if (!out)
+    {
+        std::println(std::cerr, "Error: failed while writing {}.", target->string());
+        return EXIT_FAILURE;
+    }
+
+    std::println("Wrote {} ({} step(s)).", target->string(), plan.size());
+    std::println("Add it to your migration plugin's sources and rebuild, then `dbtool migrate`.");
+    return EXIT_SUCCESS;
 }
 
 /// Marks a migration as applied without executing its Up() method.
@@ -2527,6 +2763,10 @@ int DispatchDbCommand(Options const& options)
         OptionalScopedLock const lock(manager, options.noLock || options.dryRun);
         return UnicodeUpgradeTables(manager, options.dryRun, options.yes);
     }
+    if (options.command == "diff")
+        return SchemaDiff(GetMigrationManager(options), options);
+    if (options.command == "generate")
+        return GenerateMigration(&GetMigrationManager(options), options);
     if (options.command == "backup")
         return Backup(options);
     if (options.command == "restore")
@@ -2638,6 +2878,11 @@ int main(int argc, char** argv)
 
         if (options.command == "backup-diff")
             return BackupDiffCommand(options);
+
+        // `generate --empty` only needs a clock and a title, so it must not require a
+        // reachable database the way every other `generate` invocation does.
+        if (options.command == "generate" && options.emptyMigration)
+            return GenerateMigration(nullptr, options);
 
         TraceBreadcrumb("main: setting up connection string");
         if (!SetupConnectionString(options.connectionString))

--- a/src/tools/dbtool/main.cpp
+++ b/src/tools/dbtool/main.cpp
@@ -17,10 +17,10 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <charconv>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
-#include <charconv>
 #include <expected>
 #include <filesystem>
 #include <fstream>
@@ -29,9 +29,11 @@
 #include <print>
 #include <ranges>
 #include <set>
+#include <span>
 #include <string>
 #include <type_traits>
 #include <unordered_set>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -69,6 +71,27 @@ using namespace std::string_view_literals;
 
 namespace
 {
+
+/// @brief Joins @p parts into a single comma-separated string, for display only.
+///
+/// Hand-rolled rather than `std::views::join_with`: that view is C++23, but libc++ does not ship it
+/// yet and the macOS CI leg builds against libc++. The separator is tracked with a flag rather than
+/// by testing whether the result is still empty, so an empty element cannot swallow a separator.
+///
+/// @param parts The strings to join.
+/// @return The joined string, empty when @p parts is empty.
+[[nodiscard]] std::string JoinForDisplay(std::span<std::string const> parts)
+{
+    auto result = std::string {};
+    auto first = true;
+    for (auto const& part: parts)
+    {
+        if (!std::exchange(first, false))
+            result += ", ";
+        result += part;
+    }
+    return result;
+}
 
 /// @brief Emits a startup-trace breadcrumb to stderr when `DBTOOL_TRACE=1` is set.
 ///
@@ -380,11 +403,11 @@ struct Options
     std::string batchSize;                     ///< Batch size for restore (rows per batch)
     bool pluginsDirSet = false;
     bool connectionStringSet = false;
-    bool dryRun = false;     ///< If true, show what would be done without actually doing it
-    bool noLock = false;     ///< If true, skip migration locking for write operations
-    bool schemaOnly = false; ///< If true, backup/restore schema only (no data)
-    bool yes = false;        ///< If true, confirm destructive actions (e.g. rewrite-checksums)
-    bool verbose = false;    ///< If true, emit extra informational output (e.g. shadowed plugins)
+    bool dryRun = false;         ///< If true, show what would be done without actually doing it
+    bool noLock = false;         ///< If true, skip migration locking for write operations
+    bool schemaOnly = false;     ///< If true, backup/restore schema only (no data)
+    bool yes = false;            ///< If true, confirm destructive actions (e.g. rewrite-checksums)
+    bool verbose = false;        ///< If true, emit extra informational output (e.g. shadowed plugins)
     bool emptyMigration = false; ///< `generate --empty`: scaffold a blank migration, no DB needed
 
     /// @brief `--up-to <X>` for migration commands. Empty = no bound.
@@ -1443,10 +1466,7 @@ void PrintSchemaDiff(MigrationManager::SchemaDiffResult const& diff, SqlQueryFor
     {
         std::println("Indexes to create ({}):", diff.missingIndexes.size());
         for (auto const& index: diff.missingIndexes)
-            std::println("  {} on {} ({})",
-                         index.indexName,
-                         index.tableName,
-                         index.columns | std::views::join_with(std::string_view { ", " }) | std::ranges::to<std::string>());
+            std::println("  {} on {} ({})", index.indexName, index.tableName, JoinForDisplay(index.columns));
         std::println("");
     }
 

--- a/src/tools/dbtool/main.cpp
+++ b/src/tools/dbtool/main.cpp
@@ -1530,10 +1530,10 @@ std::expected<std::filesystem::path, std::string> ResolveGenerateTarget(Options 
                                                                         std::string_view timestamp,
                                                                         std::string_view title)
 {
-    auto const target =
-        options.outputFile.empty()
-            ? std::filesystem::path { std::format("{}_{}.cpp", timestamp, Tools::SlugifyMigrationTitle(title)) }
-            : options.outputFile;
+    // Not const: it is returned below, and constness would block the implicit move.
+    auto target = options.outputFile.empty()
+                      ? std::filesystem::path { std::format("{}_{}.cpp", timestamp, Tools::SlugifyMigrationTitle(title)) }
+                      : options.outputFile;
 
     if (std::filesystem::exists(target) && !options.yes)
         return std::unexpected { std::format(


### PR DESCRIPTION
Closes #564

> Opened as a **draft**: the feature works end to end and the suite is green, but it is the author's work-in-progress and has not had a design pass. See *Status* below.

## What & why

Adds the schema-drift half of #564 — what the registered migrations *intend* versus what the database actually *has*.

`DiffAgainstLiveSchema` folds the registered migrations into the schema they describe, reads the live catalog, and reports the delta as owned, freely copyable values:

- tables the migrations declare that the database lacks, as ready-to-replay `CREATE TABLE` plans **in creation order**, so foreign keys resolve when the plan is replayed front to back;
- tables the database has that no registered migration declares (reported only — autogenerate never emits drops);
- per-column drift in rendered type or nullability.

`MakeSchemaDiffPlan` turns the same delta into replayable plan elements on demand rather than storing them, because the plan element types hold `string_view`s.

`Tools/MigrationSourcePrinter` renders a delta as C++ migration source, and `dbtool` gains two subcommands: `diff` (report only) and `generate <TITLE>` (write the migration), with `--empty` to scaffold a blank migration and `--up-to <TIMESTAMP>` to fold only migrations up to a point.

## Testing

| | Result |
|---|---|
| `clang-debug` (PEDANTIC + ASan + UBSan) | full suite green — 1402 cases |
| Databases | `sqlite3`, `mssql2022` (Docker), `postgres` (Docker 16.4) |
| `test_dbtool.py` | SUCCESS against `sqlite3` |
| `dbtool diff` | verified end to end against a live SQLite database |
| clang-tidy / clang-format | no new findings in the changed regions; `MigrationSourcePrinter.cpp` clean |

One portability fix is its own commit: `dbtool diff` rendered an index's column list with `std::views::join_with`, which is C++23 but not implemented in libc++, so the macOS CI leg failed to compile. Replaced with a small helper producing the identical string.

## Status — what still needs a look

- **Not yet reviewed for API shape.** `SchemaDiffResult` and friends are new public surface in `SqlMigration.hpp`; the naming and the owned-vs-view split deserve a second opinion before this leaves draft.
- **No tests for the diff itself.** The suite is green and `dbtool diff` was exercised by hand, but there is no automated coverage of `DiffAgainstLiveSchema` or `MigrationSourcePrinter` yet. That is the main gap.
- The modules (`LIGHTWEIGHT_BUILD_MODULES=ON`) and C++26-reflection configurations have **not** been built for this branch; `Lightweight.cppm` gained an entry, so per `AGENT.md` the modules build wants checking before merge.

- **Performance impact:** none on existing paths; the diff runs only when asked.
- **Risk:** medium — new public API in `SqlMigration.hpp` and two new `dbtool` subcommands. Nothing existing changes behaviour.