### PR TITLE
Fix two CI flakes: migration deregistration and stdexec's configure-time download

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,48 @@ if(stdexec_FOUND)
 else()
     message(STATUS "stdexec (>= ${LIGHTWEIGHT_STDEXEC_MIN_VERSION}) not found, "
                    "downloading ${LIGHTWEIGHT_STDEXEC_GIT_TAG} via CPM...")
+
+    # stdexec derives its own project VERSION from the `Revision: N` line of execution.bs, which its
+    # CMakeLists downloads from raw.githubusercontent.com at configure time -- with no status check.
+    # A failed or truncated fetch leaves an empty file behind and the configure dies inside stdexec:
+    #
+    #   string sub-command REGEX, mode REPLACE needs at least 6 arguments total to command.
+    #   VERSION "0..0" format invalid.
+    #
+    # That has broken CI legs at random (a network blip on one job while its siblings passed). Seed
+    # the file ourselves so a configure never depends on that fetch: stdexec skips its own download
+    # when the file already exists. We still try the network first, so the version it reports stays
+    # accurate when the fetch works, and fall back to a pinned revision when it does not.
+    set(LIGHTWEIGHT_STDEXEC_BS_REVISION_FALLBACK "11" CACHE STRING
+        "Revision recorded in the seeded execution.bs when the live copy cannot be fetched; only feeds \
+stdexec's own project(VERSION), which Lightweight does not consume")
+    # CPM resolves stdexec through FetchContent, whose per-package binary dir is
+    # <FETCHCONTENT_BASE_DIR>/<lowercased name>-build; the module defaults that base to
+    # ${CMAKE_BINARY_DIR}/_deps, which we mirror in case FetchContent has not been included yet.
+    set(_lightweight_stdexec_deps "${FETCHCONTENT_BASE_DIR}")
+    if(NOT _lightweight_stdexec_deps)
+        set(_lightweight_stdexec_deps "${CMAKE_BINARY_DIR}/_deps")
+    endif()
+    set(_lightweight_stdexec_bs "${_lightweight_stdexec_deps}/stdexec-build/execution.bs")
+    if(NOT EXISTS "${_lightweight_stdexec_bs}")
+        file(DOWNLOAD "https://raw.githubusercontent.com/cplusplus/sender-receiver/main/execution.bs"
+             "${_lightweight_stdexec_bs}"
+             TIMEOUT 30
+             STATUS _lightweight_stdexec_bs_status)
+        file(STRINGS "${_lightweight_stdexec_bs}" _lightweight_stdexec_bs_revision REGEX "Revision: [0-9]+")
+        if(NOT _lightweight_stdexec_bs_revision)
+            list(GET _lightweight_stdexec_bs_status 1 _lightweight_stdexec_bs_error)
+            message(STATUS "stdexec: execution.bs unavailable (${_lightweight_stdexec_bs_error}); "
+                           "seeding revision ${LIGHTWEIGHT_STDEXEC_BS_REVISION_FALLBACK}")
+            file(WRITE "${_lightweight_stdexec_bs}" "Revision: ${LIGHTWEIGHT_STDEXEC_BS_REVISION_FALLBACK}\n")
+        endif()
+        unset(_lightweight_stdexec_bs_revision)
+        unset(_lightweight_stdexec_bs_status)
+        unset(_lightweight_stdexec_bs_error)
+    endif()
+    unset(_lightweight_stdexec_bs)
+    unset(_lightweight_stdexec_deps)
+
     CPMAddPackage(
         NAME stdexec
         GITHUB_REPOSITORY NVIDIA/stdexec

--- a/docs/sql-migrations.md
+++ b/docs/sql-migrations.md
@@ -32,7 +32,10 @@ LIGHTWEIGHT_SQL_MIGRATION(20260126120000, "Create users table")
 }
 ```
 
-The migration is automatically registered with the MigrationManager when the program starts.
+The migration is automatically registered with the MigrationManager when the program starts, and
+unregistered again when it is destroyed. Registration is tied to the object's lifetime, so a
+migration that does not live for the whole program -- one with automatic storage duration, say --
+leaves no dangling pointer behind in the manager it registered with.
 
 ### Using the Migration Class
 

--- a/src/Lightweight/SqlMigration.cpp
+++ b/src/Lightweight/SqlMigration.cpp
@@ -123,6 +123,11 @@ MigrationBase const* MigrationManager::GetMigration(MigrationTimestamp timestamp
     return it != std::end(_migrations) ? *it : nullptr;
 }
 
+void MigrationManager::RemoveMigration(MigrationBase const* migration) noexcept
+{
+    _migrations.remove(migration);
+}
+
 void MigrationManager::RemoveAllMigrations()
 {
     _migrations.clear();

--- a/src/Lightweight/SqlMigration.hpp
+++ b/src/Lightweight/SqlMigration.hpp
@@ -237,6 +237,14 @@ namespace SqlMigration
         /// @return Pointer to the migration if found, nullptr otherwise.
         [[nodiscard]] LIGHTWEIGHT_API MigrationBase const* GetMigration(MigrationTimestamp timestamp) const noexcept;
 
+        /// Remove a single migration from the manager.
+        ///
+        /// Called by @c MigrationBase's destructor so a migration that goes out of scope does not
+        /// leave a dangling pointer behind. Removing a migration that was never added is a no-op.
+        ///
+        /// @param migration Pointer to the migration to remove.
+        LIGHTWEIGHT_API void RemoveMigration(MigrationBase const* migration) noexcept;
+
         /// Remove all migrations from the manager.
         ///
         /// This function is useful if the migration manager should be reset.
@@ -828,7 +836,16 @@ namespace SqlMigration
             MigrationManager::GetInstance().AddMigration(this);
         }
 
-        virtual ~MigrationBase() = default;
+        /// Unregisters this migration from the singleton manager the constructor registered it with.
+        ///
+        /// Registration is a side effect of construction, so deregistration has to be one of
+        /// destruction: otherwise the manager keeps a pointer to a dead object, and its
+        /// duplicate-timestamp lookup dereferences it. A later migration reusing that storage is then
+        /// reported as a duplicate of itself.
+        virtual ~MigrationBase()
+        {
+            MigrationManager::GetInstance().RemoveMigration(this);
+        }
 
         /// Apply the migration.
         ///

--- a/src/tests/MigrationTests.cpp
+++ b/src/tests/MigrationTests.cpp
@@ -2043,12 +2043,8 @@ class CapturingWarningLogger: public Lightweight::SqlLogger::Null
 /// We only need `GetTimestamp` to be callable from a `CompatPolicy` lambda.
 ///
 /// Constructing one auto-registers it with `MigrationManager::GetInstance()` (a
-/// hard-coded side effect of the `MigrationBase` ctor). These stubs have automatic
-/// storage duration, so the destructor below resets the singleton rather than leaving
-/// a dangling pointer behind: `AddMigration` compares timestamps through the stored
-/// pointers, so a later migration allocated at a recycled address is (incorrectly)
-/// reported as a duplicate of itself. PluginIngestionTests.cpp's `FakeMigration`
-/// carries the same reset for the same reason.
+/// hard-coded side effect of the `MigrationBase` ctor); `~MigrationBase` unregisters it
+/// again, so a stub with automatic storage duration leaves nothing behind.
 class StubMigration: public Lightweight::SqlMigration::MigrationBase
 {
   public:
@@ -2057,11 +2053,7 @@ class StubMigration: public Lightweight::SqlMigration::MigrationBase
     {
     }
 
-    ~StubMigration() override
-    {
-        Lightweight::SqlMigration::MigrationManager::GetInstance().RemoveAllMigrations();
-        Lightweight::SqlMigration::MigrationManager::GetInstance().RemoveAllReleases();
-    }
+    ~StubMigration() override = default;
 
     StubMigration(StubMigration const&) = delete;
     StubMigration& operator=(StubMigration const&) = delete;
@@ -2318,6 +2310,55 @@ TEST_CASE_METHOD(SqlMigrationTestFixture,
     CHECK(mgr.CompatFlagsFor(modern).empty());
 
     mgr.SetCompatPolicy({});
+}
+
+TEST_CASE_METHOD(SqlMigrationTestFixture, "MigrationBase: destruction unregisters the migration", "[SqlMigration]")
+{
+    auto& mgr = Lightweight::SqlMigration::MigrationManager::GetInstance();
+    REQUIRE(mgr.GetAllMigrations().empty()); // fixture clears state
+
+    {
+        StubMigration const scoped { 20'000'000'000'101ULL };
+        CHECK(mgr.GetAllMigrations().size() == 1);
+    }
+
+    // The constructor registered it, so the destructor has to deregister it: anything left behind is
+    // a pointer to a dead object that `AddMigration`'s duplicate lookup would dereference.
+    CHECK(mgr.GetAllMigrations().empty());
+}
+
+TEST_CASE_METHOD(SqlMigrationTestFixture,
+                 "MigrationBase: a migration reusing a dead one's storage is not a duplicate of itself",
+                 "[SqlMigration]")
+{
+    // Regression test for a CI flake: with the dead migration still listed, `AddMigration` compared
+    // the incoming timestamp against a dangling pointer. When the new migration happened to land on
+    // the freed storage, the pointer resolved back to the object being constructed and it was
+    // rejected as conflicting with itself ("'stub' conflicts with 'stub'").
+    constexpr uint64_t Timestamp = 20'000'000'000'102ULL;
+
+    {
+        StubMigration const first { Timestamp };
+        (void) first;
+    }
+
+    CHECK_NOTHROW([&] {
+        StubMigration const second { Timestamp };
+        (void) second;
+    }());
+}
+
+TEST_CASE_METHOD(SqlMigrationTestFixture,
+                 "MigrationManager::RemoveMigration: removing an unregistered migration is a no-op",
+                 "[SqlMigration]")
+{
+    // The ctor only ever registers with the singleton, so any other manager has never seen `stub`.
+    Lightweight::SqlMigration::MigrationManager other;
+    StubMigration const stub { 20'000'000'000'103ULL };
+
+    CHECK_NOTHROW(other.RemoveMigration(&stub));
+    CHECK(other.GetAllMigrations().empty());
+    CHECK(Lightweight::SqlMigration::MigrationManager::GetInstance().GetAllMigrations().size() == 1);
 }
 
 // ============================================================================

--- a/src/tests/PluginIngestionTests.cpp
+++ b/src/tests/PluginIngestionTests.cpp
@@ -86,11 +86,9 @@ void TouchPluginFile(std::filesystem::path const& path, std::filesystem::file_ti
 /// Minimal `MigrationBase` subclass usable as a fixture pointer for
 /// `AddMigration`. Constructing one auto-registers it with
 /// `MigrationManager::GetInstance()` (a hard-coded side effect of the
-/// `MigrationBase` ctor); the destructor below resets the singleton so a
-/// fixture instance going out of scope at end-of-test does not leave a
-/// dangling pointer in the singleton's list. Without this reset the
-/// next test's `FakeMigration` allocated at the same stack address is
-/// (incorrectly) reported as a duplicate by `AddMigration`'s lookup.
+/// `MigrationBase` ctor) and `~MigrationBase` unregisters it again, so a
+/// fixture instance going out of scope at end-of-test leaves no dangling
+/// pointer in the singleton's list for the next test to trip over.
 class FakeMigration: public Lightweight::SqlMigration::MigrationBase
 {
   public:
@@ -99,11 +97,7 @@ class FakeMigration: public Lightweight::SqlMigration::MigrationBase
     {
     }
 
-    ~FakeMigration() override
-    {
-        Lightweight::SqlMigration::MigrationManager::GetInstance().RemoveAllMigrations();
-        Lightweight::SqlMigration::MigrationManager::GetInstance().RemoveAllReleases();
-    }
+    ~FakeMigration() override = default;
 
     FakeMigration(FakeMigration const&) = delete;
     FakeMigration& operator=(FakeMigration const&) = delete;


### PR DESCRIPTION
Two unrelated CI flakes, both hit while triaging the open PRs (#575, #576). Neither was caused by
the PR it failed on — the affected files were byte-identical to `master`, and re-running both jobs
turned them green.

## 1. `MigrationBase` never unregistered itself (`fix(SqlMigration)`)

`MigrationBase`'s constructor registers `this` with `MigrationManager::GetInstance()`; its
destructor was `= default`. A migration that does not outlive the manager therefore left a dangling
pointer in the list, and `AddMigration`'s duplicate-timestamp check dereferences every entry it
walks. When a later migration landed on the freed storage, the stale pointer resolved back to the
object under construction and it was rejected as a duplicate of *itself*:

```
Duplicate migration timestamp 20260101000000 detected: 'fixture' conflicts with 'fixture'
```

That is what failed the macOS leg of #576 in `PluginIngestionTests` while every other leg passed —
it depends on the allocator reusing an address, so it is platform-dependent by nature.

The fix pairs the constructor's registration with `MigrationManager::RemoveMigration()` in
`~MigrationBase`. Removing a migration that was never added is a no-op, which covers the defaulted
copy constructor.

Two test classes carried an explicit workaround for the old behaviour — `StubMigration`
(`MigrationTests.cpp`) and `FakeMigration` (`PluginIngestionTests.cpp`) both wiped the entire
singleton from their destructors, each with a comment describing exactly this failure mode. Both go
back to a defaulted destructor now that the library maintains the invariant itself.

**Verification:** reverting only the destructor makes the new
`"a migration reusing a dead one's storage is not a duplicate of itself"` case fail with the same
self-conflict message the macOS job produced (`'stub' conflicts with 'stub'`), and
`"destruction unregisters the migration"` fail alongside it. With the fix, all pass.

## 2. stdexec's configure-time download (`build:`)

stdexec's own `CMakeLists.txt` derives its `project(VERSION)` from the `Revision: N` line of
`execution.bs`, which it downloads from raw.githubusercontent.com during configure — with no status
check. A failed or truncated fetch leaves an empty file and the configure dies inside stdexec:

```
string sub-command REGEX, mode REPLACE needs at least 6 arguments total to command.
VERSION "0..0" format invalid.
```

That took out the tsan job of #575 while its sibling jobs, resolving the same package, passed.

We now seed the file before `CPMAddPackage` (stdexec skips its own download when it already exists).
The network is still tried first so the reported version stays accurate; a pinned
`LIGHTWEIGHT_STDEXEC_BS_REVISION_FALLBACK` takes over when the fetch fails. It only feeds stdexec's
own `project(VERSION)`, which Lightweight never consumes. A configure no longer depends on that host
being reachable — which also makes offline builds work.

---

**Performance impact:** none. `~MigrationBase` gains one `std::list::remove` over a list that holds
a handful of entries in practice, at destruction time only. The CMake change replaces a download
stdexec would have performed anyway.

**Risk assessment:** the behavioural change is that a destroyed migration is no longer listed by
`MigrationManager`. Code that relied on a dead migration lingering was relying on a use-after-free;
nothing in the tree does. `RemoveMigration` is `noexcept` and tolerates unknown pointers, so the
defaulted copy constructor and any double-removal are safe. Destruction order is safe by
construction: `GetInstance()`'s function-local static is created during the first `MigrationBase`
constructor, so every migration is destroyed before it. No ABI-visible layout change; one new
exported member function. Not DBMS-specific. The CMake change is a no-op when the download works.

**Code coverage:** three new test cases in `MigrationTests.cpp` covering deregistration on
destruction, the recycled-storage self-conflict, and `RemoveMigration` on an unregistered migration.

**Databases tested:** `sqlite3`, `mssql2022` (Docker), `postgres` (Docker) — full suite, all green
under both compilers below.

**Compilers tested:** `clang-debug` (Clang 22, ASan + UBSan) and `gcc-release` (the build CI's
database legs actually run). `scripts/check-doc-snippets.py` passes; `clang-tidy` clean on the
changed library sources.

**Not run locally:** the Windows and macOS legs (no such host here) and the
`LIGHTWEIGHT_BUILD_MODULES=ON` configuration — no namespace-scope entity was added to a public
header, so the module-linkage rule does not apply. CI covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUh877b7VuwesqHQWUtPsc
